### PR TITLE
[Bug Fix] SecurityRule list - add rulebase to get request params

### DIFF
--- a/scm/config/security/security_rule.py
+++ b/scm/config/security/security_rule.py
@@ -482,7 +482,7 @@ class SecurityRule(BaseObject):
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, SecurityRuleRulebase):
             try:
-                SecurityRuleRulebase(rulebase.lower())
+                rulebase = SecurityRuleRulebase(rulebase.lower())
             except ValueError:
                 raise InvalidObjectError(
                     message="rulebase must be either 'pre' or 'post'",
@@ -523,6 +523,7 @@ class SecurityRule(BaseObject):
 
         while True:
             params = container_parameters.copy()
+            params["position"] = rulebase.value
             params["limit"] = limit
             params["offset"] = offset
 

--- a/tests/scm/config/security/test_security_rules.py
+++ b/tests/scm/config/security/test_security_rules.py
@@ -129,6 +129,7 @@ class TestSecurityRuleList(TestSecurityRuleBase):
                 "folder": "Texas",
                 "limit": 5000,
                 "offset": 0,
+                "position": "pre",
             },
         )
         assert isinstance(existing_objects, list)
@@ -536,6 +537,40 @@ class TestSecurityRuleList(TestSecurityRuleBase):
         with pytest.raises(InvalidObjectError):
             self.client.list(folder=folder, rulebase=invalid_rulebase)
 
+    @pytest.mark.parametrize(
+        "rulebase",
+        [
+            "pre",
+            "post",
+        ],
+    )
+    def test_list_rulebase(self, rulebase):
+        """Test that list method is called with correct rulebase value."""
+        folder = "Texas"
+
+        mock_response = {
+            "data": [
+                SecurityRuleResponseFactory().model_dump(by_alias=True),
+            ],
+            "offset": 0,
+            "total": 1,
+            "limit": 200,
+            "rulebase": rulebase,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        self.client.list(folder=folder, rulebase=rulebase)
+
+        self.mock_scm.get.assert_called_once_with(
+            "/config/security/v1/security-rules",
+            params={
+                "folder": folder,
+                "limit": 5000,
+                "offset": 0,
+                "position": rulebase,
+            },
+        )
+
     # -------------------- New Tests for exact_match and Exclusions --------------------
 
     def test_list_exact_match(self):
@@ -749,17 +784,27 @@ class TestSecurityRuleList(TestSecurityRuleBase):
         # Verify API calls were made with correct offset values
         self.mock_scm.get.assert_any_call(  # noqa
             "/config/security/v1/security-rules",
-            params={"folder": "Texas", "limit": 2500, "offset": 0},
+            params={"folder": "Texas", "limit": 2500, "offset": 0, "position": "pre"},
         )
 
         self.mock_scm.get.assert_any_call(  # noqa
             "/config/security/v1/security-rules",
-            params={"folder": "Texas", "limit": 2500, "offset": 2500},
+            params={
+                "folder": "Texas",
+                "limit": 2500,
+                "offset": 2500,
+                "position": "pre",
+            },
         )
 
         self.mock_scm.get.assert_any_call(  # noqa
             "/config/security/v1/security-rules",
-            params={"folder": "Texas", "limit": 2500, "offset": 5000},
+            params={
+                "folder": "Texas",
+                "limit": 2500,
+                "offset": 5000,
+                "position": "pre",
+            },
         )
 
         # Verify content ordering and rule-specific attributes


### PR DESCRIPTION
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

In the SecurityRule list method, rulebase argument was not passed as a parameter to the SCM get request. Because of that, always default parameter (pre) was used, and there was no option to collect 'post' rules from the SCM.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!