### PR TITLE
Fix HTTP Server Profile fetch() method to handle inconsistent API response formats

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,18 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.3.29
+
+**Released:** May 4, 2025
+
+### Fixed
+- **HTTP Server Profiles:**
+  - Fixed inconsistent API response format in the `fetch()` method of HTTP Server Profiles
+  - Added support for both direct object response and list-style data array format
+  - Enhanced error handling for empty responses
+  - Added comprehensive test coverage for both response formats
+  - Resolves issue #182
+
 ## Version 0.3.28
 
 **Released:** May 4, 2025

--- a/scm/config/objects/http_server_profiles.py
+++ b/scm/config/objects/http_server_profiles.py
@@ -470,7 +470,20 @@ class HTTPServerProfile(BaseObject):
                 details={"error": "Response is not a dictionary"},
             )
 
-        if "id" in response:
+        # Handle the case when response has a 'data' key with a list
+        # This is a workaround for an API inconsistency where fetch sometimes returns a list format
+        if "data" in response and isinstance(response["data"], list):
+            if len(response["data"]) == 0:
+                raise InvalidObjectError(
+                    message="No HTTP server profile found with the given name and container",
+                    error_code="E003",
+                    http_status_code=404,
+                    details={"error": "HTTP server profile not found"},
+                )
+            # Return the first item from the data list
+            return HTTPServerProfileResponseModel(**response["data"][0])
+        # Handle the normal case when response has an 'id' field
+        elif "id" in response:
             return HTTPServerProfileResponseModel(**response)
         else:
             raise InvalidObjectError(

--- a/tests/scm/config/objects/test_http_server_profiles.py
+++ b/tests/scm/config/objects/test_http_server_profiles.py
@@ -884,37 +884,37 @@ class TestHTTPServerProfileListAndFetch:
         with pytest.raises(InvalidObjectError) as exc_info:
             http_server_profile.fetch(name="test-profile", folder="Security Profiles")
         assert "Invalid response format: missing 'id' field" in exc_info.value.message
-        
+
     def test_fetch_with_data_list_response(self):
         """Test fetching a HTTP server profile when API returns a list format with 'data' key."""
         api_client = MagicMock(spec=Scm)
         # Mock the API response in the problematic format:
         # Instead of a single object, it returns a list inside 'data' key
         mock_response = {
-            'data': [
+            "data": [
                 {
-                    'folder': 'All',
-                    'id': '4042341d-7013-472c-ba24-ca37e48a8058',
-                    'name': 'hgu-http-srv-profile',
-                    'server': [
+                    "folder": "All",
+                    "id": "4042341d-7013-472c-ba24-ca37e48a8058",
+                    "name": "hgu-http-srv-profile",
+                    "server": [
                         {
-                            'address': '1.2.3.4',
-                            'certificate_profile': 'None',
-                            'http_method': 'POST',
-                            'name': 'hgu-srv-http',
-                            'password': 'passwd-hash',
-                            'port': 443,
-                            'protocol': 'HTTPS',
-                            'tls_version': '1.2',
-                            'username': 'test'
+                            "address": "1.2.3.4",
+                            "certificate_profile": "None",
+                            "http_method": "POST",
+                            "name": "hgu-srv-http",
+                            "password": "passwd-hash",
+                            "port": 443,
+                            "protocol": "HTTPS",
+                            "tls_version": "1.2",
+                            "username": "test",
                         }
                     ],
-                    'tag_registration': False
+                    "tag_registration": False,
                 }
             ],
-            'limit': 200,
-            'offset': 0,
-            'total': 1
+            "limit": 200,
+            "offset": 0,
+            "total": 1,
         }
         api_client.get.return_value = mock_response
 
@@ -928,24 +928,22 @@ class TestHTTPServerProfileListAndFetch:
         assert len(profile.server) == 1
         assert profile.server[0].name == "hgu-srv-http"
         assert profile.server[0].protocol == "HTTPS"
-        
+
     def test_fetch_with_empty_data_list(self):
         """Test fetching a HTTP server profile when API returns an empty list in 'data' key."""
         api_client = MagicMock(spec=Scm)
         # Mock an empty response
-        mock_response = {
-            'data': [],
-            'limit': 200, 
-            'offset': 0,
-            'total': 0
-        }
+        mock_response = {"data": [], "limit": 200, "offset": 0, "total": 0}
         api_client.get.return_value = mock_response
 
         http_server_profile = HTTPServerProfile(api_client)
         with pytest.raises(InvalidObjectError) as exc_info:
             http_server_profile.fetch(name="nonexistent-profile", folder="All")
-            
-        assert "No HTTP server profile found with the given name and container" in exc_info.value.message
+
+        assert (
+            "No HTTP server profile found with the given name and container"
+            in exc_info.value.message
+        )
         assert exc_info.value.http_status_code == 404
 
     def test_list_response_not_dict(self):

--- a/tests/scm/config/objects/test_http_server_profiles.py
+++ b/tests/scm/config/objects/test_http_server_profiles.py
@@ -1,6 +1,7 @@
 # tests/scm/config/objects/test_http_server_profiles.py
 
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 import requests
@@ -883,6 +884,69 @@ class TestHTTPServerProfileListAndFetch:
         with pytest.raises(InvalidObjectError) as exc_info:
             http_server_profile.fetch(name="test-profile", folder="Security Profiles")
         assert "Invalid response format: missing 'id' field" in exc_info.value.message
+        
+    def test_fetch_with_data_list_response(self):
+        """Test fetching a HTTP server profile when API returns a list format with 'data' key."""
+        api_client = MagicMock(spec=Scm)
+        # Mock the API response in the problematic format:
+        # Instead of a single object, it returns a list inside 'data' key
+        mock_response = {
+            'data': [
+                {
+                    'folder': 'All',
+                    'id': '4042341d-7013-472c-ba24-ca37e48a8058',
+                    'name': 'hgu-http-srv-profile',
+                    'server': [
+                        {
+                            'address': '1.2.3.4',
+                            'certificate_profile': 'None',
+                            'http_method': 'POST',
+                            'name': 'hgu-srv-http',
+                            'password': 'passwd-hash',
+                            'port': 443,
+                            'protocol': 'HTTPS',
+                            'tls_version': '1.2',
+                            'username': 'test'
+                        }
+                    ],
+                    'tag_registration': False
+                }
+            ],
+            'limit': 200,
+            'offset': 0,
+            'total': 1
+        }
+        api_client.get.return_value = mock_response
+
+        http_server_profile = HTTPServerProfile(api_client)
+        profile = http_server_profile.fetch(name="hgu-http-srv-profile", folder="All")
+
+        # Verify the result - should get the first item from data list
+        assert profile.name == "hgu-http-srv-profile"
+        assert profile.folder == "All"
+        assert profile.id == UUID("4042341d-7013-472c-ba24-ca37e48a8058")
+        assert len(profile.server) == 1
+        assert profile.server[0].name == "hgu-srv-http"
+        assert profile.server[0].protocol == "HTTPS"
+        
+    def test_fetch_with_empty_data_list(self):
+        """Test fetching a HTTP server profile when API returns an empty list in 'data' key."""
+        api_client = MagicMock(spec=Scm)
+        # Mock an empty response
+        mock_response = {
+            'data': [],
+            'limit': 200, 
+            'offset': 0,
+            'total': 0
+        }
+        api_client.get.return_value = mock_response
+
+        http_server_profile = HTTPServerProfile(api_client)
+        with pytest.raises(InvalidObjectError) as exc_info:
+            http_server_profile.fetch(name="nonexistent-profile", folder="All")
+            
+        assert "No HTTP server profile found with the given name and container" in exc_info.value.message
+        assert exc_info.value.http_status_code == 404
 
     def test_list_response_not_dict(self):
         """Test list with response that's not a dictionary."""


### PR DESCRIPTION
### **User description**
## Summary
- Fixed HTTP Server Profile fetch() method to handle inconsistent API response formats from the remote SCM API
- Added support for both direct object response format and list-style data array format
- Enhanced error handling for empty responses
- Added comprehensive test coverage for both response formats

## Test plan
- Added new test cases to verify the fix works with both response formats
- All existing tests pass without modification
- Verified error handling for empty response data

Fixes #182

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix HTTP Server Profile fetch() for inconsistent API responses

- Handle both direct object and list-style data formats

- Improve error handling for empty responses

- Add comprehensive test coverage for new scenarios


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_server_profiles.py</strong><dd><code>Enhance fetch() method to handle multiple response formats</code></dd></summary>
<hr>

scm/config/objects/http_server_profiles.py

<li>Modified fetch() to handle both direct object and list-style responses<br> <li> Added error handling for empty data lists<br> <li> Improved response parsing logic


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/184/files#diff-fe15cfebc43f45003659f353b8a973f49bbb47500e4ab0c03b1d4450f7363f90">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_http_server_profiles.py</strong><dd><code>Add tests for new fetch() method scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/scm/config/objects/test_http_server_profiles.py

<li>Added test for fetching with data list response<br> <li> Added test for empty data list response<br> <li> Imported UUID for assertion testing


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/184/files#diff-38d78e5d2f8870ba4b04412faa191bffa82acc45ba5249cc467ca09fc5c3c50e">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-notes.md</strong><dd><code>Update release notes for version 0.3.29</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/about/release-notes.md

<li>Added release notes for version 0.3.29<br> <li> Documented fix for HTTP Server Profiles fetch() method


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/184/files#diff-0dbef2eee08ae742e45363c13a338a93394f65721027aedb7b85f60818e35960">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>