### PR TITLE
fix(models/security_rules): Modified device field validation to match dict

### DIFF
--- a/scm/models/security/security_rules.py
+++ b/scm/models/security/security_rules.py
@@ -146,11 +146,9 @@ class SecurityRuleBaseModel(BaseModel):
         max_length=64,
         pattern=r"^[a-zA-Z\d\-_. ]+$",
     )
-    device: Optional[str] = Field(
+    device: Optional[dict] = Field(
         None,
         description="Device",
-        max_length=64,
-        pattern=r"^[a-zA-Z\d\-_. ]+$",
     )
 
     # Common validators


### PR DESCRIPTION
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

- The internet access default policy in SCM returns a `dict` for `device` field:

```python
'action': 'allow',
 'application': ['any'],
 'category': ['any'],
 'destination': ['any'],
 'destination_hip': ['any'],
 'device': {}
```

This will vail the device field validation in pydantic which is now expecting `str` if the field is present.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!