### PR TITLE
fix: allow non-unique values in security rule from_ and to_ fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.3.39"
+version = "0.3.40"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/models/security/security_rules.py
+++ b/scm/models/security/security_rules.py
@@ -195,11 +195,9 @@ class SecurityRuleBaseModel(BaseModel):
         return v
 
     @field_validator(
-        "from_",
         "source",
         "source_user",
         "source_hip",
-        "to_",
         "destination",
         "destination_hip",
         "application",


### PR DESCRIPTION
### **User description**
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [ ] Target your pull request to the **main development branch** in the `https://github.com/cdot65/pan-scm-sdk` repository (do NOT target the Palo Alto Networks repo!).
- [ ] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Provide a detailed description of the changes your pull request introduces.

#### What does this pull request accomplish?

- Feature addition
- Bug fix
- Performance improvement
- Refactoring
- Documentation update
- Other (please specify)

#### Are there any breaking changes included?

- [ ] Yes
- [ ] No


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Allow non-unique values in security rule 'from_' and 'to_' fields

- Update validation for zone-related fields in security rules

- Add comprehensive tests for non-unique zone values

- Bump version to 0.3.40


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security_rules.py</strong><dd><code>Remove uniqueness validation for zone fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scm/models/security/security_rules.py

<li>Removed 'from_' and 'to_' from field_validator<br> <li> Allows non-unique values in these fields


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/212/files#diff-b1b5de32d8f39814a6b0529383ca02e58fc0d47bf137b7595996e460cbeec85d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_security_rules_models.py</strong><dd><code>Add comprehensive tests for non-unique zone values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/scm/models/security/test_security_rules_models.py

<li>Added TestSecurityRuleNonUniqueValues class<br> <li> Implemented tests for non-unique values in 'from_' and 'to_' fields<br> <li> Verified uniqueness still required for other fields<br> <li> Tested real-world scenarios with duplicate zones


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/212/files#diff-d9555a1aec2ee1f2800ee3334737ea52b945698916cc746fc4f0e9375e4cc3c1">+258/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Version update</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Increment package version to 0.3.40</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 0.3.39 to 0.3.40


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-sdk/pull/212/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>