### PR TITLE
Add SyslogServerProfile CRUD functionality and tests

### DIFF
--- a/scm/config/objects/__init__.py
+++ b/scm/config/objects/__init__.py
@@ -5,6 +5,7 @@ from .address_group import AddressGroup
 from .application import Application
 from .application_filters import ApplicationFilters
 from .application_group import ApplicationGroup
+from .syslog_server_profiles import SyslogServerProfile
 from .dynamic_user_group import DynamicUserGroup
 from .external_dynamic_lists import ExternalDynamicLists
 from .hip_object import HIPObject

--- a/scm/config/objects/syslog_server_profiles.py
+++ b/scm/config/objects/syslog_server_profiles.py
@@ -1,0 +1,508 @@
+# scm/config/objects/syslog_server_profiles.py
+
+# Standard library imports
+import logging
+from typing import List, Dict, Any, Optional
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import (
+    InvalidObjectError,
+    MissingQueryParameterError,
+)
+from scm.models.objects import (
+    SyslogServerProfileCreateModel,
+    SyslogServerProfileResponseModel,
+    SyslogServerProfileUpdateModel,
+)
+
+
+class SyslogServerProfile(BaseObject):
+    """
+    Manages Syslog Server Profile objects in Palo Alto Networks' Strata Cloud Manager.
+
+    Args:
+        api_client: The API client instance
+        max_limit (Optional[int]): Maximum number of objects to return in a single API request.
+            Defaults to 2500. Must be between 1 and 5000.
+    """
+
+    ENDPOINT = "/config/objects/v1/syslog-server-profiles"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000  # Maximum allowed by the API
+
+    def __init__(
+        self,
+        api_client,
+        max_limit: Optional[int] = None,
+    ):
+        super().__init__(api_client)
+        self.logger = logging.getLogger(__name__)
+
+        # Validate and set max_limit
+        self._max_limit = self._validate_max_limit(max_limit)
+
+    @property
+    def max_limit(self) -> int:
+        """Get the current maximum limit for API requests."""
+        return self._max_limit
+
+    @max_limit.setter
+    def max_limit(self, value: int) -> None:
+        """Set a new maximum limit for API requests."""
+        self._max_limit = self._validate_max_limit(value)
+
+    def _validate_max_limit(self, limit: Optional[int]) -> int:
+        """
+        Validates the max_limit parameter.
+
+        Args:
+            limit: The limit to validate
+
+        Returns:
+            int: The validated limit
+
+        Raises:
+            InvalidObjectError: If the limit is invalid
+        """
+        if limit is None:
+            return self.DEFAULT_MAX_LIMIT
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            raise InvalidObjectError(
+                message="max_limit must be an integer",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit type"},
+            )
+
+        if limit_int < 1:
+            raise InvalidObjectError(
+                message="max_limit must be greater than 0",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit value"},
+            )
+
+        if limit_int > self.ABSOLUTE_MAX_LIMIT:
+            raise InvalidObjectError(
+                message=f"max_limit cannot exceed {self.ABSOLUTE_MAX_LIMIT}",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "max_limit exceeds maximum allowed value"},
+            )
+
+        return limit_int
+
+    def create(
+        self,
+        data: Dict[str, Any],
+    ) -> SyslogServerProfileResponseModel:
+        """
+        Creates a new syslog server profile object.
+
+        Args:
+            data: Dictionary containing the syslog server profile data
+
+        Returns:
+            SyslogServerProfileResponseModel: The created syslog server profile
+        """
+        # Use the dictionary "data" to pass into Pydantic and return a modeled object
+        syslog_server_profile = SyslogServerProfileCreateModel(**data)
+
+        # Convert back to a Python dictionary, removing any unset fields
+        payload = syslog_server_profile.model_dump(exclude_unset=True)
+        self.logger.debug(f"Sending syslog server profile payload to API: {payload}")
+
+        # Send the updated object to the remote API as JSON, expecting a dictionary object to be returned.
+        try:
+            response: Dict[str, Any] = self.api_client.post(
+                self.ENDPOINT,
+                json=payload,
+            )
+        except Exception as e:
+            self.logger.error(f"Error in API call: {str(e)}")
+            raise
+
+        # Return the SCM API response as a new Pydantic object
+        return SyslogServerProfileResponseModel(**response)
+
+    def get(
+        self,
+        object_id: str,
+    ) -> SyslogServerProfileResponseModel:
+        """
+        Gets a syslog server profile object by ID.
+
+        Args:
+            object_id: The ID of the syslog server profile to retrieve
+
+        Returns:
+            SyslogServerProfileResponseModel: The retrieved syslog server profile
+        """
+        # Send the request to the remote API
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        response: Dict[str, Any] = self.api_client.get(endpoint)
+
+        # Return the SCM API response as a new Pydantic object
+        return SyslogServerProfileResponseModel(**response)
+
+    def update(
+        self,
+        syslog_server_profile: SyslogServerProfileUpdateModel,
+    ) -> SyslogServerProfileResponseModel:
+        """
+        Updates an existing syslog server profile object.
+
+        Args:
+            syslog_server_profile: SyslogServerProfileUpdateModel instance containing the update data
+
+        Returns:
+            SyslogServerProfileResponseModel: The updated syslog server profile
+        """
+        # Convert to dict for API request, excluding unset fields
+        payload = syslog_server_profile.model_dump(exclude_unset=True)
+
+        # Extract ID and remove from payload since it's in the URL
+        object_id = str(syslog_server_profile.id)
+        payload.pop("id", None)
+
+        # Send the updated object to the remote API as JSON
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        response: Dict[str, Any] = self.api_client.put(
+            endpoint,
+            json=payload,
+        )
+
+        # Return the SCM API response as a new Pydantic object
+        return SyslogServerProfileResponseModel(**response)
+
+    @staticmethod
+    def _apply_filters(
+        syslog_server_profiles: List[SyslogServerProfileResponseModel],
+        filters: Dict[str, Any],
+    ) -> List[SyslogServerProfileResponseModel]:
+        """
+        Apply client-side filtering to the list of syslog server profiles.
+
+        Args:
+            syslog_server_profiles: List of SyslogServerProfileResponseModel objects
+            filters: Dictionary of filter criteria
+
+        Returns:
+            List[SyslogServerProfileResponseModel]: Filtered list of syslog server profiles
+        """
+        filter_criteria = syslog_server_profiles
+
+        # Filter by transport protocol
+        if "transport" in filters:
+            if not isinstance(filters["transport"], list):
+                raise InvalidObjectError(
+                    message="'transport' filter must be a list",
+                    error_code="E003",
+                    http_status_code=400,
+                    details={"errorType": "Invalid Object"},
+                )
+            transports = filters["transport"]
+            # The servers are stored as a dictionary in the model, so we need to check each server's transport
+            filter_criteria = [
+                profile
+                for profile in filter_criteria
+                if any(
+                    server_data.get("transport") in transports
+                    for server_name, server_data in profile.servers.items()
+                )
+            ]
+
+        # Filter by format type
+        if "format" in filters:
+            if not isinstance(filters["format"], list):
+                raise InvalidObjectError(
+                    message="'format' filter must be a list",
+                    error_code="E003",
+                    http_status_code=400,
+                    details={"errorType": "Invalid Object"},
+                )
+            formats = filters["format"]
+            filter_criteria = [
+                profile
+                for profile in filter_criteria
+                if any(
+                    server_data.get("format") in formats
+                    for server_name, server_data in profile.servers.items()
+                )
+            ]
+
+        return filter_criteria
+
+    @staticmethod
+    def _build_container_params(
+        folder: Optional[str],
+        snippet: Optional[str],
+        device: Optional[str],
+    ) -> dict:
+        """
+        Builds container parameters dictionary.
+
+        Args:
+            folder: Optional folder name
+            snippet: Optional snippet name
+            device: Optional device name
+
+        Returns:
+            dict: Dictionary of non-None container parameters
+        """
+        return {
+            k: v
+            for k, v in {"folder": folder, "snippet": snippet, "device": device}.items()
+            if v is not None
+        }
+
+    def list(
+        self,
+        folder: Optional[str] = None,
+        snippet: Optional[str] = None,
+        device: Optional[str] = None,
+        exact_match: bool = False,
+        exclude_folders: Optional[List[str]] = None,
+        exclude_snippets: Optional[List[str]] = None,
+        exclude_devices: Optional[List[str]] = None,
+        **filters,
+    ) -> List[SyslogServerProfileResponseModel]:
+        """
+        Lists syslog server profile objects with optional filtering.
+
+        Args:
+            folder: Optional folder name
+            snippet: Optional snippet name
+            device: Optional device name
+            exact_match (bool): If True, only return objects whose container
+                                exactly matches the provided container parameter.
+            exclude_folders (List[str], optional): List of folder names to exclude from results.
+            exclude_snippets (List[str], optional): List of snippet values to exclude from results.
+            exclude_devices (List[str], optional): List of device values to exclude from results.
+            **filters: Additional filters including:
+                - transport: List[str] - Filter by server transport protocols (e.g., ['UDP', 'TCP'])
+                - format: List[str] - Filter by syslog format (e.g., ['BSD', 'IETF'])
+
+        Returns:
+            List[SyslogServerProfileResponseModel]: A list of syslog server profile objects
+        """
+        if folder == "":
+            raise MissingQueryParameterError(
+                message="Field 'folder' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "folder",
+                    "error": '"folder" is not allowed to be empty',
+                },
+            )
+
+        container_parameters = self._build_container_params(
+            folder,
+            snippet,
+            device,
+        )
+
+        if len(container_parameters) != 1:
+            raise InvalidObjectError(
+                message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid container parameters"},
+            )
+
+        # Pagination logic using instance max_limit
+        limit = self._max_limit
+        offset = 0
+        all_objects = []
+
+        while True:
+            params = container_parameters.copy()
+            params["limit"] = limit
+            params["offset"] = offset
+
+            response = self.api_client.get(
+                self.ENDPOINT,
+                params=params,
+            )
+
+            if not isinstance(response, dict):
+                raise InvalidObjectError(
+                    message="Invalid response format: expected dictionary",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={"error": "Response is not a dictionary"},
+                )
+
+            if "data" not in response:
+                raise InvalidObjectError(
+                    message="Invalid response format: missing 'data' field",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={
+                        "field": "data",
+                        "error": '"data" field missing in the response',
+                    },
+                )
+
+            if not isinstance(response["data"], list):
+                raise InvalidObjectError(
+                    message="Invalid response format: 'data' field must be a list",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={
+                        "field": "data",
+                        "error": '"data" field must be a list',
+                    },
+                )
+
+            data = response["data"]
+            object_instances = [SyslogServerProfileResponseModel(**item) for item in data]
+            all_objects.extend(object_instances)
+
+            # If we got fewer than 'limit' objects, we've reached the end
+            if len(data) < limit:
+                break
+
+            offset += limit
+
+        # Apply existing filters first
+        filtered_objects = self._apply_filters(
+            all_objects,
+            filters,
+        )
+
+        # Determine which container key and value we are filtering on
+        container_key, container_value = next(iter(container_parameters.items()))
+
+        # If exact_match is True, filter out filtered_objects that don't match exactly
+        if exact_match:
+            filtered_objects = [
+                each
+                for each in filtered_objects
+                if getattr(each, container_key) == container_value
+            ]
+
+        # Exclude folders if provided
+        if exclude_folders and isinstance(exclude_folders, list):
+            filtered_objects = [
+                each for each in filtered_objects if each.folder not in exclude_folders
+            ]
+
+        # Exclude snippets if provided
+        if exclude_snippets and isinstance(exclude_snippets, list):
+            filtered_objects = [
+                each
+                for each in filtered_objects
+                if each.snippet not in exclude_snippets
+            ]
+
+        # Exclude devices if provided
+        if exclude_devices and isinstance(exclude_devices, list):
+            filtered_objects = [
+                each for each in filtered_objects if each.device not in exclude_devices
+            ]
+
+        return filtered_objects
+
+    def fetch(
+        self,
+        name: str,
+        folder: Optional[str] = None,
+        snippet: Optional[str] = None,
+        device: Optional[str] = None,
+    ) -> SyslogServerProfileResponseModel:
+        """
+        Fetches a single syslog server profile object by name.
+
+        Args:
+            name (str): The name of the syslog server profile to fetch.
+            folder (str, optional): The folder in which the resource is defined.
+            snippet (str, optional): The snippet in which the resource is defined.
+            device (str, optional): The device in which the resource is defined.
+
+        Returns:
+            SyslogServerProfileResponseModel: The fetched syslog server profile object as a Pydantic model.
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        if folder == "":
+            raise MissingQueryParameterError(
+                message="Field 'folder' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "folder",
+                    "error": '"folder" is not allowed to be empty',
+                },
+            )
+
+        params = {}
+
+        container_parameters = self._build_container_params(
+            folder,
+            snippet,
+            device,
+        )
+
+        if len(container_parameters) != 1:
+            raise InvalidObjectError(
+                message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "error": "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+                },
+            )
+
+        params.update(container_parameters)
+        params["name"] = name
+
+        response = self.api_client.get(
+            self.ENDPOINT,
+            params=params,
+        )
+
+        if not isinstance(response, dict):
+            raise InvalidObjectError(
+                message="Invalid response format: expected dictionary",
+                error_code="E003",
+                http_status_code=500,
+                details={"error": "Response is not a dictionary"},
+            )
+
+        if "id" in response:
+            return SyslogServerProfileResponseModel(**response)
+        else:
+            raise InvalidObjectError(
+                message="Invalid response format: missing 'id' field",
+                error_code="E003",
+                http_status_code=500,
+                details={"error": "Response missing 'id' field"},
+            )
+
+    def delete(
+        self,
+        object_id: str,
+    ) -> None:
+        """
+        Deletes a syslog server profile object.
+
+        Args:
+            object_id (str): The ID of the object to delete.
+        """
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        self.api_client.delete(endpoint)

--- a/scm/models/objects/__init__.py
+++ b/scm/models/objects/__init__.py
@@ -10,6 +10,11 @@ from .address_group import (
     AddressGroupCreateModel,
     AddressGroupUpdateModel,
 )
+from .syslog_server_profiles import (
+    SyslogServerProfileCreateModel,
+    SyslogServerProfileUpdateModel,
+    SyslogServerProfileResponseModel,
+)
 from .application import (
     ApplicationCreateModel,
     ApplicationResponseModel,
@@ -87,6 +92,14 @@ from .quarantined_devices import (
     QuarantinedDevicesCreateModel,
     QuarantinedDevicesResponseModel,
     QuarantinedDevicesListParamsModel,
+)
+from .syslog_server_profiles import (
+    SyslogServerProfileCreateModel,
+    SyslogServerProfileResponseModel,
+    SyslogServerProfileUpdateModel,
+    SyslogServerModel,
+    FormatModel,
+    EscapingModel,
 )
 
 """

--- a/scm/models/objects/syslog_server_profiles.py
+++ b/scm/models/objects/syslog_server_profiles.py
@@ -1,0 +1,311 @@
+# scm/models/objects/syslog_server_profiles.py
+
+# Standard library imports
+from typing import Optional, List, Dict, Literal, Union, Any
+from uuid import UUID
+
+# External libraries
+from pydantic import (
+    BaseModel,
+    Field,
+    model_validator,
+    ConfigDict,
+    constr,
+)
+
+
+class EscapingModel(BaseModel):
+    """
+    Model for character escaping configuration in syslog server profiles.
+    
+    Attributes:
+        escape_character (Optional[str]): Escape sequence delimiter.
+        escaped_characters (Optional[str]): A list of all the characters to be escaped (without spaces).
+    """
+    
+    escape_character: Optional[str] = Field(
+        None,
+        max_length=1,
+        description="Escape sequence delimiter"
+    )
+    escaped_characters: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="A list of all the characters to be escaped (without spaces)"
+    )
+
+
+class FormatModel(BaseModel):
+    """
+    Model for log format configuration in syslog server profiles.
+    
+    Attributes:
+        escaping (Optional[EscapingModel]): Character escaping configuration.
+        traffic (Optional[str]): Format for traffic logs.
+        threat (Optional[str]): Format for threat logs.
+        wildfire (Optional[str]): Format for wildfire logs.
+        url (Optional[str]): Format for URL logs.
+        data (Optional[str]): Format for data logs.
+        gtp (Optional[str]): Format for GTP logs.
+        sctp (Optional[str]): Format for SCTP logs.
+        tunnel (Optional[str]): Format for tunnel logs.
+        auth (Optional[str]): Format for authentication logs.
+        userid (Optional[str]): Format for user ID logs.
+        iptag (Optional[str]): Format for IP tag logs.
+        decryption (Optional[str]): Format for decryption logs.
+        config (Optional[str]): Format for configuration logs.
+        system (Optional[str]): Format for system logs.
+        globalprotect (Optional[str]): Format for GlobalProtect logs.
+        hip_match (Optional[str]): Format for HIP match logs.
+        correlation (Optional[str]): Format for correlation logs.
+    """
+    
+    escaping: Optional[EscapingModel] = Field(
+        None, 
+        description="Character escaping configuration"
+    )
+    traffic: Optional[str] = Field(
+        None, 
+        description="Format for traffic logs"
+    )
+    threat: Optional[str] = Field(
+        None, 
+        description="Format for threat logs"
+    )
+    wildfire: Optional[str] = Field(
+        None, 
+        description="Format for wildfire logs"
+    )
+    url: Optional[str] = Field(
+        None, 
+        description="Format for URL logs"
+    )
+    data: Optional[str] = Field(
+        None, 
+        description="Format for data logs"
+    )
+    gtp: Optional[str] = Field(
+        None, 
+        description="Format for GTP logs"
+    )
+    sctp: Optional[str] = Field(
+        None, 
+        description="Format for SCTP logs"
+    )
+    tunnel: Optional[str] = Field(
+        None, 
+        description="Format for tunnel logs"
+    )
+    auth: Optional[str] = Field(
+        None, 
+        description="Format for authentication logs"
+    )
+    userid: Optional[str] = Field(
+        None, 
+        description="Format for user ID logs"
+    )
+    iptag: Optional[str] = Field(
+        None, 
+        description="Format for IP tag logs"
+    )
+    decryption: Optional[str] = Field(
+        None, 
+        description="Format for decryption logs"
+    )
+    config: Optional[str] = Field(
+        None, 
+        description="Format for configuration logs"
+    )
+    system: Optional[str] = Field(
+        None, 
+        description="Format for system logs"
+    )
+    globalprotect: Optional[str] = Field(
+        None, 
+        description="Format for GlobalProtect logs"
+    )
+    hip_match: Optional[str] = Field(
+        None, 
+        description="Format for HIP match logs"
+    )
+    correlation: Optional[str] = Field(
+        None, 
+        description="Format for correlation logs"
+    )
+
+
+class SyslogServerModel(BaseModel):
+    """
+    Model for syslog server configuration in a syslog server profile.
+    
+    Attributes:
+        name (str): Syslog server name.
+        server (str): Syslog server address.
+        transport (Literal["UDP", "TCP"]): Transport protocol for the syslog server.
+        port (int): Syslog server port.
+        format (Literal["BSD", "IETF"]): Syslog format.
+        facility (Literal["LOG_USER", "LOG_LOCAL0", "LOG_LOCAL1", "LOG_LOCAL2", "LOG_LOCAL3", "LOG_LOCAL4", "LOG_LOCAL5", "LOG_LOCAL6", "LOG_LOCAL7"]): 
+            Syslog facility.
+    """
+    
+    name: str = Field(
+        ..., 
+        description="Syslog server name"
+    )
+    server: str = Field(
+        ..., 
+        description="Syslog server address"
+    )
+    transport: Literal["UDP", "TCP"] = Field(
+        ..., 
+        description="Transport protocol"
+    )
+    port: int = Field(
+        ..., 
+        description="Syslog server port",
+        ge=1,
+        le=65535
+    )
+    format: Literal["BSD", "IETF"] = Field(
+        ..., 
+        description="Syslog format"
+    )
+    facility: Literal[
+        "LOG_USER", 
+        "LOG_LOCAL0", 
+        "LOG_LOCAL1", 
+        "LOG_LOCAL2", 
+        "LOG_LOCAL3", 
+        "LOG_LOCAL4", 
+        "LOG_LOCAL5", 
+        "LOG_LOCAL6", 
+        "LOG_LOCAL7"
+    ] = Field(
+        ..., 
+        description="Syslog facility"
+    )
+
+
+class SyslogServerProfileBaseModel(BaseModel):
+    """
+    Base model for Syslog Server Profile objects containing fields common to all CRUD operations.
+    
+    Attributes:
+        name (str): The name of the syslog server profile.
+        servers (Dict[str, Any]): A dictionary of server configurations.
+        format (Optional[FormatModel]): Format settings for different log types.
+        folder (Optional[str]): The folder in which the resource is defined.
+        snippet (Optional[str]): The snippet in which the resource is defined.
+        device (Optional[str]): The device in which the resource is defined.
+    """
+    
+    # Required fields
+    name: constr(max_length=31) = Field(
+        ...,
+        description="The name of the syslog server profile"
+    )
+    
+    # Server configurations - can be a dict or list in API
+    servers: Dict[str, Any] = Field(
+        ...,
+        description="Syslog server configurations"
+    )
+    
+    # Optional fields
+    format: Optional[FormatModel] = Field(
+        None,
+        description="Format settings for different log types"
+    )
+    
+    # Container Types
+    folder: Optional[constr(pattern=r"^[a-zA-Z\d\-_. ]+$", max_length=64)] = Field(
+        None,
+        description="The folder in which the resource is defined",
+        examples=["Shared"]
+    )
+    snippet: Optional[constr(pattern=r"^[a-zA-Z\d\-_. ]+$", max_length=64)] = Field(
+        None,
+        description="The snippet in which the resource is defined",
+        examples=["My Snippet"]
+    )
+    device: Optional[constr(pattern=r"^[a-zA-Z\d\-_. ]+$", max_length=64)] = Field(
+        None,
+        description="The device in which the resource is defined",
+        examples=["My Device"]
+    )
+    
+    # Pydantic model configuration
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+
+class SyslogServerProfileCreateModel(SyslogServerProfileBaseModel):
+    """
+    Represents the creation of a new Syslog Server Profile object for Palo Alto Networks' Strata Cloud Manager.
+    
+    This class defines the structure and validation rules for a SyslogServerProfileCreateModel object,
+    it inherits all fields from the SyslogServerProfileBaseModel class, and provides a custom validator
+    to ensure that the creation request contains exactly one of the following container types:
+        - folder
+        - snippet
+        - device
+    
+    Error:
+        ValueError: Raised when container type validation fails.
+    """
+    
+    # Custom Validators
+    @model_validator(mode="after")
+    def validate_container_type(self) -> "SyslogServerProfileCreateModel":
+        """Validates that exactly one container type is provided."""
+        container_fields = [
+            "folder",
+            "snippet",
+            "device",
+        ]
+        provided = [
+            field for field in container_fields if getattr(self, field) is not None
+        ]
+        if len(provided) != 1:
+            raise ValueError(
+                "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+            )
+        return self
+
+
+class SyslogServerProfileUpdateModel(SyslogServerProfileBaseModel):
+    """
+    Represents the update of an existing Syslog Server Profile object for Palo Alto Networks' Strata Cloud Manager.
+    
+    This class defines the structure and validation rules for a SyslogServerProfileUpdateModel object.
+    
+    Attributes:
+        id (UUID): The UUID of the syslog server profile.
+    """
+    
+    id: UUID = Field(
+        ...,
+        description="The UUID of the syslog server profile",
+        examples=["123e4567-e89b-12d3-a456-426655440000"]
+    )
+
+
+class SyslogServerProfileResponseModel(SyslogServerProfileBaseModel):
+    """
+    Represents a Syslog Server Profile object response from Palo Alto Networks' Strata Cloud Manager.
+    
+    This class defines the structure and validation rules for a SyslogServerProfileResponseModel object,
+    it inherits all fields from the SyslogServerProfileBaseModel class, and adds an id field.
+    
+    Attributes:
+        id (UUID): The UUID of the syslog server profile.
+    """
+    
+    id: UUID = Field(
+        ...,
+        description="The UUID of the syslog server profile",
+        examples=["123e4567-e89b-12d3-a456-426655440000"]
+    )

--- a/tests/scm/config/objects/test_syslog_server_profiles.py
+++ b/tests/scm/config/objects/test_syslog_server_profiles.py
@@ -1,0 +1,964 @@
+# tests/scm/config/objects/test_syslog_server_profiles.py
+
+import pytest
+from unittest.mock import MagicMock, patch
+import uuid
+import requests
+import sys
+
+from scm.client import Scm
+from scm.config.objects import SyslogServerProfile
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError, NotFoundError, APIError
+from scm.models.objects import (
+    SyslogServerProfileCreateModel,
+    SyslogServerProfileUpdateModel,
+    SyslogServerProfileResponseModel,
+)
+
+
+# -------------------- Helper functions --------------------
+
+
+def create_sample_syslog_server_profile_response():
+    """Create a sample syslog server profile response dictionary."""
+    return {
+        "id": str(uuid.uuid4()),
+        "name": "test-syslog-profile",
+        "servers": {
+            "server1": {
+                "name": "server1",
+                "server": "192.168.1.100",
+                "transport": "UDP",
+                "port": 514,
+                "format": "BSD",
+                "facility": "LOG_USER"
+            }
+        },
+        "format": {
+            "traffic": "traffic-format",
+            "threat": "threat-format",
+        },
+        "folder": "Security Profiles",
+    }
+
+
+def create_valid_syslog_server_profile_data():
+    """Create a valid syslog server profile data dictionary for testing."""
+    return {
+        "name": "test-syslog-profile",
+        "servers": {
+            "server1": {
+                "name": "server1",
+                "server": "192.168.1.100",
+                "transport": "UDP",
+                "port": 514,
+                "format": "BSD",
+                "facility": "LOG_USER"
+            }
+        },
+        "folder": "Security Profiles",
+    }
+
+
+# -------------------- SyslogServerProfile validation tests --------------------
+
+
+class TestSyslogServerProfileValidation:
+    """Tests for SyslogServerProfile validation."""
+
+    def test_max_limit_validation_default(self):
+        """Test default max_limit validation."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+        assert syslog_server_profile.max_limit == SyslogServerProfile.DEFAULT_MAX_LIMIT
+
+    def test_max_limit_validation_custom(self):
+        """Test custom max_limit validation."""
+        api_client = MagicMock(spec=Scm)
+        custom_limit = 1000
+        syslog_server_profile = SyslogServerProfile(api_client, max_limit=custom_limit)
+        assert syslog_server_profile.max_limit == custom_limit
+
+    def test_max_limit_validation_invalid_type(self):
+        """Test max_limit validation with invalid type."""
+        api_client = MagicMock(spec=Scm)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            SyslogServerProfile(api_client, max_limit="invalid")
+        assert "Invalid max_limit type" in str(exc_info.value.details)
+
+    def test_max_limit_validation_too_small(self):
+        """Test max_limit validation with value that's too small."""
+        api_client = MagicMock(spec=Scm)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            SyslogServerProfile(api_client, max_limit=0)
+        assert "Invalid max_limit value" in str(exc_info.value.details)
+
+    def test_max_limit_validation_too_large(self):
+        """Test max_limit validation with value that's too large."""
+        api_client = MagicMock(spec=Scm)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            SyslogServerProfile(api_client, max_limit=10000)
+        assert "max_limit exceeds maximum allowed value" in str(exc_info.value.details)
+
+    def test_max_limit_setter(self):
+        """Test max_limit setter."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+        syslog_server_profile.max_limit = 1000
+        assert syslog_server_profile.max_limit == 1000
+
+
+# -------------------- SyslogServerProfile CRUD operation tests --------------------
+
+
+class TestSyslogServerProfileOperations:
+    """Tests for SyslogServerProfile CRUD operations."""
+
+    def test_create(self):
+        """Test creating a new syslog server profile."""
+        api_client = MagicMock(spec=Scm)
+        api_client.post.return_value = create_sample_syslog_server_profile_response()
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        data = create_valid_syslog_server_profile_data()
+        response = syslog_server_profile.create(data)
+
+        # Verify the result
+        assert response.name == "test-syslog-profile"
+        assert "server1" in response.servers
+        assert response.servers["server1"]["transport"] == "UDP"
+        assert response.folder == "Security Profiles"
+
+        # Verify API call
+        api_client.post.assert_called_once()
+        args, kwargs = api_client.post.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "json" in kwargs
+
+    def test_create_with_api_error(self):
+        """Test error handling when API returns an error during creation."""
+        api_client = MagicMock(spec=Scm)
+        api_client.post.side_effect = requests.exceptions.HTTPError("API Error", response=MagicMock(status_code=500))
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+        data = create_valid_syslog_server_profile_data()
+        
+        with pytest.raises(Exception) as exc_info:
+            syslog_server_profile.create(data)
+        assert "API Error" in str(exc_info.value)
+
+    def test_create_with_generic_exception(self):
+        """Test handling of generic exceptions in the create method."""
+        api_client = MagicMock(spec=Scm)
+        api_client.post.side_effect = Exception("Generic error")
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+        data = create_valid_syslog_server_profile_data()
+        
+        with pytest.raises(Exception) as exc_info:
+            syslog_server_profile.create(data)
+        assert "Generic error" in str(exc_info.value)
+    
+    def test_create_error_logging(self):
+        """Test that errors are properly logged during create operations."""
+        api_client = MagicMock(spec=Scm)
+        api_client.post.side_effect = Exception("Test error")
+        
+        with patch("logging.Logger.error") as mock_log:
+            syslog_server_profile = SyslogServerProfile(api_client)
+            data = create_valid_syslog_server_profile_data()
+            
+            with pytest.raises(Exception):
+                syslog_server_profile.create(data)
+            
+            # Verify error was logged
+            mock_log.assert_called_once()
+            assert "Error in API call" in mock_log.call_args[0][0]
+    
+    def test_create_with_server_error(self):
+        """Test handling of 500 server errors in the create method."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        api_client.post.side_effect = requests.exceptions.HTTPError(
+            "500 Server Error", response=mock_response
+        )
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+        data = create_valid_syslog_server_profile_data()
+        
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            syslog_server_profile.create(data)
+        assert "500 Server Error" in str(exc_info.value)
+
+    def test_get(self):
+        """Test getting a syslog server profile by ID."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = create_sample_syslog_server_profile_response()
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        object_id = "123e4567-e89b-12d3-a456-426655440000"
+        response = syslog_server_profile.get(object_id)
+
+        # Verify the result
+        assert response.name == "test-syslog-profile"
+        assert "server1" in response.servers
+        assert response.servers["server1"]["transport"] == "UDP"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == f"/config/objects/v1/syslog-server-profiles/{object_id}"
+
+    def test_update(self):
+        """Test updating a syslog server profile."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = create_sample_syslog_server_profile_response()
+        api_client.put.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Create a valid update model
+        update_data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "updated-profile",
+            "servers": {
+                "server1": {
+                    "name": "server1",
+                    "server": "192.168.1.200",
+                    "transport": "TCP",
+                    "port": 1514,
+                    "format": "IETF",
+                    "facility": "LOG_LOCAL0"
+                }
+            },
+        }
+        update_model = SyslogServerProfileUpdateModel(**update_data)
+        
+        response = syslog_server_profile.update(update_model)
+
+        # Verify the result is correct
+        assert response.name == "test-syslog-profile"  # From our mocked response
+        assert "server1" in response.servers
+
+        # Verify API call
+        api_client.put.assert_called_once()
+        args, kwargs = api_client.put.call_args
+        assert args[0] == f"/config/objects/v1/syslog-server-profiles/{update_data['id']}"
+        assert "json" in kwargs
+        assert "id" not in kwargs["json"]  # ID should be removed from the payload
+
+    def test_delete(self):
+        """Test deleting a syslog server profile."""
+        api_client = MagicMock(spec=Scm)
+        api_client.delete.return_value = None
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        object_id = "123e4567-e89b-12d3-a456-426655440000"
+        syslog_server_profile.delete(object_id)
+
+        # Verify API call
+        api_client.delete.assert_called_once_with(
+            f"/config/objects/v1/syslog-server-profiles/{object_id}"
+        )
+
+
+# -------------------- SyslogServerProfile list and fetch tests --------------------
+
+
+class TestSyslogServerProfileListAndFetch:
+    """Tests for SyslogServerProfile list and fetch operations."""
+
+    def test_list_with_folder(self):
+        """Test listing syslog server profiles in a folder."""
+        api_client = MagicMock(spec=Scm)
+        profile1 = create_sample_syslog_server_profile_response()
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "another-profile"
+        mock_response = {
+            "data": [profile1, profile2],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(folder="Security Profiles")
+
+        # Verify the result
+        assert len(profiles) == 2
+        assert profiles[0].folder == "Security Profiles"
+        assert profiles[1].name == "another-profile"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["folder"] == "Security Profiles"
+
+    def test_list_with_snippet(self):
+        """Test listing syslog server profiles in a snippet."""
+        api_client = MagicMock(spec=Scm)
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["folder"] = None
+        profile1["snippet"] = "TestSnippet"
+        mock_response = {
+            "data": [profile1],
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(snippet="TestSnippet")
+
+        # Verify the result
+        assert len(profiles) == 1
+        assert profiles[0].snippet == "TestSnippet"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["snippet"] == "TestSnippet"
+
+    def test_list_with_device(self):
+        """Test listing syslog server profiles in a device."""
+        api_client = MagicMock(spec=Scm)
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["folder"] = None
+        profile1["device"] = "TestDevice"
+        mock_response = {
+            "data": [profile1],
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(device="TestDevice")
+
+        # Verify the result
+        assert len(profiles) == 1
+        assert profiles[0].device == "TestDevice"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["device"] == "TestDevice"
+
+    def test_list_empty_folder(self):
+        """Test listing syslog server profiles with empty folder string."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(MissingQueryParameterError) as exc_info:
+            syslog_server_profile.list(folder="")
+        assert "folder" in str(exc_info.value.details.get("field"))
+
+    def test_list_no_container(self):
+        """Test listing syslog server profiles without a container."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list()
+        assert "Invalid container parameters" in str(exc_info.value.details.get("error"))
+
+    def test_list_with_filtering(self):
+        """Test listing syslog server profiles with filtering."""
+        api_client = MagicMock(spec=Scm)
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["servers"]["server1"]["transport"] = "UDP"
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "another-profile"
+        profile2["servers"]["server1"]["transport"] = "TCP"
+        
+        mock_response = {
+            "data": [profile1, profile2],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            transport=["UDP"]
+        )
+
+        # Verify the result
+        assert len(profiles) == 1
+        assert profiles[0].servers["server1"]["transport"] == "UDP"
+        assert profiles[0].name == "test-syslog-profile"
+        
+    def test_list_with_multiple_filters(self):
+        """Test listing syslog server profiles with multiple filters."""
+        api_client = MagicMock(spec=Scm)
+        
+        # Profile 1: UDP with BSD format
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["servers"]["server1"]["transport"] = "UDP"
+        profile1["servers"]["server1"]["format"] = "BSD"
+        
+        # Profile 2: TCP with BSD format
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "profile2"
+        profile2["servers"]["server1"]["transport"] = "TCP"
+        profile2["servers"]["server1"]["format"] = "BSD"
+        
+        # Profile 3: UDP with IETF format
+        profile3 = create_sample_syslog_server_profile_response()
+        profile3["name"] = "profile3"
+        profile3["servers"]["server1"]["transport"] = "UDP"
+        profile3["servers"]["server1"]["format"] = "IETF"
+        
+        # Profile 4: TCP with IETF format
+        profile4 = create_sample_syslog_server_profile_response()
+        profile4["name"] = "profile4"
+        profile4["servers"]["server1"]["transport"] = "TCP"
+        profile4["servers"]["server1"]["format"] = "IETF"
+        
+        mock_response = {
+            "data": [profile1, profile2, profile3, profile4],
+            "limit": 200,
+            "offset": 0,
+            "total": 4,
+        }
+        api_client.get.return_value = mock_response
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Filter by transport and format (should return only profile3)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles",
+            transport=["UDP"],
+            format=["IETF"]
+        )
+        
+        # Verify the result - should be just one profile with both criteria
+        assert len(profiles) == 1
+        assert profiles[0].servers["server1"]["transport"] == "UDP"
+        assert profiles[0].servers["server1"]["format"] == "IETF"
+        assert profiles[0].name == "profile3"
+
+    def test_list_with_invalid_transport_filter(self):
+        """Test listing syslog server profiles with invalid transport filter."""
+        api_client = MagicMock(spec=Scm)
+        # Need to return a valid response for the first API call
+        api_client.get.return_value = {
+            "data": [create_sample_syslog_server_profile_response()],
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
+        }
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list(folder="Security Profiles", transport="UDP")
+        assert "errorType" in str(exc_info.value.details)
+        
+    def test_list_with_transport_filter(self):
+        """Test listing syslog server profiles with transport filter."""
+        api_client = MagicMock(spec=Scm)
+        
+        # Profile with UDP server
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["servers"]["server1"]["transport"] = "UDP"
+        
+        # Profile with TCP server
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "tcp-profile"
+        profile2["servers"]["server1"]["transport"] = "TCP"
+        
+        mock_response = {
+            "data": [profile1, profile2],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            transport=["TCP"]
+        )
+
+        # Verify the result
+        assert len(profiles) == 1
+        assert profiles[0].name == "tcp-profile"
+        assert profiles[0].servers["server1"]["transport"] == "TCP"
+        
+    def test_list_with_invalid_format_filter(self):
+        """Test listing syslog server profiles with invalid format filter."""
+        api_client = MagicMock(spec=Scm)
+        # Need to return a valid response for the first API call
+        api_client.get.return_value = {
+            "data": [create_sample_syslog_server_profile_response()],
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
+        }
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list(folder="Security Profiles", format="BSD")
+        assert "errorType" in str(exc_info.value.details)
+        
+    def test_apply_filters_directly(self):
+        """Test _apply_filters method directly to improve code coverage."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Create sample profiles
+        profile1 = SyslogServerProfileResponseModel(**create_sample_syslog_server_profile_response())
+        profile1.servers["server1"]["transport"] = "UDP"
+        
+        profile2 = SyslogServerProfileResponseModel(**create_sample_syslog_server_profile_response())
+        profile2.name = "profile2"
+        profile2.servers["server1"]["transport"] = "TCP"
+        
+        # Test transport filter
+        filtered = syslog_server_profile._apply_filters(
+            [profile1, profile2], 
+            {"transport": ["UDP"]}
+        )
+        assert len(filtered) == 1
+        assert filtered[0].servers["server1"]["transport"] == "UDP"
+        
+        # Test format filter
+        profile1.servers["server1"]["format"] = "BSD"
+        profile2.servers["server1"]["format"] = "IETF"
+        
+        filtered = syslog_server_profile._apply_filters(
+            [profile1, profile2],
+            {"format": ["IETF"]}
+        )
+        assert len(filtered) == 1
+        assert filtered[0].servers["server1"]["format"] == "IETF"
+        
+        # Test multiple filters (should result in empty list with our test data)
+        filtered = syslog_server_profile._apply_filters(
+            [profile1, profile2],
+            {"transport": ["TCP"], "format": ["BSD"]}
+        )
+        assert len(filtered) == 0
+        
+        # Test with empty profiles list
+        filtered = syslog_server_profile._apply_filters(
+            [],
+            {"transport": ["UDP"]}
+        )
+        assert len(filtered) == 0
+        
+        # Test with empty filters dictionary
+        filtered = syslog_server_profile._apply_filters(
+            [profile1, profile2],
+            {}
+        )
+        assert len(filtered) == 2
+
+    def test_fetch(self):
+        """Test fetching a single syslog server profile by name."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = create_sample_syslog_server_profile_response()
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profile = syslog_server_profile.fetch(
+            name="test-syslog-profile", 
+            folder="Security Profiles"
+        )
+
+        # Verify the result
+        assert profile.name == "test-syslog-profile"
+        assert profile.folder == "Security Profiles"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["name"] == "test-syslog-profile"
+        assert kwargs["params"]["folder"] == "Security Profiles"
+
+    def test_fetch_with_snippet(self):
+        """Test fetching a syslog server profile in a snippet container."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = create_sample_syslog_server_profile_response()
+        mock_response["folder"] = None
+        mock_response["snippet"] = "TestSnippet"
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profile = syslog_server_profile.fetch(
+            name="test-syslog-profile", 
+            snippet="TestSnippet"
+        )
+
+        # Verify the result
+        assert profile.name == "test-syslog-profile"
+        assert profile.snippet == "TestSnippet"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["name"] == "test-syslog-profile"
+        assert kwargs["params"]["snippet"] == "TestSnippet"
+
+    def test_fetch_with_device(self):
+        """Test fetching a syslog server profile in a device container."""
+        api_client = MagicMock(spec=Scm)
+        mock_response = create_sample_syslog_server_profile_response()
+        mock_response["folder"] = None
+        mock_response["device"] = "TestDevice"
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profile = syslog_server_profile.fetch(
+            name="test-syslog-profile", 
+            device="TestDevice"
+        )
+
+        # Verify the result
+        assert profile.name == "test-syslog-profile"
+        assert profile.device == "TestDevice"
+
+        # Verify API call
+        api_client.get.assert_called_once()
+        args, kwargs = api_client.get.call_args
+        assert args[0] == "/config/objects/v1/syslog-server-profiles"
+        assert "params" in kwargs
+        assert kwargs["params"]["name"] == "test-syslog-profile"
+        assert kwargs["params"]["device"] == "TestDevice"
+
+    def test_fetch_empty_name(self):
+        """Test fetching with empty name."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(MissingQueryParameterError) as exc_info:
+            syslog_server_profile.fetch(name="", folder="Security Profiles")
+        assert "name" in str(exc_info.value.details.get("field"))
+
+    def test_fetch_empty_folder(self):
+        """Test fetching with empty folder string."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(MissingQueryParameterError) as exc_info:
+            syslog_server_profile.fetch(name="test-profile", folder="")
+        assert "folder" in str(exc_info.value.details.get("field"))
+
+    def test_fetch_no_container(self):
+        """Test fetching without a container."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.fetch(name="test-profile")
+        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(exc_info.value)
+        
+    def test_fetch_invalid_response_format(self):
+        """Test fetching with an invalid response format."""
+        api_client = MagicMock(spec=Scm)
+        api_client.get.return_value = "not a dictionary"  # Invalid response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.fetch(name="test-profile", folder="Security Profiles")
+        assert "Invalid response format: expected dictionary" in exc_info.value.message
+        
+    def test_fetch_missing_id_field(self):
+        """Test fetching with response missing ID field."""
+        api_client = MagicMock(spec=Scm)
+        api_client.get.return_value = {"name": "test-profile"}  # Missing ID
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.fetch(name="test-profile", folder="Security Profiles")
+        assert "Invalid response format: missing 'id' field" in exc_info.value.message
+        
+    def test_list_response_not_dict(self):
+        """Test list with response that's not a dictionary."""
+        api_client = MagicMock(spec=Scm)
+        api_client.get.return_value = "not a dictionary"  # Invalid response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list(folder="Security Profiles")
+        assert "Invalid response format: expected dictionary" in exc_info.value.message
+        
+    def test_list_response_missing_data(self):
+        """Test list with response missing data field."""
+        api_client = MagicMock(spec=Scm)
+        api_client.get.return_value = {"total": 0}  # Missing data field
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list(folder="Security Profiles")
+        assert "Invalid response format: missing 'data' field" in exc_info.value.message
+        
+    def test_list_response_data_not_list(self):
+        """Test list with data field that's not a list."""
+        api_client = MagicMock(spec=Scm)
+        api_client.get.return_value = {"data": "not a list"}  # Data not a list
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            syslog_server_profile.list(folder="Security Profiles")
+        assert "Invalid response format: 'data' field must be a list" in exc_info.value.message
+        
+    def test_list_with_pagination(self):
+        """Test list with pagination through multiple requests."""
+        api_client = MagicMock(spec=Scm)
+        
+        # First response with 2 items (limit=2)
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["name"] = "profile1"
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "profile2"
+        
+        first_response = {
+            "data": [profile1, profile2],
+            "limit": 2,
+            "offset": 0,
+            "total": 3,
+        }
+        
+        # Second response with 1 item
+        profile3 = create_sample_syslog_server_profile_response()
+        profile3["name"] = "profile3"
+        
+        second_response = {
+            "data": [profile3],
+            "limit": 2,
+            "offset": 2,
+            "total": 3,
+        }
+        
+        # Configure the mock to return different responses based on the offset parameter
+        def get_side_effect(*args, **kwargs):
+            if kwargs.get("params", {}).get("offset") == 0:
+                return first_response
+            else:
+                return second_response
+                
+        api_client.get.side_effect = get_side_effect
+
+        # Call list with max_limit=2 to trigger pagination
+        syslog_server_profile = SyslogServerProfile(api_client, max_limit=2)
+        profiles = syslog_server_profile.list(folder="Security Profiles")
+
+        # Verify we got all 3 profiles from both API calls
+        assert len(profiles) == 3
+        assert profiles[0].name == "profile1"
+        assert profiles[1].name == "profile2"
+        assert profiles[2].name == "profile3"
+        
+        # Verify API was called twice with different offset values
+        assert api_client.get.call_count == 2
+        # First call should have offset=0
+        assert api_client.get.call_args_list[0][1]["params"]["offset"] == 0
+        # Second call should have offset=2
+        assert api_client.get.call_args_list[1][1]["params"]["offset"] == 2
+        
+    def test_list_with_exclude_filters(self):
+        """Test list with exclude filters."""
+        api_client = MagicMock(spec=Scm)
+        
+        # Create test profiles
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["name"] = "profile1"
+        profile1["folder"] = "Folder1"
+        
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "profile2"
+        profile2["folder"] = "Folder2"
+        
+        profile3 = create_sample_syslog_server_profile_response()
+        profile3["name"] = "profile3"
+        profile3["snippet"] = "Snippet1"
+        
+        profile4 = create_sample_syslog_server_profile_response()
+        profile4["name"] = "profile4"
+        profile4["device"] = "Device1"
+        
+        mock_response = {
+            "data": [profile1, profile2, profile3, profile4],
+            "limit": 200,
+            "offset": 0,
+            "total": 4,
+        }
+        api_client.get.return_value = mock_response
+
+        # Test excluding folders
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            exclude_folders=["Folder2"]
+        )
+        
+        # Should exclude profile2 with Folder2
+        assert len(profiles) == 3
+        assert "profile2" not in [p.name for p in profiles]
+        
+        # Test excluding snippets
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            exclude_snippets=["Snippet1"]
+        )
+        
+        # Should exclude profile3 with Snippet1
+        assert len(profiles) == 3
+        assert "profile3" not in [p.name for p in profiles]
+        
+        # Test excluding devices
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            exclude_devices=["Device1"]
+        )
+        
+        # Should exclude profile4 with Device1
+        assert len(profiles) == 3
+        assert "profile4" not in [p.name for p in profiles]
+        
+    def test_list_with_multiple_excludes(self):
+        """Test list with multiple exclude filters."""
+        api_client = MagicMock(spec=Scm)
+        
+        # Create test profiles
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["name"] = "profile1"
+        profile1["folder"] = "Folder1"
+        
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "profile2"
+        profile2["folder"] = "Folder2"
+        
+        profile3 = create_sample_syslog_server_profile_response()
+        profile3["name"] = "profile3"
+        profile3["snippet"] = "Snippet1"
+        
+        profile4 = create_sample_syslog_server_profile_response()
+        profile4["name"] = "profile4"
+        profile4["device"] = "Device1"
+        
+        mock_response = {
+            "data": [profile1, profile2, profile3, profile4],
+            "limit": 200,
+            "offset": 0,
+            "total": 4,
+        }
+        api_client.get.return_value = mock_response
+
+        # Test excluding multiple items
+        syslog_server_profile = SyslogServerProfile(api_client)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            exclude_folders=["Folder2"],
+            exclude_snippets=["Snippet1"],
+            exclude_devices=["Device1"]
+        )
+        
+        # Should only keep profile1
+        assert len(profiles) == 1
+        assert profiles[0].name == "profile1"
+        
+    def test_list_with_invalid_exclude_types(self):
+        """Test list with invalid exclude filter types."""
+        api_client = MagicMock(spec=Scm)
+        # Need valid response for initial get
+        api_client.get.return_value = {
+            "data": [create_sample_syslog_server_profile_response()],
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
+        }
+        
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Testing with non-list exclude_folders (should still work but ignore the filter)
+        profiles = syslog_server_profile.list(
+            folder="Security Profiles", 
+            exclude_folders="Folder2"  # String instead of list
+        )
+        
+        # Should not apply the invalid filter
+        assert len(profiles) == 1
+        
+    def test_list_with_exact_match(self):
+        """Test list with exact_match parameter."""
+        api_client = MagicMock(spec=Scm)
+        
+        # Create test profiles with different folder values
+        profile1 = create_sample_syslog_server_profile_response()
+        profile1["name"] = "profile1"
+        profile1["folder"] = "Security Profiles"  # Exact match
+        
+        profile2 = create_sample_syslog_server_profile_response()
+        profile2["name"] = "profile2"
+        profile2["folder"] = "Other Folder"  # Different folder
+        
+        mock_response = {
+            "data": [profile1, profile2],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        api_client.get.return_value = mock_response
+
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Without exact_match, should return both profiles
+        profiles = syslog_server_profile.list(folder="Security Profiles", exact_match=False)
+        assert len(profiles) == 2
+        
+        # With exact_match, should return only the exact match profile
+        profiles = syslog_server_profile.list(folder="Security Profiles", exact_match=True)
+        assert len(profiles) == 1
+        assert profiles[0].name == "profile1"
+        assert profiles[0].folder == "Security Profiles"
+        
+    def test_build_container_params(self):
+        """Test the _build_container_params method directly for code coverage."""
+        api_client = MagicMock(spec=Scm)
+        syslog_server_profile = SyslogServerProfile(api_client)
+        
+        # Test with all None values
+        params = syslog_server_profile._build_container_params(None, None, None)
+        assert params == {}
+        
+        # Test with only folder
+        params = syslog_server_profile._build_container_params("FolderA", None, None)
+        assert params == {"folder": "FolderA"}
+        
+        # Test with only snippet
+        params = syslog_server_profile._build_container_params(None, "SnippetB", None)
+        assert params == {"snippet": "SnippetB"}
+        
+        # Test with only device
+        params = syslog_server_profile._build_container_params(None, None, "DeviceC")
+        assert params == {"device": "DeviceC"}
+        
+        # Test with multiple values (this would lead to an error in actual usage)
+        params = syslog_server_profile._build_container_params("FolderA", "SnippetB", "DeviceC")
+        assert len(params) == 3
+        assert params["folder"] == "FolderA"
+        assert params["snippet"] == "SnippetB" 
+        assert params["device"] == "DeviceC"

--- a/tests/scm/models/objects/test_syslog_server_profiles_models.py
+++ b/tests/scm/models/objects/test_syslog_server_profiles_models.py
@@ -1,0 +1,350 @@
+# tests/scm/models/objects/test_syslog_server_profiles_models.py
+
+from uuid import UUID
+
+# External libraries
+import pytest
+from pydantic import ValidationError
+
+# Local SDK imports
+from scm.models.objects.syslog_server_profiles import (
+    SyslogServerProfileCreateModel,
+    SyslogServerProfileUpdateModel,
+    SyslogServerProfileResponseModel,
+    SyslogServerModel,
+    FormatModel,
+    EscapingModel,
+)
+
+
+# -------------------- Helper Functions --------------------
+
+def create_valid_server():
+    """Helper function to create a valid server model dict."""
+    return {
+        "name": "test-server",
+        "server": "192.168.1.100", 
+        "transport": "UDP",
+        "port": 514,
+        "format": "BSD",
+        "facility": "LOG_USER"
+    }
+
+def create_valid_format():
+    """Helper function to create a valid format model dict."""
+    return {
+        "traffic": "$format_string_traffic",
+        "threat": "$format_string_threat",
+        "escaping": {
+            "escape_character": "\\",
+            "escaped_characters": "%"
+        }
+    }
+
+def create_valid_profile_data(container_type="folder"):
+    """Helper function to create a valid syslog server profile data dict."""
+    data = {
+        "name": "test-syslog-profile",
+        "servers": {
+            "name": create_valid_server()
+        },
+        "format": create_valid_format()
+    }
+    
+    # Add the specified container
+    if container_type == "folder":
+        data["folder"] = "Shared"
+    elif container_type == "snippet":
+        data["snippet"] = "TestSnippet"
+    elif container_type == "device":
+        data["device"] = "TestDevice"
+    
+    return data
+
+
+# -------------------- Test Classes for Pydantic Models --------------------
+
+
+class TestSyslogServerModel:
+    """Tests for SyslogServerModel validation."""
+    
+    def test_valid_server(self):
+        """Test that a valid server configuration is accepted."""
+        server_data = create_valid_server()
+        server = SyslogServerModel(**server_data)
+        assert server.name == server_data["name"]
+        assert server.server == server_data["server"]
+        assert server.transport == server_data["transport"]
+        assert server.port == server_data["port"]
+        assert server.format == server_data["format"]
+        assert server.facility == server_data["facility"]
+
+    def test_invalid_transport(self):
+        """Test that an invalid transport protocol is rejected."""
+        server_data = create_valid_server()
+        server_data["transport"] = "INVALID"
+        
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerModel(**server_data)
+        error_msg = str(exc_info.value)
+        assert "transport" in error_msg
+        assert "Input should be 'UDP' or 'TCP'" in error_msg
+    
+    def test_invalid_format(self):
+        """Test that an invalid format is rejected."""
+        server_data = create_valid_server()
+        server_data["format"] = "INVALID"
+        
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerModel(**server_data)
+        error_msg = str(exc_info.value)
+        assert "format" in error_msg
+        assert "Input should be 'BSD' or 'IETF'" in error_msg
+    
+    def test_invalid_facility(self):
+        """Test that an invalid facility is rejected."""
+        server_data = create_valid_server()
+        server_data["facility"] = "INVALID"
+        
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerModel(**server_data)
+        error_msg = str(exc_info.value)
+        assert "facility" in error_msg
+        assert "Input should be 'LOG_USER'" in error_msg
+
+    def test_port_range(self):
+        """Test port number validation."""
+        server_data = create_valid_server()
+        
+        # Test port below minimum
+        server_data["port"] = 0
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerModel(**server_data)
+        assert "port" in str(exc_info.value)
+        assert "Input should be greater than or equal to 1" in str(exc_info.value)
+        
+        # Test port above maximum
+        server_data["port"] = 65536
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerModel(**server_data)
+        assert "port" in str(exc_info.value)
+        assert "Input should be less than or equal to 65535" in str(exc_info.value)
+
+
+class TestFormatModel:
+    """Tests for FormatModel validation."""
+    
+    def test_valid_format(self):
+        """Test that a valid format configuration is accepted."""
+        format_data = create_valid_format()
+        format_model = FormatModel(**format_data)
+        assert format_model.traffic == format_data["traffic"]
+        assert format_model.threat == format_data["threat"]
+        assert format_model.escaping.escape_character == format_data["escaping"]["escape_character"]
+        assert format_model.escaping.escaped_characters == format_data["escaping"]["escaped_characters"]
+    
+    def test_escaping_model(self):
+        """Test EscapingModel validation."""
+        escaping_data = {
+            "escape_character": "\\",
+            "escaped_characters": "%$[]"
+        }
+        escaping = EscapingModel(**escaping_data)
+        assert escaping.escape_character == escaping_data["escape_character"]
+        assert escaping.escaped_characters == escaping_data["escaped_characters"]
+    
+    def test_escape_character_length(self):
+        """Test that escape_character must be a single character."""
+        escaping_data = {
+            "escape_character": "\\\\",  # More than one character
+            "escaped_characters": "%"
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            EscapingModel(**escaping_data)
+        assert "escape_character" in str(exc_info.value)
+        assert "String should have at most 1 character" in str(exc_info.value)
+
+
+class TestSyslogServerProfileCreateModel:
+    """Tests for SyslogServerProfileCreateModel validation."""
+
+    def test_invalid_data_error(self):
+        """Test that ValidationError is raised when invalid data is provided."""
+        data = {"invalid_field": "test"}
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileCreateModel(**data)
+        error_msg = str(exc_info.value)
+        assert "name\n  Field required" in error_msg
+        assert "servers\n  Field required" in error_msg
+
+    def test_missing_required_fields(self):
+        """Test validation when required fields are missing."""
+        data = {"name": "test-profile"}
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileCreateModel(**data)
+        error_msg = str(exc_info.value)
+        assert "servers\n  Field required" in error_msg
+
+    def test_multiple_containers_error(self):
+        """Test validation when multiple containers are provided."""
+        data = create_valid_profile_data()
+        data["snippet"] = "TestSnippet"  # Adding a second container
+        
+        with pytest.raises(ValueError) as exc_info:
+            SyslogServerProfileCreateModel(**data)
+        assert (
+            "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+            in str(exc_info.value)
+        )
+
+    def test_no_container_error(self):
+        """Test validation when no container is provided."""
+        data = create_valid_profile_data()
+        data.pop("folder")  # Remove the container
+        
+        with pytest.raises(ValueError) as exc_info:
+            SyslogServerProfileCreateModel(**data)
+        assert (
+            "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+            in str(exc_info.value)
+        )
+
+    def test_valid_model_with_folder(self):
+        """Test validation with valid data using folder container."""
+        data = create_valid_profile_data("folder")
+        model = SyslogServerProfileCreateModel(**data)
+        assert model.name == data["name"]
+        assert model.servers == data["servers"]
+        assert model.folder == data["folder"]
+        assert model.format.traffic == data["format"]["traffic"]
+        assert model.format.threat == data["format"]["threat"]
+
+    def test_valid_model_with_snippet(self):
+        """Test validation with valid data using snippet container."""
+        data = create_valid_profile_data("snippet")
+        model = SyslogServerProfileCreateModel(**data)
+        assert model.name == data["name"]
+        assert model.snippet == data["snippet"]
+        assert model.folder is None
+        assert model.device is None
+
+    def test_valid_model_with_device(self):
+        """Test validation with valid data using device container."""
+        data = create_valid_profile_data("device")
+        model = SyslogServerProfileCreateModel(**data)
+        assert model.name == data["name"]
+        assert model.device == data["device"]
+        assert model.folder is None
+        assert model.snippet is None
+
+
+class TestSyslogServerProfileUpdateModel:
+    """Tests for SyslogServerProfileUpdateModel validation."""
+
+    def test_invalid_data_error(self):
+        """Test that ValidationError is raised when invalid data is provided."""
+        data = {"invalid": "data"}
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileUpdateModel(**data)
+        error_msg = str(exc_info.value)
+        assert "validation error" in error_msg
+        assert "name\n  Field required" in error_msg
+        assert "servers\n  Field required" in error_msg
+        assert "id\n  Field required" in error_msg
+
+    def test_missing_id(self):
+        """Test validation when 'id' field is missing."""
+        data = create_valid_profile_data()
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileUpdateModel(**data)
+        assert "id\n  Field required" in str(exc_info.value)
+
+    def test_invalid_id_format(self):
+        """Test validation for invalid UUID format."""
+        data = create_valid_profile_data()
+        data["id"] = "invalid-uuid"
+        
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileUpdateModel(**data)
+        assert "id\n  Input should be a valid UUID" in str(exc_info.value)
+
+    def test_valid_model(self):
+        """Test validation with valid data."""
+        data = create_valid_profile_data()
+        data["id"] = "123e4567-e89b-12d3-a456-426655440000"
+        
+        model = SyslogServerProfileUpdateModel(**data)
+        assert model.id == UUID(data["id"])
+        assert model.name == data["name"]
+        assert model.servers == data["servers"]
+        assert model.folder == data["folder"]
+
+    def test_minimal_update(self):
+        """Test updating with minimal required fields."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "updated-profile",
+            "servers": {
+                "server1": create_valid_server()
+            }
+        }
+        
+        model = SyslogServerProfileUpdateModel(**data)
+        assert model.id == UUID(data["id"])
+        assert model.name == data["name"]
+        assert model.servers == data["servers"]
+        assert model.format is None
+        assert model.folder is None
+        assert model.snippet is None
+        assert model.device is None
+
+
+class TestSyslogServerProfileResponseModel:
+    """Tests for SyslogServerProfileResponseModel validation."""
+
+    def test_valid_model(self):
+        """Test validation with valid response data."""
+        data = create_valid_profile_data()
+        data["id"] = "123e4567-e89b-12d3-a456-426655440000"
+        
+        model = SyslogServerProfileResponseModel(**data)
+        assert model.id == UUID(data["id"])
+        assert model.name == data["name"]
+        assert model.servers == data["servers"]
+        assert model.folder == data["folder"]
+        assert model.format.traffic == data["format"]["traffic"]
+        assert model.format.threat == data["format"]["threat"]
+
+    def test_with_snippet(self):
+        """Test validation with snippet container."""
+        data = create_valid_profile_data("snippet")
+        data["id"] = "123e4567-e89b-12d3-a456-426655440000"
+        
+        model = SyslogServerProfileResponseModel(**data)
+        assert model.id == UUID(data["id"])
+        assert model.snippet == data["snippet"]
+        assert model.folder is None
+        assert model.device is None
+
+    def test_with_device(self):
+        """Test validation with device container."""
+        data = create_valid_profile_data("device")
+        data["id"] = "123e4567-e89b-12d3-a456-426655440000"
+        
+        model = SyslogServerProfileResponseModel(**data)
+        assert model.id == UUID(data["id"])
+        assert model.device == data["device"]
+        assert model.folder is None
+        assert model.snippet is None
+
+    def test_missing_required_fields(self):
+        """Test validation when required fields are missing."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            SyslogServerProfileResponseModel(**data)
+        error_msg = str(exc_info.value)
+        assert "2 validation errors for SyslogServerProfileResponseModel" in error_msg
+        assert "name\n  Field required" in error_msg
+        assert "servers\n  Field required" in error_msg


### PR DESCRIPTION

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in this repository.
- [x] Ensure your commit messages follow the project's preferred format.
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Introduce a comprehensive SyslogServerProfile class to manage syslog server profiles, including create, update, delete, list, and fetch operations. Implement accompanying data models for validation and response parsing. Add unit tests to verify functionality and edge cases.

#### What does this pull request accomplish?

- Feature addition

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

#### Is there anything the reviewers should know?

Thank you for your contributions!