### PR TITLE
Remove `description` field from IKE crypto profile models.

### DIFF
--- a/scm/models/network/ike_crypto_profile.py
+++ b/scm/models/network/ike_crypto_profile.py
@@ -101,10 +101,6 @@ class IKECryptoProfileBaseModel(BaseModel):
         pattern=r"^[0-9a-zA-Z._-]+$",
         max_length=31,
     )
-    description: Optional[str] = Field(
-        None,
-        description="Description of the IKE crypto profile",
-    )
     hash: List[HashAlgorithm] = Field(
         ...,
         description="Hashing algorithms",
@@ -186,7 +182,3 @@ class IKECryptoProfileResponseModel(IKECryptoProfileBaseModel):
         description="The UUID of the IKE crypto profile",
         examples=["123e4567-e89b-12d3-a456-426655440000"],
     )
-
-    # Exclude description field from model_fields - API doesn't return it
-    # Use exclude=True so it doesn't appear in model_fields but still can be passed to init
-    description: Optional[str] = Field(None, exclude=True)

--- a/tests/scm/config/network/test_ike_crypto_profile.py
+++ b/tests/scm/config/network/test_ike_crypto_profile.py
@@ -141,8 +141,8 @@ class TestIKECryptoProfileUpdate(TestIKECryptoProfileBase):
 
         # Create an update model
         update_data = sample_profile_response.copy()
-        # Add description for update model
-        update_data["description"] = "Updated test profile"
+        # Update hash algorithm for the update
+        update_data["hash"] = ["sha384", "sha512"]
         update_model = IKECryptoProfileUpdateModel(**update_data)
 
         result = ike_crypto_profile.update(update_model)
@@ -155,8 +155,10 @@ class TestIKECryptoProfileUpdate(TestIKECryptoProfileBase):
             == "/config/network/v1/ike-crypto-profiles/123e4567-e89b-12d3-a456-426655440000"
         )
         assert "id" not in call_args[1]["json"], "ID should not be in the request payload"
-        # Verify description is in the update payload
-        assert "description" in call_args[1]["json"], "Description should be in the request payload"
+        # Verify hash algorithms were updated in the payload
+        assert call_args[1]["json"]["hash"] == ["sha384", "sha512"], (
+            "Hash should be updated in the request payload"
+        )
 
         assert isinstance(result, IKECryptoProfileResponseModel)
         assert result.name == "test-profile"

--- a/tests/scm/models/network/test_ike_crypto_profile_models.py
+++ b/tests/scm/models/network/test_ike_crypto_profile_models.py
@@ -150,9 +150,6 @@ class TestIKECryptoProfileModels:
         assert HashAlgorithm.SHA256 in profile.hash
         assert profile.folder == "test-folder"
 
-        # Test description is excluded from model fields but still accessible
-        assert IKECryptoProfileResponseModel.model_fields["description"].exclude is True
-
         # Test missing required ID
         invalid_data = {
             "name": "test-profile",
@@ -163,36 +160,3 @@ class TestIKECryptoProfileModels:
         }
         with pytest.raises(ValidationError):
             IKECryptoProfileResponseModel(**invalid_data)
-
-    def test_description_in_update_model(self):
-        """Test description field in update model but not in response model."""
-        # The update model should accept description field
-        update_data = {
-            "id": "123e4567-e89b-12d3-a456-426655440000",
-            "name": "test-profile",
-            "description": "This is a test description",
-            "hash": ["sha1", "sha256"],
-            "encryption": ["aes-128-cbc", "aes-256-cbc"],
-            "dh_group": ["group2", "group5"],
-            "folder": "test-folder",
-        }
-        # This should not raise an error - description should be accepted
-        update_model = IKECryptoProfileUpdateModel(**update_data)
-        assert update_model.description == "This is a test description"
-
-        # Response model has description field, but it's excluded from serialization
-        response_data = {
-            "id": "123e4567-e89b-12d3-a456-426655440000",
-            "name": "test-profile",
-            "hash": ["sha1", "sha256"],
-            "encryption": ["aes-128-cbc", "aes-256-cbc"],
-            "dh_group": ["group2", "group5"],
-            "folder": "test-folder",
-        }
-        response_model = IKECryptoProfileResponseModel(**response_data)
-        assert hasattr(response_model, "description")
-        assert response_model.description is None
-        assert response_model.model_fields["description"].exclude is True
-        # Ensure description is excluded when serializing to dict
-        model_dict = response_model.model_dump()
-        assert "description" not in model_dict


### PR DESCRIPTION
### **User description**
The `description` field and its related logic have been removed from models and tests as it is no longer required. Updated tests to reflect changes by focusing on other relevant fields like `hash`. Simplified code and ensured no unnecessary fields are included in API payloads.

### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in the `https://github.com/cdot65/pan-scm-sdk` repository (do NOT target the Palo Alto Networks repo!).
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Provide a detailed description of the changes your pull request introduces.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `description` field from IKE crypto profile models

- Update tests to reflect removal of `description`

- Simplify code and API payloads

- Adjust update test to focus on `hash` field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ike_crypto_profile.py</strong><dd><code>Remove description field from IKE crypto profile models</code>&nbsp; &nbsp; </dd></summary>
<hr>

scm/models/network/ike_crypto_profile.py

<li>Removed <code>description</code> field from <code>IKECryptoProfileBaseModel</code><br> <li> Removed <code>description</code> field from <code>IKECryptoProfileResponseModel</code>


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/166/files#diff-5d752022e07dc16e2d3a11a61d2f8c839838ace396603ccc88db02b5b17aa715">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ike_crypto_profile.py</strong><dd><code>Update IKE crypto profile tests to use hash instead of description</code></dd></summary>
<hr>

tests/scm/config/network/test_ike_crypto_profile.py

<li>Updated test_update_ike_crypto_profile to use <code>hash</code> instead of <br><code>description</code><br> <li> Adjusted assertions to check for <code>hash</code> update in payload


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/166/files#diff-69011b735ac023ba693ed13a80c650520c4d2e6f80082d5bafc7dd4ce417b907">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ike_crypto_profile_models.py</strong><dd><code>Remove description-related tests from IKE crypto profile models</code></dd></summary>
<hr>

tests/scm/models/network/test_ike_crypto_profile_models.py

<li>Removed test for <code>description</code> field exclusion<br> <li> Deleted test_description_in_update_model method


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/166/files#diff-63aaf0b96cbaa6e904ac820fafdfc30f7a3afd815305a40d7b74e6272cdd6adb">+0/-36</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>