### PR TITLE
Fix gp_client_version field name

### DIFF
--- a/openapi/config-setup.yaml
+++ b/openapi/config-setup.yaml
@@ -1390,7 +1390,7 @@ components:
         "vm_state":
           type: string
           readOnly: true
-        "gp_client_verion":
+        "gp_client_version":
           type: string
           readOnly: true
         "gp_data_version":

--- a/scm/models/setup/device.py
+++ b/scm/models/setup/device.py
@@ -6,7 +6,7 @@ Defines Pydantic models for representing Device resources returned by the SCM AP
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DeviceLicenseModel(BaseModel):
@@ -102,7 +102,7 @@ class DeviceResponseModel(DeviceBaseModel):
         wf_release_date: WildFire release date.
         iot_version: IoT version.
         iot_release_date: IoT release date.
-        gp_client_verion: GlobalProtect client version.
+        gp_client_version: GlobalProtect client version.
         gp_data_version: GlobalProtect data version.
         log_db_version: Log DB version.
         software_version: Software version.
@@ -120,6 +120,8 @@ class DeviceResponseModel(DeviceBaseModel):
         ha_peer_serial: HA peer serial number.
         vm_state: VM state.
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str = Field(..., description="Unique device identifier (serial number).")
     connected_since: Optional[str] = Field(None, description="ISO timestamp when connected.")
@@ -149,7 +151,11 @@ class DeviceResponseModel(DeviceBaseModel):
     wf_release_date: Optional[str] = Field(None, description="WildFire release date.")
     iot_version: Optional[str] = Field(None, description="IoT version.")
     iot_release_date: Optional[str] = Field(None, description="IoT release date.")
-    gp_client_verion: Optional[str] = Field(None, description="GlobalProtect client version.")
+    gp_client_version: Optional[str] = Field(
+        None,
+        alias="gp_client_verion",
+        description="GlobalProtect client version.",
+    )
     gp_data_version: Optional[str] = Field(None, description="GlobalProtect data version.")
     log_db_version: Optional[str] = Field(None, description="Log DB version.")
     software_version: Optional[str] = Field(None, description="Software version.")

--- a/tests/factories/setup/device.py
+++ b/tests/factories/setup/device.py
@@ -74,7 +74,7 @@ class DeviceResponseModelFactory(factory.Factory):
     iot_release_date = factory.LazyFunction(
         lambda: fake.date_time().strftime("%Y/%m/%d %H:%M:%S %Z")
     )
-    gp_client_verion = factory.LazyFunction(lambda: fake.numerify(text="#.#.#"))
+    gp_client_version = factory.LazyFunction(lambda: fake.numerify(text="#.#.#"))
     gp_data_version = factory.LazyFunction(lambda: fake.numerify(text="#"))
     log_db_version = factory.LazyFunction(lambda: fake.numerify(text="##.#.#"))
     software_version = factory.LazyFunction(lambda: fake.numerify(text="##.#.#"))
@@ -157,7 +157,7 @@ class DeviceResponseModelDictFactory(factory.Factory):
     iot_release_date = factory.LazyFunction(
         lambda: fake.date_time().strftime("%Y/%m/%d %H:%M:%S %Z")
     )
-    gp_client_verion = factory.LazyFunction(lambda: fake.numerify(text="#.#.#"))
+    gp_client_version = factory.LazyFunction(lambda: fake.numerify(text="#.#.#"))
     gp_data_version = factory.LazyFunction(lambda: fake.numerify(text="#"))
     log_db_version = factory.LazyFunction(lambda: fake.numerify(text="##.#.#"))
     software_version = factory.LazyFunction(lambda: fake.numerify(text="##.#.#"))


### PR DESCRIPTION
### **User description**
## Summary
- fix `gp_client_verion` typo in DeviceResponseModel
- keep backward-compatible alias
- update device factories and OpenAPI spec
- fix docstring indentation

## Testing
- `make test-cov` *(fails: docker not found)*
- `poetry run pytest -m "not api" --cov=scm --cov-report=xml --cov-report=term-missing tests/` *(fails: pytest not installed)*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix typo in `gp_client_version` field name

- Add backward compatibility with alias

- Update device factories and OpenAPI spec

- Correct docstring indentation in device model


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device.py</strong><dd><code>Correct GlobalProtect client version field and add compatibility</code></dd></summary>
<hr>

scm/models/setup/device.py

<li>Rename <code>gp_client_verion</code> to <code>gp_client_version</code><br> <li> Add backward compatibility using <code>alias</code><br> <li> Import <code>ConfigDict</code> and add <code>model_config</code><br> <li> Fix docstring indentation


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/199/files#diff-ffd6f329ea8c5dede2da412cb8fdae56311bd8fc291444c813025570e43ae9cf">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device.py</strong><dd><code>Update device factories with correct field name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/factories/setup/device.py

<li>Update <code>gp_client_verion</code> to <code>gp_client_version</code> in both factory classes


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/199/files#diff-da162debaa9bd9911a98cda7fecb72af9daeb013876ef6065e213eb834e8d6ac">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config-setup.yaml</strong><dd><code>Update OpenAPI spec with correct field name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi/config-setup.yaml

- Rename `gp_client_verion` to `gp_client_version` in OpenAPI spec


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/199/files#diff-cd9ba99e585509a2f3076d8b04e5829b87739a28d35347fd0966037e6762faac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>