### PR TITLE
87-support-for-all-to-be-passed-in-commit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,9 @@
 # Use an official Python runtime as a parent image, based on Alpine
 FROM python:3.12-alpine
 
+# Add build argument for version
+ARG SDK_VERSION
+
 # Install dependencies required for compiling certain Python packages
 # gcc and musl-dev are required for compiling C extensions
 # libffi-dev is required for the cffi package
@@ -11,8 +14,15 @@ RUN apk add --no-cache gcc musl-dev libffi-dev make
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Install any needed packages specified
-RUN pip install --no-cache-dir pan-scm-sdk==0.1.0
+# Copy the distribution files
+COPY dist/ /app/dist/
+
+# Install the package from local dist directory using the version specified by build arg
+RUN if [ -z "$SDK_VERSION" ] ; then \
+        echo "Error: SDK_VERSION build argument is required" && exit 1 ; \
+    else \
+        pip install --no-cache-dir /app/dist/pan_scm_sdk-${SDK_VERSION}-py3-none-any.whl ; \
+    fi
 
 # Set the locale to avoid issues with emoji rendering
 ENV LANG=C.UTF-8

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,7 +1,14 @@
+## Version 0.3.11
+
+- Added support for passing the string value of "all" to a commit to specify all admin users.
+
+## Version 0.3.10
+
+- Added support for new security rule types of SWG by allowing the `device` field to be either string or dictionary
+
 ## Version 0.3.9
 
-- Added support remote networks
-- First time to leverage SASE APIs until Remote Network endpoints for SCM API are working properly
+- Added support for NAT rules
 
 ## Version 0.3.8
 

--- a/docs/sdk/client.md
+++ b/docs/sdk/client.md
@@ -239,6 +239,7 @@ status = client.wait_for_job("job-id", timeout=600)
 # Commit changes synchronously
 result = client.commit(
     folders=["Texas"],
+    admin=["all"],
     description="Update network configuration",
     sync=True,
     timeout=300
@@ -265,6 +266,7 @@ from scm.exceptions import APIError, AuthenticationError, TimeoutError
 try:
     result = client.commit(
         folders=["Texas"],
+        admin=["automation@scm-tenant.example.com"],
         description="Update configuration",
         sync=True
     )

--- a/docs/sdk/models/operations/candidate_push.md
+++ b/docs/sdk/models/operations/candidate_push.md
@@ -103,6 +103,8 @@ except ValueError as e:
 
 </div>
 
+> **Note**: use the string value of "all" if you intend to commit the changes for all admin users.
+
 ## Usage Examples
 
 ### Creating a Commit Request
@@ -117,7 +119,7 @@ from scm.config.operations import CandidatePush
 
 commit_dict = {
     "folders": ["Texas", "Production"],
-    "admin": ["admin@example.com"],
+    "admin": ["admin@example.com", "all"],
     "description": "Updating security policies"
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.3.10"
+version = "0.3.11"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"
@@ -38,6 +38,7 @@ python-dotenv = "^1.0.1"
 pytest-mock = "^3.14.0"
 pytest-cov = "^5.0.0"
 dynaconf = "^3.2.6"
+pytest-dotenv = "^0.5.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@
 [pytest]
 markers =
     api: mark a test as part of the API integration tests.
+
+env_files =
+    .env

--- a/scm/models/operations/candidate_push.py
+++ b/scm/models/operations/candidate_push.py
@@ -56,12 +56,16 @@ class CandidatePushRequestModel(BaseModel):
 
     @field_validator("admin")
     def validate_admin(cls, v):
-        """Ensure admin list is not empty and contains valid email addresses."""
         if not v:
             raise ValueError("At least one admin must be specified")
-        if not all(isinstance(admin, str) and "@" in admin for admin in v):
-            raise ValueError("All admin entries must be valid email addresses")
-        return v
+
+        if not all(
+            isinstance(admin, str) and (admin.lower() == "all" or "@" in admin)
+            for admin in v
+        ):
+            raise ValueError("All admin entries must be 'all' or valid email addresses")
+
+        return [admin.lower() if admin.lower() == "all" else admin for admin in v]
 
 
 class CandidatePushResponseModel(BaseModel):

--- a/tests/scm/config/test_base_object.py
+++ b/tests/scm/config/test_base_object.py
@@ -365,3 +365,20 @@ class TestBaseObject:
             sync=True,
             timeout=600,
         )
+
+        # Test with username of "all" passed in admins
+        response = self.test_object.commit(
+            folders=["folder1", "folder2"],
+            description="Test commit with all params",
+            admin=["all"],
+            sync=True,
+            timeout=600,
+        )
+        assert isinstance(response, CandidatePushResponseModel)
+        self.mock_scm.commit.assert_called_with(
+            folders=["folder1", "folder2"],
+            description="Test commit with all params",
+            admin=["all"],
+            sync=True,
+            timeout=600,
+        )

--- a/tests/scm/models/auth/operations/test_commit.py
+++ b/tests/scm/models/auth/operations/test_commit.py
@@ -174,3 +174,29 @@ class TestCandidatePushRequestModel:
             else:
                 with pytest.raises(ValidationError):
                     CandidatePushRequestModel(**case["data"])
+
+    def test_admin_string_all(self):
+        """Test validation when 'all' is passed as a string directly."""
+        invalid_data = {
+            "folders": ["folder1"],
+            "admin": "all",  # Invalid string value
+            "description": "Test invalid admin string",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            CandidatePushRequestModel(**invalid_data)
+
+        error = exc_info.value
+        assert "Input should be a valid list" in str(error)
+
+    def test_admin_normalized_values(self):
+        """Test that 'all' values are properly normalized in mixed lists."""
+        # Test mixed case normalization
+        valid_data = {
+            "folders": ["folder1"],
+            "admin": ["ALL", "aLl", "all", "admin@example.com"],
+            "description": "Test case normalization",
+        }
+        model = CandidatePushRequestModel(**valid_data)
+
+        # All 'all' variants should be lowercase, email should remain unchanged
+        assert model.admin == ["all", "all", "all", "admin@example.com"]

--- a/tests/scm/test_client.py
+++ b/tests/scm/test_client.py
@@ -886,3 +886,61 @@ class TestClientCommitMethods(TestClientBase):
         assert "List should have at least 1 item after validation" in str(
             exc_info.value
         )
+
+    def test_commit_with_all_admin(self):
+        """Test commit using 'all' as admin value."""
+        # Mock the client_id to return a string
+        self.client.oauth_client.auth_request.client_id = "test@example.com"
+
+        mock_response = {
+            "success": True,
+            "job_id": "1587",
+            "message": "CommitAndPush job enqueued with jobid 1587",
+        }
+        self.session.request.return_value.json.return_value = mock_response
+
+        # Test with 'all' as a string
+        result = self.client.commit(
+            folders=["folder1"],
+            description="Test commit with 'all' admin",
+            admin=["all"],
+        )
+
+        assert isinstance(result, CandidatePushResponseModel)
+        assert result.success is True
+        assert result.job_id == "1587"
+
+        # Verify the admin field was processed correctly
+        self.session.request.assert_called_with(
+            "POST",
+            "https://api.strata.paloaltonetworks.com/config/operations/v1/config-versions/candidate:push",
+            json={
+                "folders": ["folder1"],
+                "description": "Test commit with 'all' admin",
+                "admin": ["all"],
+            },
+        )
+
+        # Reset mock for the next test
+        self.session.request.reset_mock()
+
+        # Test with 'all' in a list
+        result = self.client.commit(
+            folders=["folder1"],
+            description="Test commit with 'all' admin in list",
+            admin=["all"],
+        )
+
+        assert isinstance(result, CandidatePushResponseModel)
+        assert result.success is True
+
+        # Verify the admin field was processed correctly
+        self.session.request.assert_called_with(
+            "POST",
+            "https://api.strata.paloaltonetworks.com/config/operations/v1/config-versions/candidate:push",
+            json={
+                "folders": ["folder1"],
+                "description": "Test commit with 'all' admin in list",
+                "admin": ["all"],
+            },
+        )


### PR DESCRIPTION
### Support for passing the string value of "all" to a commit to specify all admin users

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Enable the passing of the string value "all" in place of email addresses to specify all admin users.

#### What does this pull request accomplish?

- Feature addition

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!