### PR TITLE
Fix unused session in OAuth2 token refresh

### DIFF
--- a/scm/auth.py
+++ b/scm/auth.py
@@ -160,12 +160,9 @@ class OAuth2Client:
         """Refresh the OAuth2 access token with improved error handling and retry logic."""
         logger.debug("Refreshing token...")
 
-        # Create a new session for the refresh request to avoid any stale state
-        temp_session = Session()
-        retry_strategy = self._setup_retry_strategy()
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        temp_session.mount("http://", adapter)  # noqa
-        temp_session.mount("https://", adapter)
+        # Refresh using the existing OAuth2 session which already has
+        # the retry strategy configured. The previously created
+        # temporary session was never used and has been removed.
 
         try:
             new_token = self.session.fetch_token(
@@ -202,5 +199,3 @@ class OAuth2Client:
         except Exception as e:
             logger.error(f"Unexpected error during token refresh: {str(e)}")
             raise APIError(f"Failed to refresh token: {str(e)}") from e
-        finally:
-            temp_session.close()


### PR DESCRIPTION
### **User description**
## Summary
- clean up `OAuth2Client.refresh_token` by removing the unused temporary session

## Testing
- `python3 -m py_compile scm/auth.py`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove unused temporary session in OAuth2 token refresh

- Utilize existing OAuth2 session with retry strategy

- Improve error handling and logging in refresh_token

- Clean up code by removing unnecessary session creation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.py</strong><dd><code>Refactor OAuth2 token refresh for efficiency and reliability</code></dd></summary>
<hr>

scm/auth.py

<li>Removed unused temporary session creation and closure<br> <li> Updated to use existing OAuth2 session with retry strategy<br> <li> Enhanced error handling and logging for token refresh<br> <li> Cleaned up unnecessary code and improved comments


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/200/files#diff-8c19d81bc3cb8aec884f680b88b6fde4acf592ddbd082f7725e0be45159cead4">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>