### PR TITLE
Pydantic model definitions too strict? #207

### DIFF
--- a/docs/sdk/config/objects/tag.md
+++ b/docs/sdk/config/objects/tag.md
@@ -46,7 +46,7 @@ snippets, or devices as needed.
 
 | Attribute  | Type | Required | Description                                   |
 |------------|------|----------|-----------------------------------------------|
-| `name`     | str  | Yes      | Name of the tag object (max 63 chars)         |
+| `name`     | str  | Yes      | Name of the tag object (max 127 chars)        |
 | `id`       | UUID | Yes*     | Unique identifier (*response only)            |
 | `color`    | str  | No       | Color from a predefined list                  |
 | `comments` | str  | No       | Comments (max 1023 chars)                     |

--- a/docs/sdk/models/objects/tag_models.md
+++ b/docs/sdk/models/objects/tag_models.md
@@ -11,7 +11,7 @@ and outputs when interacting with the SCM API.
 
 | Attribute | Type | Required | Default | Description                                                                                |
 |-----------|------|----------|---------|--------------------------------------------------------------------------------------------|
-| name      | str  | Yes      | None    | Name of the tag. Max length: 63 chars. Must match pattern: ^[a-zA-Z0-9_ \.-\[\]\-\&\(\)]+$ |
+| name      | str  | Yes      | None    | Name of the tag. Max length: 127 chars. Must match pattern: ^[a-zA-Z0-9_ \.-\[\]\-\&\(\)]+$ |
 | color     | str  | No       | None    | Color associated with the tag. Must be one of the predefined colors                        |
 | comments  | str  | No       | None    | Comments about the tag. Max length: 1023 chars                                             |
 | folder    | str  | No*      | None    | Folder where tag is defined. Max length: 64 chars                                          |

--- a/scm/models/objects/address.py
+++ b/scm/models/objects/address.py
@@ -19,7 +19,7 @@ from pydantic import (
     model_validator,
 )
 
-TagString = constr(max_length=64)
+TagString = constr(max_length=127)
 
 
 class AddressBaseModel(BaseModel):

--- a/scm/models/objects/address_group.py
+++ b/scm/models/objects/address_group.py
@@ -17,7 +17,7 @@ from pydantic import (
     model_validator,
 )
 
-TagString = constr(max_length=64)
+TagString = constr(max_length=127)
 
 
 class DynamicFilter(BaseModel):

--- a/scm/models/objects/service_group.py
+++ b/scm/models/objects/service_group.py
@@ -19,7 +19,7 @@ from pydantic import (
     model_validator,
 )
 
-TagString = constr(max_length=64)
+TagString = constr(max_length=127)
 
 
 class ServiceGroupBaseModel(BaseModel):

--- a/scm/models/objects/tag.py
+++ b/scm/models/objects/tag.py
@@ -20,7 +20,7 @@ from pydantic import (
 
 from scm.utils.tag_colors import normalize_color_name
 
-TagString = constr(max_length=64)
+TagString = constr(max_length=127)
 
 
 class Colors(str, Enum):
@@ -104,7 +104,7 @@ class TagBaseModel(BaseModel):
     # Required fields
     name: str = Field(
         ...,
-        max_length=63,
+        max_length=127,
         description="The name of the Tag object",
         pattern=r"^[a-zA-Z0-9_ \.-\[\]\-\&\(\)]+$",
     )

--- a/tests/scm/models/objects/test_tag_models.py
+++ b/tests/scm/models/objects/test_tag_models.py
@@ -53,12 +53,12 @@ class TestTagCreateModel:
     def test_tag_create_model_name_too_long(self):
         """Test validation when name exceeds maximum length."""
         data = {
-            "name": "a" * 64,  # Max length is 63
+            "name": "a" * 128,  # Max length is 127
             "folder": "Texas",
         }
         with pytest.raises(ValidationError) as exc_info:
             TagCreateModel(**data)
-        assert "String should have at most 63 characters" in str(exc_info.value)
+        assert "String should have at most 127 characters" in str(exc_info.value)
 
     def test_tag_create_model_multiple_containers(self):
         """Test validation when multiple containers are provided."""


### PR DESCRIPTION
### **User description**
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in the `https://github.com/cdot65/pan-scm-sdk` repository (do NOT target the Palo Alto Networks repo!).
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Provide a detailed description of the changes your pull request introduces.

#### What does this pull request accomplish?

- Bug fix

#### Are there any breaking changes included?

- [ ] Yes
- [x] No


___

### **PR Type**
Enhancement


___

### **Description**
- Increased maximum tag name length to 127 characters

- Updated models for Address, AddressGroup, ServiceGroup, Tag

- Modified tag test to reflect new character limit


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>address.py</strong><dd><code>Update TagString max length in Address model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scm/models/objects/address.py

- Changed `TagString` max_length from 64 to 127


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/211/files#diff-4adeb3b3c014cd427c5b639afa4ff26b1f9d5ffff5da0787491478a367222063">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>address_group.py</strong><dd><code>Update TagString max length in AddressGroup model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scm/models/objects/address_group.py

- Changed `TagString` max_length from 64 to 127


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/211/files#diff-6fa34336c94db40deb4bf4a447a480edec5967f226fd7530f0321a5a86202722">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_group.py</strong><dd><code>Update TagString max length in ServiceGroup model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scm/models/objects/service_group.py

- Changed `TagString` max_length from 64 to 127


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/211/files#diff-bed0d80557ccc3e01b841857b8e9751fe735e0a42ab94ffc6f0469066f4ec266">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tag.py</strong><dd><code>Update TagString and name field max length in Tag model</code>&nbsp; &nbsp; </dd></summary>
<hr>

scm/models/objects/tag.py

<li>Changed <code>TagString</code> max_length from 64 to 127<br> <li> Updated <code>name</code> field max_length from 63 to 127


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/211/files#diff-d08af45eedf518b8fdc864b0d3f693e33edc78eb147b257ed08d3242822b1f0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_tag_models.py</strong><dd><code>Update tag model tests for new character limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/scm/models/objects/test_tag_models.py

<li>Updated test case for name length validation<br> <li> Changed test string length from 64 to 128<br> <li> Updated error message assertion


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/211/files#diff-89e932a57cdc2713897d71d7ea00b591c43253524a85cb2d7a0b8fe4dacb9629">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>