### PR TITLE
Update `device` field to accept None, string, or dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.3.9"
+version = "0.3.10"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/models/security/security_rules.py
+++ b/scm/models/security/security_rules.py
@@ -1,7 +1,7 @@
 # scm/models/security/security_rules.py
 
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Union, Dict
 from uuid import UUID
 
 from pydantic import (
@@ -237,6 +237,30 @@ class SecurityRuleResponseModel(SecurityRuleBaseModel):
         description="The UUID of the security rule",
         examples=["123e4567-e89b-12d3-a456-426655440000"],
     )
+
+    # Override the device field to accept None, a string, or an empty dict
+    device: Optional[Union[str, Dict]] = Field(
+        None,
+        description="Device (optional: can be None, a string, or an empty dictionary)",
+    )
+
+    @field_validator("device")
+    def validate_device(cls, v):
+        """
+        Validate that the device field is None, a string, or an empty dictionary.
+
+        Args:
+            v: The value of the device field to be validated.
+
+        Raises:
+            ValueError: If the device is a dictionary but not empty.
+
+        Returns:
+            The validated value of the device field.
+        """
+        if isinstance(v, dict) and v != {}:
+            raise ValueError("If device is a dictionary, it must be empty")
+        return v
 
 
 class SecurityRuleMoveModel(BaseModel):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,7 @@
 
 # Standard library imports
 import uuid
-from typing import List
+from typing import List, Union, Dict
 
 # External libraries
 import factory
@@ -27,8 +27,6 @@ from scm.models.network.nat_rules import (
     SourceTranslation,
     InterfaceAddress,
 )
-
-
 # Local SDK imports
 from scm.models.objects import (
     AddressCreateModel,
@@ -3615,15 +3613,41 @@ class SecurityRuleResponseFactory(factory.Factory):
     log_setting = "default-logging"
     schedule = None
 
+    # Set device to None by default (will be overridden by with_device)
+    device = None
+
     @classmethod
     def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
         """Create an instance with snippet container."""
         return cls(folder=None, snippet=snippet, device=None, **kwargs)
 
     @classmethod
-    def with_device(cls, device: str = "TestDevice", **kwargs):
-        """Create an instance with device container."""
+    def with_device(cls, device: Union[str, Dict] = "TestDevice", **kwargs):
+        """
+        Create an instance with device container.
+
+        Args:
+            device: Either a string device name or an empty dictionary
+            **kwargs: Additional fields to override
+
+        Returns:
+            An instance of SecurityRuleResponseModel
+        """
+        # Validate the device parameter
+        if isinstance(device, dict) and device != {}:
+            raise ValueError("If device is a dictionary, it must be empty")
+
         return cls(folder=None, snippet=None, device=device, **kwargs)
+
+    @classmethod
+    def with_empty_dict_device(cls, **kwargs):
+        """
+        Create an instance with an empty dictionary as device.
+
+        Returns:
+            An instance of SecurityRuleResponseModel with device={}
+        """
+        return cls(folder=None, snippet=None, device={}, **kwargs)
 
     @classmethod
     def from_request(cls, request_model: SecurityRuleCreateModel, **kwargs):

--- a/tests/scm/models/security/test_security_rules_models.py
+++ b/tests/scm/models/security/test_security_rules_models.py
@@ -1,5 +1,5 @@
 # tests/scm/models/security/test_security_rules_models.py
-
+import uuid
 from uuid import UUID
 
 # External libraries
@@ -250,13 +250,33 @@ class TestSecurityRuleResponseModel:
         assert model.folder is None
         assert model.device is None
 
-    def test_security_rule_response_model_with_device(self):
-        """Test response model with device container."""
-        data = SecurityRuleResponseFactory.with_device()
+    def test_security_rule_response_model_with_device_string(self):
+        """Test response model with device container as string."""
+        data = SecurityRuleResponseFactory.with_device("TestDevice")
         model = SecurityRuleResponseModel(**data.model_dump())
         assert model.device == "TestDevice"
         assert model.folder is None
         assert model.snippet is None
+
+    def test_security_rule_response_model_with_device_empty_dict(self):
+        """Test response model with device container as empty dictionary."""
+        data = SecurityRuleResponseFactory.with_empty_dict_device()
+        model = SecurityRuleResponseModel(**data.model_dump())
+        assert model.device == {}
+        assert model.folder is None
+        assert model.snippet is None
+
+    def test_security_rule_response_model_device_validation(self):
+        """Test that device validation rejects non-empty dictionaries."""
+        with pytest.raises(
+            ValueError,
+            match="If device is a dictionary, it must be empty",
+        ):
+            SecurityRuleResponseModel(
+                id=uuid.uuid4(),
+                name="test_rule",
+                device={"some_key": "some_value"},
+            )
 
 
 class TestSecurityRuleProfileSetting:


### PR DESCRIPTION
Modified the `device` field in `security_rules.py` to support None as a valid input in addition to strings and dictionaries. Updated description and validation logic accordingly to reflect the changes. This enhances flexibility for handling optional device values.

Add new tests for device handling in security rule models

Expanded test coverage for `SecurityRuleResponseModel` by adding tests for devices as strings, empty dictionaries, and invalid dictionary inputs. Ensured proper validation and error handling for non-empty dictionaries in the `device` field.

Bump version to 0.3.10

Update the project version in pyproject.toml from 0.3.9 to 0.3.10. This prepares the SDK for a new release with the latest changes.

Add validation for the device field in security rules model

Updated the `device` field to accept either a string or an empty dictionary. Added a validator to ensure dictionaries provided for `device` are empty, raising an error otherwise. This enforces stricter data integrity and consistency.

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Update the security rule response model to support the new structure of SWG type security rules that have the field `device` set to an empty dictionary for the time being. Expect additional changes in the near future.

#### What does this pull request accomplish?

- Feature addition

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!