### PR TITLE
Refactor client method names for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,34 +140,34 @@ if nat_rules:
 
 The unified client provides access to the following services through attribute-based access:
 
-| Client Property | Class | Description |
-|----------------|-------|-------------|
-| **Objects** | | |
-| `address` | `Address` | Manages IP and FQDN address objects |
-| `address_group` | `AddressGroup` | Manages address group objects |
-| `application` | `Application` | Manages custom application objects |
-| `application_filter` | `ApplicationFilters` | Manages application filter objects |
-| `application_group` | `ApplicationGroup` | Manages application group objects |
-| `dynamic_user_group` | `DynamicUserGroup` | Manages dynamic user group objects |
-| `external_dynamic_list` | `ExternalDynamicLists` | Manages external dynamic list objects |
-| `hip_object` | `HIPObject` | Manages host information profile objects |
-| `hip_profile` | `HIPProfile` | Manages host information profile group objects |
-| `http_server_profile` | `HTTPServerProfile` | Manages HTTP server profile objects |
-| `service` | `Service` | Manages service objects |
-| `service_group` | `ServiceGroup` | Manages service group objects |
-| `tag` | `Tag` | Manages tag objects |
-| **Network** | | |
-| `nat_rule` | `NATRule` | Manages network address translation rules |
-| **Deployment** | | |
-| `remote_network` | `RemoteNetworks` | Manages remote network connections |
-| **Security** | | |
-| `security_rule` | `SecurityRule` | Manages security policy rules |
-| `anti_spyware_profile` | `AntiSpywareProfile` | Manages anti-spyware security profiles |
-| `decryption_profile` | `DecryptionProfile` | Manages SSL decryption profiles |
-| `dns_security_profile` | `DNSSecurityProfile` | Manages DNS security profiles |
-| `url_category` | `URLCategories` | Manages custom URL categories |
-| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles |
-| `wildfire_antivirus_profile` | `WildfireAntivirusProfile` | Manages WildFire anti-virus profiles |
+| Client Property                    | Class                            | Description                                    |
+|------------------------------------|----------------------------------|------------------------------------------------|
+| **Objects**                        |                                  |                                                |
+| `address`                          | `Address`                        | Manages IP and FQDN address objects            |
+| `address_group`                    | `AddressGroup`                   | Manages address group objects                  |
+| `application`                      | `Application`                    | Manages custom application objects             |
+| `application_filter`               | `ApplicationFilters`             | Manages application filter objects             |
+| `application_group`                | `ApplicationGroup`               | Manages application group objects              |
+| `dynamic_user_group`               | `DynamicUserGroup`               | Manages dynamic user group objects             |
+| `external_dynamic_list`            | `ExternalDynamicLists`           | Manages external dynamic list objects          |
+| `hip_object`                       | `HIPObject`                      | Manages host information profile objects       |
+| `hip_profile`                      | `HIPProfile`                     | Manages host information profile group objects |
+| `http_server_profile`              | `HTTPServerProfile`              | Manages HTTP server profile objects            |
+| `service`                          | `Service`                        | Manages service objects                        |
+| `service_group`                    | `ServiceGroup`                   | Manages service group objects                  |
+| `tag`                              | `Tag`                            | Manages tag objects                            |
+| **Network**                        |                                  |                                                |
+| `nat_rule`                         | `NATRule`                        | Manages network address translation rules      |
+| **Deployment**                     |                                  |                                                |
+| `remote_network`                   | `RemoteNetworks`                 | Manages remote network connections             |
+| **Security**                       |                                  |                                                |
+| `security_rule`                    | `SecurityRule`                   | Manages security policy rules                  |
+| `anti_spyware_profile`             | `AntiSpywareProfile`             | Manages anti-spyware security profiles         |
+| `decryption_profile`               | `DecryptionProfile`              | Manages SSL decryption profiles                |
+| `dns_security_profile`             | `DNSSecurityProfile`             | Manages DNS security profiles                  |
+| `url_category`                     | `URLCategories`                  | Manages custom URL categories                  |
+| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles      |
+| `wildfire_antivirus_profile`       | `WildfireAntivirusProfile`       | Manages WildFire anti-virus profiles           |
 
 #### Traditional Access Pattern (Legacy Support)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,34 +119,34 @@ client.commit(
 
 The unified client provides access to the following services through its attribute-based interface:
 
-| Client Property | Class | Description |
-|----------------|-------|-------------|
-| **Objects** | | |
-| `address` | `Address` | Manages IP and FQDN address objects |
-| `address_group` | `AddressGroup` | Manages address group objects |
-| `application` | `Application` | Manages custom application objects |
-| `application_filter` | `ApplicationFilters` | Manages application filter objects |
-| `application_group` | `ApplicationGroup` | Manages application group objects |
-| `dynamic_user_group` | `DynamicUserGroup` | Manages dynamic user group objects |
-| `external_dynamic_list` | `ExternalDynamicLists` | Manages external dynamic list objects |
-| `hip_object` | `HIPObject` | Manages host information profile objects |
-| `hip_profile` | `HIPProfile` | Manages host information profile group objects |
-| `http_server_profile` | `HTTPServerProfile` | Manages HTTP server profile objects |
-| `service` | `Service` | Manages service objects |
-| `service_group` | `ServiceGroup` | Manages service group objects |
-| `tag` | `Tag` | Manages tag objects |
-| **Network** | | |
-| `nat_rule` | `NATRule` | Manages network address translation rules |
-| **Deployment** | | |
-| `remote_network` | `RemoteNetworks` | Manages remote network connections |
-| **Security** | | |
-| `security_rule` | `SecurityRule` | Manages security policy rules |
-| `anti_spyware_profile` | `AntiSpywareProfile` | Manages anti-spyware security profiles |
-| `decryption_profile` | `DecryptionProfile` | Manages SSL decryption profiles |
-| `dns_security_profile` | `DNSSecurityProfile` | Manages DNS security profiles |
-| `url_category` | `URLCategories` | Manages custom URL categories |
-| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles |
-| `wildfire_antivirus_profile` | `WildfireAntivirusProfile` | Manages WildFire anti-virus profiles |
+| Client Property                    | Class                            | Description                                    |
+|------------------------------------|----------------------------------|------------------------------------------------|
+| **Objects**                        |                                  |                                                |
+| `address`                          | `Address`                        | Manages IP and FQDN address objects            |
+| `address_group`                    | `AddressGroup`                   | Manages address group objects                  |
+| `application`                      | `Application`                    | Manages custom application objects             |
+| `application_filter`               | `ApplicationFilters`             | Manages application filter objects             |
+| `application_group`                | `ApplicationGroup`               | Manages application group objects              |
+| `dynamic_user_group`               | `DynamicUserGroup`               | Manages dynamic user group objects             |
+| `external_dynamic_list`            | `ExternalDynamicLists`           | Manages external dynamic list objects          |
+| `hip_object`                       | `HIPObject`                      | Manages host information profile objects       |
+| `hip_profile`                      | `HIPProfile`                     | Manages host information profile group objects |
+| `http_server_profile`              | `HTTPServerProfile`              | Manages HTTP server profile objects            |
+| `service`                          | `Service`                        | Manages service objects                        |
+| `service_group`                    | `ServiceGroup`                   | Manages service group objects                  |
+| `tag`                              | `Tag`                            | Manages tag objects                            |
+| **Network**                        |                                  |                                                |
+| `nat_rule`                         | `NATRule`                        | Manages network address translation rules      |
+| **Deployment**                     |                                  |                                                |
+| `remote_network`                   | `RemoteNetworks`                 | Manages remote network connections             |
+| **Security**                       |                                  |                                                |
+| `security_rule`                    | `SecurityRule`                   | Manages security policy rules                  |
+| `anti_spyware_profile`             | `AntiSpywareProfile`             | Manages anti-spyware security profiles         |
+| `decryption_profile`               | `DecryptionProfile`              | Manages SSL decryption profiles                |
+| `dns_security_profile`             | `DNSSecurityProfile`             | Manages DNS security profiles                  |
+| `url_category`                     | `URLCategories`                  | Manages custom URL categories                  |
+| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles      |
+| `wildfire_antivirus_profile`       | `WildfireAntivirusProfile`       | Manages WildFire anti-virus profiles           |
 
 For more detailed usage instructions and examples, refer to the [User Guide](about/introduction.md).
 

--- a/docs/sdk/client.md
+++ b/docs/sdk/client.md
@@ -116,19 +116,19 @@ The unified client provides access to all service objects in the SDK through att
 - `client.address` - Address objects
 - `client.address_group` - Address Group objects
 - `client.application` - Application objects
-- `client.application_filters` - Application Filters
+- `client.application_filter` - Application Filters
 - `client.application_group` - Application Group objects
 - `client.dynamic_user_group` - Dynamic User Group objects
-- `client.external_dynamic_lists` - External Dynamic Lists
+- `client.external_dynamic_list` - External Dynamic Lists
 - `client.hip_object` - HIP Objects
 - `client.hip_profile` - HIP Profiles
-- `client.http_server_profiles` - HTTP Server Profiles
+- `client.http_server_profile` - HTTP Server Profiles
 - `client.service` - Service objects
 - `client.service_group` - Service Group objects
 - `client.tag` - Tag objects
 
 **Network**
-- `client.nat_rules` - NAT Rules
+- `client.nat_rule` - NAT Rules
 
 **Deployment**
 - `client.remote_networks` - Remote Networks
@@ -138,7 +138,7 @@ The unified client provides access to all service objects in the SDK through att
 - `client.anti_spyware_profile` - Anti-Spyware Profiles
 - `client.decryption_profile` - Decryption Profiles
 - `client.dns_security_profile` - DNS Security Profiles
-- `client.url_categories` - URL Categories
+- `client.url_category` - URL Categories
 - `client.vulnerability_protection_profile` - Vulnerability Protection Profiles
 - `client.wildfire_antivirus_profile` - WildFire Antivirus Profiles
 

--- a/docs/sdk/config/objects/application_filters.md
+++ b/docs/sdk/config/objects/application_filters.md
@@ -96,7 +96,7 @@ and behaviors.
     )
 
     # Access the application_filters module directly through the client
-    # client.application_filters is automatically initialized for you
+    # client.application_filter is automatically initialized for you
 ```
 
 </div>
@@ -138,7 +138,7 @@ You can also use the traditional approach if preferred:
     }
 
     # Create high-risk filter
-    high_risk = client.application_filters.create(high_risk_filter)
+    high_risk = client.application_filter.create(high_risk_filter)
 
     # SaaS applications filter
     saas_filter = {
@@ -150,7 +150,7 @@ You can also use the traditional approach if preferred:
     }
 
     # Create SaaS filter
-    saas = client.application_filters.create(saas_filter)
+    saas = client.application_filter.create(saas_filter)
 ```
 
 </div>
@@ -163,11 +163,11 @@ You can also use the traditional approach if preferred:
 
 ```python
     # Fetch by name and folder
-    filter_obj = client.application_filters.fetch(name="high-risk-apps", folder="Texas")
+    filter_obj = client.application_filter.fetch(name="high-risk-apps", folder="Texas")
     print(f"Found filter: {filter_obj.name}")
 
     # Get by ID
-    filter_by_id = client.application_filters.get(filter_obj.id)
+    filter_by_id = client.application_filter.get(filter_obj.id)
     print(f"Retrieved filter: {filter_by_id.name}")
     print(f"Risk levels: {filter_by_id.risk}")
 ```
@@ -182,7 +182,7 @@ You can also use the traditional approach if preferred:
 
 ```python
     # Fetch existing filter
-    existing_filter = client.application_filters.fetch(name="high-risk-apps", folder="Texas")
+    existing_filter = client.application_filter.fetch(name="high-risk-apps", folder="Texas")
 
     # Update filter criteria
     existing_filter.risk = [3, 4, 5]
@@ -191,7 +191,7 @@ You can also use the traditional approach if preferred:
     existing_filter.tunnels_other_apps = True
 
     # Perform update
-    updated_filter = client.application_filters.update(existing_filter)
+    updated_filter = client.application_filter.update(existing_filter)
 ```
 
 </div>
@@ -204,7 +204,7 @@ You can also use the traditional approach if preferred:
 
 ```python
     # List with direct filter parameters
-    filtered_results = client.application_filters.list(
+    filtered_results = client.application_filter.list(
         folder='Texas',
         category=['business-systems'],
         risk=[4, 5]
@@ -224,7 +224,7 @@ You can also use the traditional approach if preferred:
     }
 
     # List with filters as kwargs
-    filtered_results = client.application_filters.list(**list_params)
+    filtered_results = client.application_filter.list(**list_params)
 ```
 
 </div>
@@ -237,7 +237,7 @@ You can also use the traditional approach if preferred:
 
 ```python
     # Only return filters defined exactly in 'Texas'
-    exact_filters = client.application_filters.list(
+    exact_filters = client.application_filter.list(
         folder='Texas',
         exact_match=True
     )
@@ -246,7 +246,7 @@ You can also use the traditional approach if preferred:
         print(f"Exact match: {f.name} in {f.folder}")
 
     # Exclude all filters from the 'All' folder
-    no_all_filters = client.application_filters.list(
+    no_all_filters = client.application_filter.list(
         folder='Texas',
         exclude_folders=['All']
     )
@@ -256,7 +256,7 @@ You can also use the traditional approach if preferred:
         print(f"Filtered out 'All': {f.name}")
 
     # Exclude filters that come from 'default' snippet
-    no_default_snippet = client.application_filters.list(
+    no_default_snippet = client.application_filter.list(
         folder='Texas',
         exclude_snippets=['default']
     )
@@ -266,7 +266,7 @@ You can also use the traditional approach if preferred:
         print(f"Filtered out 'default' snippet: {f.name}")
 
     # Exclude filters associated with 'DeviceA'
-    no_deviceA = client.application_filters.list(
+    no_deviceA = client.application_filter.list(
         folder='Texas',
         exclude_devices=['DeviceA']
     )
@@ -276,7 +276,7 @@ You can also use the traditional approach if preferred:
         print(f"Filtered out 'DeviceA': {f.name}")
 
     # Combine exact_match with multiple exclusions
-    combined_filters = client.application_filters.list(
+    combined_filters = client.application_filter.list(
         folder='Texas',
         exact_match=True,
         exclude_folders=['All'],
@@ -310,7 +310,7 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 
     # Now when we call list(), it will use the specified max_limit for each request
     # while auto-paginating through all available objects.
-    all_filters = client.application_filters.list(folder='Texas')
+    all_filters = client.application_filter.list(folder='Texas')
 
     # 'all_filters' contains all objects from 'Texas', fetched in chunks of up to 4321 at a time.
 ```
@@ -326,7 +326,7 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 ```python
     # Delete by ID
     filter_id = "123e4567-e89b-12d3-a456-426655440000"
-    client.application_filters.delete(filter_id)
+    client.application_filter.delete(filter_id)
 ```
 
 </div>
@@ -410,7 +410,7 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
         }
 
         # Create the filter using the unified client
-        new_filter = client.application_filters.create(filter_config)
+        new_filter = client.application_filter.create(filter_config)
 
         # Commit changes directly on the client
         result = client.commit(
@@ -440,7 +440,7 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 
 1. **Client Usage**
     - Use the unified `ScmClient` approach for simpler code
-    - Access application filters operations via `client.application_filters` property
+    - Access application filters operations via `client.application_filter` property
     - Perform commit operations directly on the client
     - Monitor jobs directly on the client
     - Set appropriate max_limit parameters for large datasets using `application_filters_max_limit`

--- a/docs/sdk/config/objects/external_dynamic_lists.md
+++ b/docs/sdk/config/objects/external_dynamic_lists.md
@@ -85,7 +85,7 @@ client = ScmClient(
 )
 
 # Access the external_dynamic_lists module directly through the client
-# client.external_dynamic_lists is automatically initialized for you
+# client.external_dynamic_list is automatically initialized for you
 ```
 
 </div>
@@ -138,7 +138,7 @@ ip_edl_config = {
 }
 
 # Create IP EDL
-ip_edl = client.external_dynamic_lists.create(ip_edl_config)
+ip_edl = client.external_dynamic_list.create(ip_edl_config)
 
 # Domain-based EDL with hourly updates
 domain_edl_config = {
@@ -157,7 +157,7 @@ domain_edl_config = {
 }
 
 # Create domain EDL
-domain_edl = client.external_dynamic_lists.create(domain_edl_config)
+domain_edl = client.external_dynamic_list.create(domain_edl_config)
 ```
 
 </div>
@@ -170,11 +170,11 @@ domain_edl = client.external_dynamic_lists.create(domain_edl_config)
 
 ```python
 # Fetch by name and folder
-edl = client.external_dynamic_lists.fetch(name="malicious-ips", folder="Texas")
+edl = client.external_dynamic_list.fetch(name="malicious-ips", folder="Texas")
 print(f"Found EDL: {edl.name}")
 
 # Get by ID
-edl_by_id = client.external_dynamic_lists.get(edl.id)
+edl_by_id = client.external_dynamic_list.get(edl.id)
 print(f"Retrieved EDL: {edl_by_id.name}")
 ```
 
@@ -188,7 +188,7 @@ print(f"Retrieved EDL: {edl_by_id.name}")
 
 ```python
 # Fetch existing EDL
-existing_edl = client.external_dynamic_lists.fetch(name="malicious-ips", folder="Texas")
+existing_edl = client.external_dynamic_list.fetch(name="malicious-ips", folder="Texas")
 
 # Update attributes
 existing_edl.description = "Updated malicious IP list"
@@ -197,7 +197,7 @@ existing_edl.type.ip.recurring = {
 }
 
 # Perform update
-updated_edl = client.external_dynamic_lists.update(existing_edl)
+updated_edl = client.external_dynamic_list.update(existing_edl)
 ```
 
 </div>
@@ -210,7 +210,7 @@ updated_edl = client.external_dynamic_lists.update(existing_edl)
 
 ```python
 # List with direct filter parameters
-filtered_edls = client.external_dynamic_lists.list(
+filtered_edls = client.external_dynamic_list.list(
    folder='Texas',
    types=['ip', 'domain']
 )
@@ -230,7 +230,7 @@ list_params = {
 }
 
 # List with filters as kwargs
-filtered_edls = client.external_dynamic_lists.list(**list_params)
+filtered_edls = client.external_dynamic_list.list(**list_params)
 ```
 
 </div>
@@ -243,7 +243,7 @@ filtered_edls = client.external_dynamic_lists.list(**list_params)
 
 ```python
 # Only return edls defined exactly in 'Texas'
-exact_edls = client.external_dynamic_lists.list(
+exact_edls = client.external_dynamic_list.list(
    folder='Texas',
    exact_match=True
 )
@@ -252,7 +252,7 @@ for app in exact_edls:
    print(f"Exact match: {app.name} in {app.folder}")
 
 # Exclude all edls from the 'All' folder
-no_all_edls = client.external_dynamic_lists.list(
+no_all_edls = client.external_dynamic_list.list(
    folder='Texas',
    exclude_folders=['All']
 )
@@ -262,7 +262,7 @@ for app in no_all_edls:
    print(f"Filtered out 'All': {app.name}")
 
 # Exclude edls that come from 'default' snippet
-no_default_snippet = client.external_dynamic_lists.list(
+no_default_snippet = client.external_dynamic_list.list(
    folder='Texas',
    exclude_snippets=['default']
 )
@@ -272,7 +272,7 @@ for app in no_default_snippet:
    print(f"Filtered out 'default' snippet: {app.name}")
 
 # Exclude edls associated with 'DeviceA'
-no_deviceA = client.external_dynamic_lists.list(
+no_deviceA = client.external_dynamic_list.list(
    folder='Texas',
    exclude_devices=['DeviceA']
 )
@@ -282,7 +282,7 @@ for app in no_deviceA:
    print(f"Filtered out 'DeviceA': {app.name}")
 
 # Combine exact_match with multiple exclusions
-combined_filters = client.external_dynamic_lists.list(
+combined_filters = client.external_dynamic_list.list(
    folder='Texas',
    exact_match=True,
    exclude_folders=['All'],
@@ -316,7 +316,7 @@ client = ScmClient(
 
 # Now when we call list(), it will use the specified max_limit for each request
 # while auto-paginating through all available objects.
-all_edls = client.external_dynamic_lists.list(folder='Texas')
+all_edls = client.external_dynamic_list.list(folder='Texas')
 
 # 'all_edls' contains all objects from 'Texas', fetched in chunks of up to 4321 at a time.
 ```
@@ -332,7 +332,7 @@ all_edls = client.external_dynamic_lists.list(folder='Texas')
 ```python
 # Delete by ID
 edl_id = "123e4567-e89b-12d3-a456-426655440000"
-client.external_dynamic_lists.delete(edl_id)
+client.external_dynamic_list.delete(edl_id)
 ```
 
 </div>
@@ -424,7 +424,7 @@ edl_config = {
 }
 
 # Create the EDL using the unified client
-new_edl = client.external_dynamic_lists.create(edl_config)
+new_edl = client.external_dynamic_list.create(edl_config)
 
 # Commit changes directly on the client
 result = client.commit(
@@ -454,7 +454,7 @@ except MissingQueryParameterError as e:
 
 1. **Client Usage**
     - Use the unified `ScmClient` approach for simpler code
-    - Access EDL operations via `client.external_dynamic_lists` property
+    - Access EDL operations via `client.external_dynamic_list` property
     - Perform commit operations directly on the client
     - Monitor jobs directly on the client
     - Set appropriate max_limit parameters for large datasets using `external_dynamic_lists_max_limit`

--- a/docs/sdk/config/security_services/url_categories.md
+++ b/docs/sdk/config/security_services/url_categories.md
@@ -106,7 +106,7 @@ url_list_config = {
 }
 
 # Create URL List category using the client
-url_list = client.url_categories.create(url_list_config)
+url_list = client.url_category.create(url_list_config)
 
 # Category Match configuration
 category_match_config = {
@@ -118,7 +118,7 @@ category_match_config = {
 }
 
 # Create Category Match category
-category_match = client.url_categories.create(category_match_config)
+category_match = client.url_category.create(category_match_config)
 ```
 
 </div>
@@ -131,11 +131,11 @@ category_match = client.url_categories.create(category_match_config)
 
 ```python
 # Fetch by name and folder
-category = client.url_categories.fetch(name="blocked_sites", folder="Texas")
+category = client.url_category.fetch(name="blocked_sites", folder="Texas")
 print(f"Found category: {category.name}")
 
 # Get by ID
-category_by_id = client.url_categories.get(category.id)
+category_by_id = client.url_category.get(category.id)
 print(f"Retrieved category: {category_by_id.name}")
 print(f"URL list: {category_by_id.list}")
 ```
@@ -150,14 +150,14 @@ print(f"URL list: {category_by_id.list}")
 
 ```python
 # Fetch existing category
-existing_category = client.url_categories.fetch(name="blocked_sites", folder="Texas")
+existing_category = client.url_category.fetch(name="blocked_sites", folder="Texas")
 
 # Update URL list
 existing_category.list.extend(["newsite.com", "anothersite.com"])
 existing_category.description = "Updated blocked websites list"
 
 # Perform update
-updated_category = client.url_categories.update(existing_category)
+updated_category = client.url_category.update(existing_category)
 ```
 
 </div>
@@ -170,7 +170,7 @@ updated_category = client.url_categories.update(existing_category)
 
 ```python
 # List with direct filter parameters
-filtered_categories = client.url_categories.list(
+filtered_categories = client.url_category.list(
     folder='Texas',
     members=['example.com']
 )
@@ -188,7 +188,7 @@ list_params = {
 }
 
 # List with filters as kwargs
-filtered_categories = client.url_categories.list(**list_params)
+filtered_categories = client.url_category.list(**list_params)
 ```
 
 </div>
@@ -213,8 +213,8 @@ The `list()` method supports additional parameters to refine your query results 
 <!-- termynal -->
 
 ```python
-# Only return url_categories defined exactly in 'Texas'
-exact_url_categories = client.url_categories.list(
+# Only return url_category defined exactly in 'Texas'
+exact_url_categories = client.url_category.list(
     folder='Texas',
     exact_match=True
 )
@@ -223,7 +223,7 @@ for app in exact_url_categories:
     print(f"Exact match: {app.name} in {app.folder}")
 
 # Exclude all url_categories from the 'All' folder
-no_all_url_categories = client.url_categories.list(
+no_all_url_categories = client.url_category.list(
     folder='Texas',
     exclude_folders=['All']
 )
@@ -233,7 +233,7 @@ for app in no_all_url_categories:
     print(f"Filtered out 'All': {app.name}")
 
 # Exclude url_categories that come from 'default' snippet
-no_default_snippet = client.url_categories.list(
+no_default_snippet = client.url_category.list(
     folder='Texas',
     exclude_snippets=['default']
 )
@@ -243,7 +243,7 @@ for app in no_default_snippet:
     print(f"Filtered out 'default' snippet: {app.name}")
 
 # Exclude url_categories associated with 'DeviceA'
-no_deviceA = client.url_categories.list(
+no_deviceA = client.url_category.list(
     folder='Texas',
     exclude_devices=['DeviceA']
 )
@@ -253,7 +253,7 @@ for app in no_deviceA:
     print(f"Filtered out 'DeviceA': {app.name}")
 
 # Combine exact_match with multiple exclusions
-combined_filters = client.url_categories.list(
+combined_filters = client.url_category.list(
     folder='Texas',
     exact_match=True,
     exclude_folders=['All'],
@@ -287,7 +287,7 @@ client = Scm(
 
 # Now when we call list(), it will use the specified max_limit for each request
 # while auto-paginating through all available objects.
-all_categories = client.url_categories.list(folder='Texas')
+all_categories = client.url_category.list(folder='Texas')
 
 # 'all_categories' contains all objects from 'Texas', fetched in chunks of up to 4321 at a time.
 ```
@@ -303,7 +303,7 @@ all_categories = client.url_categories.list(folder='Texas')
 ```python
 # Delete by ID
 category_id = "123e4567-e89b-12d3-a456-426655440000"
-client.url_categories.delete(category_id)
+client.url_category.delete(category_id)
 ```
 
 </div>
@@ -378,7 +378,7 @@ try:
     }
 
     # Create the category using the client
-    new_category = client.url_categories.create(category_config)
+    new_category = client.url_category.create(category_config)
 
     # Commit changes using the client
     result = client.commit(
@@ -420,7 +420,7 @@ except MissingQueryParameterError as e:
     - Group related categories
 
 3. **Client Usage**
-    - Use the unified client interface (`client.url_categories`) for simpler code
+    - Use the unified client interface (`client.url_category`) for simpler code
     - Perform commits directly on the client (`client.commit()`)
     - Monitor jobs using client methods (`client.get_job_status()`, `client.list_jobs()`) 
     - Initialize the client once and reuse across different object types

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -146,34 +146,34 @@ print(f"Commit job status: {job_status.data[0].status_str}")
 
 The following table shows all services available through the unified client interface:
 
-| Client Property | Class | Description |
-|----------------|-------|-------------|
-| **Objects** | | |
-| `address` | `Address` | Manages IP and FQDN address objects |
-| `address_group` | `AddressGroup` | Manages address group objects |
-| `application` | `Application` | Manages custom application objects |
-| `application_filter` | `ApplicationFilters` | Manages application filter objects |
-| `application_group` | `ApplicationGroup` | Manages application group objects |
-| `dynamic_user_group` | `DynamicUserGroup` | Manages dynamic user group objects |
-| `external_dynamic_list` | `ExternalDynamicLists` | Manages external dynamic list objects |
-| `hip_object` | `HIPObject` | Manages host information profile objects |
-| `hip_profile` | `HIPProfile` | Manages host information profile group objects |
-| `http_server_profile` | `HTTPServerProfile` | Manages HTTP server profile objects |
-| `service` | `Service` | Manages service objects |
-| `service_group` | `ServiceGroup` | Manages service group objects |
-| `tag` | `Tag` | Manages tag objects |
-| **Network** | | |
-| `nat_rule` | `NATRule` | Manages network address translation rules |
-| **Deployment** | | |
-| `remote_network` | `RemoteNetworks` | Manages remote network connections |
-| **Security** | | |
-| `security_rule` | `SecurityRule` | Manages security policy rules |
-| `anti_spyware_profile` | `AntiSpywareProfile` | Manages anti-spyware security profiles |
-| `decryption_profile` | `DecryptionProfile` | Manages SSL decryption profiles |
-| `dns_security_profile` | `DNSSecurityProfile` | Manages DNS security profiles |
-| `url_category` | `URLCategories` | Manages custom URL categories |
-| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles |
-| `wildfire_antivirus_profile` | `WildfireAntivirusProfile` | Manages WildFire anti-virus profiles |
+| Client Property                    | Class                            | Description                                    |
+|------------------------------------|----------------------------------|------------------------------------------------|
+| **Objects**                        |                                  |                                                |
+| `address`                          | `Address`                        | Manages IP and FQDN address objects            |
+| `address_group`                    | `AddressGroup`                   | Manages address group objects                  |
+| `application`                      | `Application`                    | Manages custom application objects             |
+| `application_filter`               | `ApplicationFilters`             | Manages application filter objects             |
+| `application_group`                | `ApplicationGroup`               | Manages application group objects              |
+| `dynamic_user_group`               | `DynamicUserGroup`               | Manages dynamic user group objects             |
+| `external_dynamic_list`            | `ExternalDynamicLists`           | Manages external dynamic list objects          |
+| `hip_object`                       | `HIPObject`                      | Manages host information profile objects       |
+| `hip_profile`                      | `HIPProfile`                     | Manages host information profile group objects |
+| `http_server_profile`              | `HTTPServerProfile`              | Manages HTTP server profile objects            |
+| `service`                          | `Service`                        | Manages service objects                        |
+| `service_group`                    | `ServiceGroup`                   | Manages service group objects                  |
+| `tag`                              | `Tag`                            | Manages tag objects                            |
+| **Network**                        |                                  |                                                |
+| `nat_rule`                         | `NATRule`                        | Manages network address translation rules      |
+| **Deployment**                     |                                  |                                                |
+| `remote_network`                   | `RemoteNetworks`                 | Manages remote network connections             |
+| **Security**                       |                                  |                                                |
+| `security_rule`                    | `SecurityRule`                   | Manages security policy rules                  |
+| `anti_spyware_profile`             | `AntiSpywareProfile`             | Manages anti-spyware security profiles         |
+| `decryption_profile`               | `DecryptionProfile`              | Manages SSL decryption profiles                |
+| `dns_security_profile`             | `DNSSecurityProfile`             | Manages DNS security profiles                  |
+| `url_category`                     | `URLCategories`                  | Manages custom URL categories                  |
+| `vulnerability_protection_profile` | `VulnerabilityProtectionProfile` | Manages vulnerability protection profiles      |
+| `wildfire_antivirus_profile`       | `WildfireAntivirusProfile`       | Manages WildFire anti-virus profiles           |
 
 Check out the [Client Module](client.md) documentation for more information on the unified client interface and the available
 services.


### PR DESCRIPTION

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Renamed various client methods and properties, such as `url_categories`, `application_filters`, and `external_dynamic_lists`, to their singular forms (e.g., `url_category`, `application_filter`, and `external_dynamic_list`). These changes ensure naming consistency across the SDK and improve overall clarity. Documentation and examples were updated accordingly.

#### What does this pull request accomplish?

- Documentation update

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!