### PR TITLE
feat: increase static address group capacity to 4096 entries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,13 @@
 
 This checklist is derived from `project3.md` for tracking the implementation of the Devices SDK functionality.
 
+## Address Group Enhancement
+
+- [ ] Increase the maximum number of entries within an address group of type `static` to 4096
+      - [ ] Update the `max_length` constraint for the `static` field in `scm/models/objects/address_group.py`
+      - [ ] Review and update relevant test files if necessary to ensure all tests pass with 100% coverage
+      - [ ] Verify that the change doesn't break existing functionality
+
 ## Models (`scm/models/config/setup/devices.py`)
 
 - [ ] Define `InstalledLicenseModel`.

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,18 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.3.43
+
+**Released:** July 18, 2025
+
+### Improved
+
+- **Address Group Enhancement**:
+  - Increased the maximum number of entries in static address groups from 255 to 4096
+  - This change aligns with the increased capacity supported by Strata Cloud Manager
+  - Updated validation constraints in the `AddressGroupBaseModel` to support larger address groups
+  - No breaking changes - existing address groups with fewer than 255 entries will continue to work as before
+
 ## Version 0.3.42
 
 **Released:** June 22, 2025

--- a/docs/sdk/models/objects/address_group_models.md
+++ b/docs/sdk/models/objects/address_group_models.md
@@ -14,7 +14,7 @@ models handle validation of inputs and outputs when interacting with the SCM API
 | description | str           | No       | None    | Description of the address group. Max length: 1023 chars                                 |
 | tag         | List[str]     | No       | None    | List of tags. Each tag max length: 64 chars                                              |
 | dynamic     | DynamicFilter | No*      | None    | Dynamic filter for group membership                                                      |
-| static      | List[str]     | No*      | None    | List of static addresses. Min: 1, Max: 255                                               |
+| static      | List[str]     | No*      | None    | List of static addresses. Min: 1, Max: 4096                                              |
 | folder      | str           | No**     | None    | Folder where group is defined. Max length: 64 chars                                      |
 | snippet     | str           | No**     | None    | Snippet where group is defined. Max length: 64 chars                                     |
 | device      | str           | No**     | None    | Device where group is defined. Max length: 64 chars                                      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.3.42"
+version = "0.3.43"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/models/objects/address_group.py
+++ b/scm/models/objects/address_group.py
@@ -80,7 +80,7 @@ class AddressGroupBaseModel(BaseModel):
         None,
         description="Container type of Static Address Group",
         min_length=1,
-        max_length=2048,
+        max_length=4096,
         examples=["database-servers"],
     )
     folder: Optional[str] = Field(


### PR DESCRIPTION
## Summary
- Increased the maximum number of entries in static address groups from 2048 to 4096
- Updated documentation to reflect the new capacity limit
- Version bump to 0.3.43 for hotfix release

## Test plan
- [ ] Run existing tests to ensure no regression
- [ ] Manually test creating an address group with >2048 entries
- [ ] Verify documentation accurately reflects the change

🤖 Generated with [Claude Code](https://claude.ai/code)