### PR TITLE
Fix Security Zone fetch() API response format inconsistency

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,17 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.3.20
+
+**Released:** March 13, 2025
+
+### Fixed
+
+- **Security Zone**: Added temporary workaround for inconsistent API response format in the `fetch()` method
+  - Now supports both direct object response format and list-style data array format
+  - Ensures backward compatibility when API format is corrected
+  - Comprehensive test coverage for both response formats
+
 ## Version 0.3.19
 
 **Released:** March 12, 2025

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.3.19"
+version = "0.3.20"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/config/network/security_zone.py
+++ b/scm/config/network/security_zone.py
@@ -482,14 +482,26 @@ class SecurityZone(BaseObject):
                 details={"error": "Response is not a dictionary"},
             )
 
+        # Handle the expected format (direct object with 'id' field)
         if "id" in response:
             return SecurityZoneResponseModel(**response)
+        # Handle the alternate format (like list() with 'data' array)
+        elif "data" in response and isinstance(response["data"], list):
+            if not response["data"]:
+                raise InvalidObjectError(
+                    message=f"Security zone '{name}' not found",
+                    error_code="E002",
+                    http_status_code=404,
+                    details={"error": "No matching security zone found"},
+                )
+            # Return the first item in the data array
+            return SecurityZoneResponseModel(**response["data"][0])
         else:
             raise InvalidObjectError(
-                message="Invalid response format: missing 'id' field",
+                message="Invalid response format: expected either 'id' or 'data' field",
                 error_code="E003",
                 http_status_code=500,
-                details={"error": "Response missing 'id' field"},
+                details={"error": "Response has invalid structure"},
             )
 
     def delete(

--- a/scm/config/network/security_zone.py
+++ b/scm/config/network/security_zone.py
@@ -494,6 +494,17 @@ class SecurityZone(BaseObject):
                     http_status_code=404,
                     details={"error": "No matching security zone found"},
                 )
+            if "id" not in response["data"][0]:
+                raise InvalidObjectError(
+                    message="Invalid response format: missing 'id' field in data array",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={"error": "Response data item missing 'id' field"},
+                )
+            if len(response["data"]) > 1:
+                self.logger.warning(
+                    f"Multiple security zones found for '{name}'. Using the first one."
+                )
             # Return the first item in the data array
             return SecurityZoneResponseModel(**response["data"][0])
         else:


### PR DESCRIPTION
### **User description**
## Summary
- Add workaround for Security Zone fetch() API response format inconsistency
- Support both direct object response and list-style data array format
- Add comprehensive test coverage for both formats
- Increment version from 0.3.19 to 0.3.20
- Update release notes

## Test plan
- Verified both response formats work correctly with unit tests
- All existing tests pass with the new implementation
- Linting and formatting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Handle inconsistent Security Zone fetch() API responses

- Support direct object and list-style data formats

- Add comprehensive test coverage for both formats

- Update version and release notes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_zone.py</strong><dd><code>Handle inconsistent Security Zone fetch() API responses</code>&nbsp; &nbsp; </dd></summary>
<hr>

scm/config/network/security_zone.py

<li>Added support for alternate list-style response format<br> <li> Implemented error handling for empty data arrays<br> <li> Updated error messages for clarity


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/145/files#diff-a9b8bcb60c91022f353e654e1758be7c998a6a5c953a6567f84ca56d9542ceb9">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_security_zone.py</strong><dd><code>Expand test coverage for Security Zone fetch() method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/scm/config/network/test_security_zone.py

<li>Added tests for original and list-style response formats<br> <li> Implemented tests for multiple objects in data array<br> <li> Updated existing tests to match new error messages


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/145/files#diff-c2c024746bb86f898f8327fae6fbbcd4db9fd0369cdda899923815a6f3a2d4c4">+94/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-notes.md</strong><dd><code>Update release notes for version 0.3.20</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/about/release-notes.md

<li>Added release notes for version 0.3.20<br> <li> Described the Security Zone fetch() method workaround


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/145/files#diff-0dbef2eee08ae742e45363c13a338a93394f65721027aedb7b85f60818e35960">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.3.20</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Incremented version from 0.3.19 to 0.3.20


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/145/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>