### PR TITLE
[Bug Fix] SecurityRule create - add rulebase to POST request params

### DIFF
--- a/scm/config/security/security_rule.py
+++ b/scm/config/security/security_rule.py
@@ -112,7 +112,7 @@ class SecurityRule(BaseObject):
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, SecurityRuleRulebase):
             try:
-                SecurityRuleRulebase(rulebase.lower())
+                rulebase = SecurityRuleRulebase(rulebase.lower())
             except ValueError:
                 raise InvalidObjectError(
                     message="rulebase must be either 'pre' or 'post'",
@@ -124,6 +124,9 @@ class SecurityRule(BaseObject):
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
         profile = SecurityRuleCreateModel(**data)
 
+        # Create params dict to pass rulebase
+        params = {"position": rulebase.value}
+
         # Convert back to a Python dictionary, removing any unset fields and using aliases
         payload = profile.model_dump(
             exclude_unset=True,
@@ -133,6 +136,7 @@ class SecurityRule(BaseObject):
         # Send the updated object to the remote API as JSON, expecting a dictionary object to be returned.
         response: Dict[str, Any] = self.api_client.post(
             self.ENDPOINT,
+            params=params,
             json=payload,
         )
 

--- a/tests/scm/config/security/test_security_rules.py
+++ b/tests/scm/config/security/test_security_rules.py
@@ -839,6 +839,7 @@ class TestSecurityRuleCreate(TestSecurityRuleBase):
 
         self.mock_scm.post.assert_called_once_with(  # noqa
             "/config/security/v1/security-rules",
+            params={"position": "pre"},
             json=test_object.model_dump(by_alias=True),
         )
         assert isinstance(created_object, SecurityRuleResponseModel)
@@ -934,6 +935,26 @@ class TestSecurityRuleCreate(TestSecurityRuleBase):
         with pytest.raises(InvalidObjectError):
             self.client.create(data, rulebase=invalid_rulebase)
 
+    @pytest.mark.parametrize(
+        "rulebase",
+        [
+            "pre",
+            "post",
+        ],
+    )
+    def test_create_rulebase(self, rulebase):
+        """Test that create method is called with correct rulebase value."""
+        test_object = SecurityRuleCreateApiFactory.build()
+        mock_response = SecurityRuleResponseFactory.from_request(test_object)
+
+        self.mock_scm.post.return_value = mock_response.model_dump(by_alias=True)
+        self.client.create(test_object.model_dump(by_alias=True), rulebase=rulebase)
+
+        self.mock_scm.post.assert_called_once_with(
+            "/config/security/v1/security-rules",
+            params={"position": rulebase},
+            json=test_object.model_dump(by_alias=True),
+        )
 
 class TestSecurityRuleGet(TestSecurityRuleBase):
     """Tests for retrieving a specific Security Rule object."""

--- a/tests/scm/config/security/test_security_rules.py
+++ b/tests/scm/config/security/test_security_rules.py
@@ -956,6 +956,7 @@ class TestSecurityRuleCreate(TestSecurityRuleBase):
             json=test_object.model_dump(by_alias=True),
         )
 
+
 class TestSecurityRuleGet(TestSecurityRuleBase):
     """Tests for retrieving a specific Security Rule object."""
 


### PR DESCRIPTION
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

In the SecurityRule create method, rulebase argument was not passed as a parameter to the SCM post request. Because of that, the default parameter (pre) was always used, and there was no option to create rule in the 'post' rulebase.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!