### PR TITLE
docs: add contributor styling guides and templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,130 @@
 
 We welcome contributions to `pan-scm-sdk`! This document provides guidelines and instructions on how to contribute effectively.
 
+## Quick Start
+
+```bash
+git clone https://github.com/cdot65/pan-scm-sdk.git
+cd pan-scm-sdk
+make setup  # Install deps + pre-commit hooks
+```
+
+## Development Resources
+
+Before making changes, review the relevant styling guides:
+
+| Guide | Purpose |
+|-------|---------|
+| `SDK_STYLING_GUIDE.md` | Service class patterns and standards |
+| `PYDANTIC_MODELS_GUIDE.md` | Pydantic model patterns and conventions |
+| `SDK_SERVICE_TEMPLATE.py` | Copy-paste template for new services |
+
 ## How to Contribute
 
-- **Reporting Bugs**: If you find a bug, please open an issue with a clear description and steps to reproduce.
-- **Suggesting Enhancements**: For feature requests or suggestions, open an issue with a detailed explanation.
-- **Pull Requests**: Before submitting a pull request, ensure it does not duplicate existing work.
+- **Reporting Bugs**: Open an issue with clear description and steps to reproduce
+- **Suggesting Enhancements**: Open an issue with detailed explanation
+- **Pull Requests**: Ensure it does not duplicate existing work
 
 ## Pull Request Process
 
-1. Fork the repository and create your branch from `main`.
-2. Make your changes, ensuring they adhere to the project's coding conventions:
-   - Review `SDK_STYLING_GUIDE.md` for service file standards
-   - Follow `CLAUDE_MODELS.md` for model creation
-   - Use `SDK_SERVICE_TEMPLATE.py` as a starting point for new services
-   - Adhere to `WINDSURF_RULES.md` for overall project standards
-3. Write clear, concise commit messages and ensure your code passes all tests:
-   - Run `make quality` to check linting and formatting
-   - Run `make test` to execute all tests
-   - Ensure test coverage exceeds 80%
-4. Open a pull request with a comprehensive description of changes.
+1. Fork the repository and create your branch from `main`
+2. Make your changes following the styling guides listed above
+3. Run quality checks before committing:
+   ```bash
+   make quality  # isort + ruff + flake8 + mypy
+   make test     # Run all tests
+   ```
+4. Write clear, concise commit messages
+5. Open a pull request with a comprehensive description of changes
+
+## Code Patterns
+
+### Service Class Structure
+
+Every service class inherits from `BaseObject` and implements CRUD methods:
+
+```python
+class Resource(BaseObject):
+    ENDPOINT = "/config/category/v1/resources"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000
+
+    # Required: create, get, update, delete, list, fetch
+```
+
+### Model Hierarchy
+
+Every resource needs four Pydantic models:
+
+- `ResourceBaseModel` - Shared fields
+- `ResourceCreateModel` - For POST requests
+- `ResourceUpdateModel` - For PUT requests (includes `id`)
+- `ResourceResponseModel` - API response (includes `id` + response-only fields)
+
+### Container Validation
+
+Most resources require exactly one of `folder`, `snippet`, or `device`.
+
+### Payload Serialization
+
+Always use `model.model_dump(exclude_unset=True)` for API payloads.
+
+## Adding New Resources
+
+1. **Service**: Copy `SDK_SERVICE_TEMPLATE.py` → `scm/config/{category}/{resource}.py`
+2. **Models**: Create `scm/models/{category}/{resource}.py`
+3. **Client**: Register in `scm/client.py`
+4. **Tests**: Add `tests/scm/config/{category}/test_{resource}.py`
+5. **Docs**: Add `docs/sdk/config/{category}/{resource}.md`
+
+## Testing
+
+```bash
+make test                                          # All tests
+make test-cov                                      # With coverage
+poetry run pytest tests/path/test_file.py -v      # Single file
+```
+
+### Test Markers
+
+- `@pytest.mark.api` - Requires API access
+- `@pytest.mark.e2e` - End-to-end tests
+- `@pytest.mark.integration` - Integration tests
+
+## Documentation
+
+Documentation lives in `docs/sdk/`:
+
+- `config/{category}/{resource}.md` - Service usage
+- `models/{category}/{resource}_models.md` - Model reference
+
+Key patterns:
+- Use `ScmClient` unified client pattern in examples
+- Update examples use fetch → dot notation → update workflow
+- Include Filter Parameters table for `list()` method
+
+Serve docs locally:
+```bash
+make docs-serve  # http://localhost:8000/pan-scm-sdk/
+```
+
+## Project Structure
+
+```
+scm/
+├── client.py           # ScmClient entry point
+├── auth.py             # OAuth2 authentication
+├── config/             # Service classes
+│   ├── objects/        # address, tag, service, etc.
+│   ├── security/       # security_rule, profiles
+│   ├── network/        # nat_rules, ike_gateway
+│   ├── deployment/     # remote_networks, etc.
+│   ├── mobile_agent/   # auth_settings
+│   └── setup/          # folder, snippet, variable
+├── models/             # Pydantic models (parallel to config/)
+├── exceptions/         # Custom exceptions
+└── operations/         # Jobs, candidate push
+```
 
 ## Code of Conduct
 

--- a/PYDANTIC_MODELS_GUIDE.md
+++ b/PYDANTIC_MODELS_GUIDE.md
@@ -1,0 +1,532 @@
+# Pydantic Models Styling Guide
+
+This guide defines the standards and patterns for writing Pydantic models in the pan-scm-sdk project.
+
+## Table of Contents
+
+1. [File Structure](#file-structure)
+2. [Model Hierarchy](#model-hierarchy)
+3. [Model Configuration](#model-configuration)
+4. [Field Definitions](#field-definitions)
+5. [Validators](#validators)
+6. [Container Validation](#container-validation)
+7. [Enum Types](#enum-types)
+8. [Supporting Models](#supporting-models)
+9. [Import Organization](#import-organization)
+10. [Naming Conventions](#naming-conventions)
+
+## File Structure
+
+Each resource's models should be in a single file within the appropriate category:
+
+```
+scm/models/
+├── __init__.py
+├── objects/             # address.py, tag.py, service.py, etc.
+├── security/            # security_rule.py, anti_spyware_profile.py, etc.
+├── network/             # nat_rules.py, ike_gateway.py, etc.
+├── deployment/          # service_connections.py, remote_networks.py, etc.
+├── mobile_agent/        # auth_settings.py, agent_versions.py, etc.
+└── setup/               # folder.py, snippet.py, variable.py, etc.
+```
+
+## Model Hierarchy
+
+Every resource should define four models:
+
+1. **BaseModel** - Common fields shared across all operations
+2. **CreateModel** - Fields for creating new resources (inherits from Base)
+3. **UpdateModel** - Fields for updating resources (inherits from Base, adds `id`)
+4. **ResponseModel** - Fields returned from API (inherits from Base, adds `id` and response-only fields)
+
+```python
+class ResourceBaseModel(BaseModel):
+    """Base model with common fields."""
+    pass
+
+class ResourceCreateModel(ResourceBaseModel):
+    """Model for creating new resources."""
+    pass
+
+class ResourceUpdateModel(ResourceBaseModel):
+    """Model for updating existing resources."""
+    id: UUID = Field(...)
+
+class ResourceResponseModel(ResourceBaseModel):
+    """Model for API responses."""
+    id: UUID = Field(...)
+    # Additional response-only fields
+```
+
+## Model Configuration
+
+Always use `ConfigDict` with these settings:
+
+```python
+from pydantic import BaseModel, ConfigDict
+
+class ResourceBaseModel(BaseModel):
+    """Base model for Resource resources."""
+
+    model_config = ConfigDict(
+        extra="forbid",          # Reject unknown fields
+        populate_by_name=True,   # Allow field aliases
+    )
+```
+
+### Configuration Options
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| `extra` | `"forbid"` | Reject fields not defined in model |
+| `populate_by_name` | `True` | Allow using field name or alias |
+
+## Field Definitions
+
+### Required Fields
+
+Use `...` (Ellipsis) to mark required fields:
+
+```python
+name: str = Field(
+    ...,  # required
+    description="The name of the resource",
+    max_length=63,
+)
+```
+
+### Optional Fields
+
+Use `Optional[T]` with `default=None`:
+
+```python
+description: Optional[str] = Field(
+    default=None,
+    description="An optional description",
+)
+```
+
+### Field Parameters
+
+```python
+from pydantic import Field
+
+# String with constraints
+name: str = Field(
+    ...,
+    description="Resource name",
+    max_length=63,
+    pattern=r"^[a-zA-Z0-9\-_. ]+$",
+)
+
+# UUID field
+id: UUID = Field(
+    ...,
+    description="Unique identifier",
+    examples=["123e4567-e89b-12d3-a456-426655440000"],
+)
+
+# Boolean with default
+enabled: bool = Field(
+    default=True,
+    description="Whether the resource is enabled",
+)
+
+# List field
+tags: Optional[List[str]] = Field(
+    default=None,
+    description="List of tags",
+)
+```
+
+### Common Field Patterns
+
+#### Container Fields (folder/snippet/device)
+
+```python
+folder: Optional[str] = Field(
+    None,
+    pattern=r"^[a-zA-Z0-9\-_. ]+$",
+    max_length=64,
+    description="The folder in which the resource is defined",
+)
+snippet: Optional[str] = Field(
+    None,
+    pattern=r"^[a-zA-Z0-9\-_. ]+$",
+    max_length=64,
+    description="The snippet in which the resource is defined",
+)
+device: Optional[str] = Field(
+    None,
+    pattern=r"^[a-zA-Z0-9\-_. ]+$",
+    max_length=64,
+    description="The device in which the resource is defined",
+)
+```
+
+#### Name Field
+
+```python
+name: str = Field(
+    ...,
+    description="The name of the resource",
+    max_length=63,
+    pattern=r"^[a-zA-Z0-9\-_. ]+$",
+)
+```
+
+#### ID Field (for Update/Response models)
+
+```python
+id: UUID = Field(
+    ...,
+    description="The unique identifier of the resource",
+    examples=["123e4567-e89b-12d3-a456-426655440000"],
+)
+```
+
+## Validators
+
+### Field Validators
+
+Use `@field_validator` for single-field validation:
+
+```python
+from pydantic import field_validator
+
+@field_validator("name")
+@classmethod
+def validate_name(cls, v):
+    """Validate that the name is not empty."""
+    if not v or v.strip() == "":
+        raise ValueError("Name cannot be empty")
+    return v
+```
+
+### Enum Validation
+
+When a field must be one of specific values:
+
+```python
+@field_validator("type")
+@classmethod
+def validate_type_enum(cls, v):
+    """Validate that the type is one of the allowed values."""
+    allowed = ["ip-netmask", "ip-range", "fqdn", "ip-wildcard"]
+    if v not in allowed:
+        raise ValueError(f"type must be one of {allowed}, got {v}")
+    return v
+```
+
+### Model Validators
+
+Use `@model_validator` for cross-field validation:
+
+```python
+from pydantic import model_validator
+
+@model_validator(mode="after")
+def validate_ip_or_fqdn(self) -> "ResourceBaseModel":
+    """Ensure exactly one of ip_netmask or fqdn is provided."""
+    if self.ip_netmask and self.fqdn:
+        raise ValueError("Cannot specify both ip_netmask and fqdn")
+    if not self.ip_netmask and not self.fqdn:
+        raise ValueError("Must specify either ip_netmask or fqdn")
+    return self
+```
+
+## Container Validation
+
+For resources requiring exactly one container (folder/snippet/device):
+
+### Method 1: Class Method with model_validate Override
+
+```python
+class ResourceBaseModel(BaseModel):
+    folder: Optional[str] = Field(None, ...)
+    snippet: Optional[str] = Field(None, ...)
+    device: Optional[str] = Field(None, ...)
+
+    @classmethod
+    def validate_container_type(cls, values):
+        """Validate that exactly one container is provided."""
+        container_fields = [
+            values.get("folder"),
+            values.get("snippet"),
+            values.get("device")
+        ]
+        set_count = sum(1 for v in container_fields if v is not None)
+        if set_count != 1:
+            raise ValueError(
+                "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+            )
+        return values
+
+
+class ResourceCreateModel(ResourceBaseModel):
+    @classmethod
+    def model_validate(cls, value):
+        """Validate model and ensure container type is valid."""
+        model = super().model_validate(value)
+        cls.validate_container_type(model.__dict__)
+        return model
+```
+
+### Method 2: Model Validator
+
+```python
+@model_validator(mode="after")
+def validate_container(self) -> "ResourceBaseModel":
+    """Ensure exactly one container is specified."""
+    containers = [self.folder, self.snippet, self.device]
+    specified = sum(1 for c in containers if c is not None)
+
+    if specified != 1:
+        raise ValueError(
+            "Exactly one of folder, snippet, or device must be specified"
+        )
+    return self
+```
+
+## Enum Types
+
+### Using Literal for Simple Enums
+
+```python
+from typing import Literal
+
+action: Literal["allow", "deny", "drop"] = Field(
+    ...,
+    description="The action to take",
+)
+```
+
+### Using Enum Class
+
+For reusable enums:
+
+```python
+from enum import Enum
+
+class ActionType(str, Enum):
+    """Valid action types."""
+    ALLOW = "allow"
+    DENY = "deny"
+    DROP = "drop"
+
+action: ActionType = Field(
+    ...,
+    description="The action to take",
+)
+```
+
+### Documenting Enum Values
+
+Always document valid values in field description or validator:
+
+```python
+type: str = Field(
+    ...,
+    description="Variable type: percent, count, ip-netmask, zone, ip-range, "
+                "ip-wildcard, device-priority, device-id, egress-max, as-number, "
+                "fqdn, port, link-tag, group-id, rate, router-id, qos-profile, timer",
+)
+```
+
+## Supporting Models
+
+For nested structures, define supporting models:
+
+```python
+class FolderReference(BaseModel):
+    """Reference to a folder."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    id: UUID = Field(..., description="The UUID of the folder")
+    name: str = Field(..., description="The name of the folder")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value):
+        """Validate that the name is not empty."""
+        if not value or value.strip() == "":
+            raise ValueError("Folder name cannot be empty")
+        return value
+
+
+class ResourceResponseModel(ResourceBaseModel):
+    folders: Optional[List[FolderReference]] = Field(
+        default=None,
+        description="Folders the resource is applied to",
+    )
+```
+
+## Import Organization
+
+```python
+"""Models for Resource in Palo Alto Networks' Strata Cloud Manager.
+
+This module defines the Pydantic models used for creating, updating, and
+representing Resource objects in the Strata Cloud Manager.
+"""
+
+from enum import Enum
+from typing import List, Literal, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+```
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Base model | `{Resource}BaseModel` | `AddressBaseModel` |
+| Create model | `{Resource}CreateModel` | `AddressCreateModel` |
+| Update model | `{Resource}UpdateModel` | `AddressUpdateModel` |
+| Response model | `{Resource}ResponseModel` | `AddressResponseModel` |
+| Enum class | `{Name}Type` or `{Name}Enum` | `ActionType`, `ProtocolEnum` |
+| Supporting model | Descriptive name | `FolderReference`, `ThreatEntry` |
+| File name | snake_case, singular | `address.py`, `security_rule.py` |
+
+## Complete Example
+
+```python
+"""Models for Variable in Palo Alto Networks' Strata Cloud Manager.
+
+This module defines the Pydantic models used for creating, updating, and
+representing Variable resources in the Strata Cloud Manager.
+"""
+
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class VariableBaseModel(BaseModel):
+    """Base model for Variable resources."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: str = Field(
+        ...,
+        description="The name of the variable",
+        max_length=63,
+    )
+    type: str = Field(
+        ...,
+        description="The variable type",
+    )
+    value: str = Field(
+        ...,
+        description="The value of the variable",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="An optional description of the variable",
+    )
+    folder: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9\-_. ]+$",
+        max_length=64,
+        description="The folder in which the variable is defined",
+    )
+    snippet: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9\-_. ]+$",
+        max_length=64,
+        description="The snippet in which the variable is defined",
+    )
+    device: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9\-_. ]+$",
+        max_length=64,
+        description="The device in which the variable is defined",
+    )
+
+    @field_validator("type")
+    @classmethod
+    def validate_type_enum(cls, v):
+        """Validate that the type is one of the allowed values."""
+        allowed = [
+            "percent", "count", "ip-netmask", "zone", "ip-range",
+            "ip-wildcard", "device-priority", "device-id", "egress-max",
+            "as-number", "fqdn", "port", "link-tag", "group-id",
+            "rate", "router-id", "qos-profile", "timer",
+        ]
+        if v not in allowed:
+            raise ValueError(f"type must be one of {allowed}, got {v}")
+        return v
+
+    @classmethod
+    def validate_container_type(cls, values):
+        """Validate that exactly one container is provided."""
+        container_fields = [
+            values.get("folder"),
+            values.get("snippet"),
+            values.get("device")
+        ]
+        set_count = sum(1 for v in container_fields if v is not None)
+        if set_count != 1:
+            raise ValueError(
+                "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+            )
+        return values
+
+
+class VariableCreateModel(VariableBaseModel):
+    """Model for creating new Variable resources."""
+
+    @classmethod
+    def model_validate(cls, value):
+        """Validate model and ensure container type is valid."""
+        model = super().model_validate(value)
+        cls.validate_container_type(model.__dict__)
+        return model
+
+
+class VariableUpdateModel(VariableBaseModel):
+    """Model for updating existing Variable resources."""
+
+    id: UUID = Field(
+        ...,
+        description="The unique identifier of the variable",
+    )
+
+    @classmethod
+    def model_validate(cls, value):
+        """Validate model and ensure container type is valid."""
+        model = super().model_validate(value)
+        cls.validate_container_type(model.__dict__)
+        return model
+
+
+class VariableResponseModel(VariableBaseModel):
+    """Model for Variable responses from the API."""
+
+    id: UUID = Field(
+        ...,
+        description="The unique identifier of the variable",
+        examples=["123e4567-e89b-12d3-a456-426655440000"],
+    )
+    overridden: Optional[bool] = Field(
+        default=None,
+        description="Is the variable overridden?",
+    )
+    labels: Optional[List[str]] = Field(
+        default=None,
+        description="Labels assigned to the variable",
+    )
+    parent: Optional[str] = Field(
+        default=None,
+        description="The parent folder or container",
+    )
+```

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ Python SDK for Palo Alto Networks Strata Cloud Manager.
 For developers working on this SDK:
 
 - **Service File Standards**: See `SDK_STYLING_GUIDE.md` for comprehensive service file guidelines
-- **Model Standards**: See `CLAUDE_MODELS.md` for Pydantic model patterns and conventions
+- **Model Standards**: See `PYDANTIC_MODELS_GUIDE.md` for Pydantic model patterns and conventions
 - **Templates**: Use `SDK_SERVICE_TEMPLATE.py` as a starting point for new services
-- **Claude Code Integration**: Reference `CLAUDE.md` for AI-assisted development guidelines
 
 ## Installation
 
@@ -195,9 +194,8 @@ The unified client provides access to the following services through attribute-b
 Before starting development, please review:
 
 - `SDK_STYLING_GUIDE.md` - Comprehensive guide for writing consistent SDK code
-- `CLAUDE_MODELS.md` - Guidelines for creating Pydantic models
+- `PYDANTIC_MODELS_GUIDE.md` - Guidelines for creating Pydantic models
 - `SDK_SERVICE_TEMPLATE.py` - Template for new service files
-- `WINDSURF_RULES.md` - Overall project standards
 
 ### Setup
 

--- a/SDK_SERVICE_TEMPLATE.py
+++ b/SDK_SERVICE_TEMPLATE.py
@@ -1,0 +1,395 @@
+"""Service classes for interacting with Resources in Palo Alto Networks' Strata Cloud Manager.
+
+This module provides the Resource class for performing CRUD operations on Resource
+objects in the Strata Cloud Manager.
+
+Usage:
+    1. Copy this file to scm/config/{category}/resource.py
+    2. Replace all occurrences of "Resource" with your resource name (e.g., "Address")
+    3. Replace all occurrences of "resource" with lowercase name (e.g., "address")
+    4. Update ENDPOINT to match the API path
+    5. Update model imports to match your models
+    6. Implement any resource-specific filtering in _apply_filters()
+    7. Create corresponding models in scm/models/{category}/resource.py
+"""
+
+# Standard library imports
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import APIError, InvalidObjectError, ObjectNotPresentError
+
+# TODO: Update these imports to match your models
+from scm.models.category.resource import (
+    ResourceCreateModel,
+    ResourceResponseModel,
+    ResourceUpdateModel,
+)
+
+
+class Resource(BaseObject):
+    """Manages Resource objects in Palo Alto Networks' Strata Cloud Manager.
+
+    This class provides methods for creating, retrieving, updating, and deleting
+    Resource objects.
+
+    Attributes:
+        ENDPOINT: The API endpoint for Resource resources.
+        DEFAULT_MAX_LIMIT: The default maximum number of items per request.
+        ABSOLUTE_MAX_LIMIT: The maximum allowed items per request.
+
+    """
+
+    # TODO: Update endpoint to match your resource
+    ENDPOINT = "/config/category/v1/resources"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000  # Maximum allowed by the API
+
+    def __init__(
+        self,
+        api_client,
+        max_limit: int = DEFAULT_MAX_LIMIT,
+    ):
+        """Initialize the Resource service class.
+
+        Args:
+            api_client: The API client instance for making HTTP requests.
+            max_limit: Maximum number of items to return in a single request.
+                      Defaults to DEFAULT_MAX_LIMIT.
+
+        """
+        super().__init__(api_client)
+        self.max_limit = min(max_limit, self.ABSOLUTE_MAX_LIMIT)
+
+    @property
+    def max_limit(self) -> int:
+        """Get the maximum number of items to return in a single request.
+
+        Returns:
+            int: The current max_limit value.
+
+        """
+        return self._max_limit
+
+    @max_limit.setter
+    def max_limit(self, value: int) -> None:
+        """Set a new maximum limit for API requests."""
+        self._max_limit = self._validate_max_limit(value)
+
+    def _validate_max_limit(self, limit: Optional[int]) -> int:
+        """Validate the max_limit parameter.
+
+        Args:
+            limit: The limit to validate.
+
+        Returns:
+            int: The validated limit.
+
+        Raises:
+            InvalidObjectError: If the limit is invalid.
+
+        """
+        if limit is None:
+            return self.DEFAULT_MAX_LIMIT
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            raise InvalidObjectError(
+                message="max_limit must be an integer",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit type"},
+            )
+
+        if limit_int < 1:
+            raise InvalidObjectError(
+                message="max_limit must be greater than 0",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit value"},
+            )
+
+        if limit_int > self.ABSOLUTE_MAX_LIMIT:
+            return self.ABSOLUTE_MAX_LIMIT
+
+        return limit_int
+
+    def create(
+        self,
+        data: Dict[str, Any],
+    ) -> ResourceResponseModel:
+        """Create a new resource in the Strata Cloud Manager.
+
+        Args:
+            data: Dictionary containing resource data.
+
+        Returns:
+            ResourceResponseModel: The created resource.
+
+        Raises:
+            InvalidObjectError: If the resource data is invalid.
+            APIError: If the API request fails.
+
+        """
+        create_model = ResourceCreateModel(**data)
+        payload = create_model.model_dump(exclude_unset=True)
+        response = self.api_client.post(self.ENDPOINT, json=payload)
+        return ResourceResponseModel.model_validate(response)
+
+    def get(
+        self,
+        object_id: Union[str, UUID],
+    ) -> ResourceResponseModel:
+        """Get a resource by its ID.
+
+        Args:
+            object_id: The ID of the resource to retrieve.
+
+        Returns:
+            ResourceResponseModel: The requested resource.
+
+        Raises:
+            ObjectNotPresentError: If the resource doesn't exist.
+            APIError: If the API request fails.
+
+        """
+        object_id_str = str(object_id)
+        try:
+            response = self.api_client.get(f"{self.ENDPOINT}/{object_id_str}")
+            return ResourceResponseModel.model_validate(response)
+        except APIError as e:
+            if e.http_status_code == 404:
+                raise ObjectNotPresentError(f"Resource with ID {object_id} not found")
+            raise
+
+    def update(
+        self,
+        resource: ResourceUpdateModel,
+    ) -> ResourceResponseModel:
+        """Update an existing resource.
+
+        Args:
+            resource: The ResourceUpdateModel containing the updated data.
+
+        Returns:
+            ResourceResponseModel: The updated resource.
+
+        Raises:
+            InvalidObjectError: If the update data is invalid.
+            ObjectNotPresentError: If the resource doesn't exist.
+            APIError: If the API request fails.
+
+        """
+        payload = resource.model_dump(exclude_unset=True)
+        object_id = str(resource.id)
+        payload.pop("id", None)
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        response = self.api_client.put(endpoint, json=payload)
+        return ResourceResponseModel.model_validate(response)
+
+    def delete(
+        self,
+        object_id: Union[str, UUID],
+    ) -> None:
+        """Delete a resource.
+
+        Args:
+            object_id: The ID of the resource to delete.
+
+        Raises:
+            ObjectNotPresentError: If the resource doesn't exist.
+            APIError: If the API request fails.
+
+        """
+        try:
+            object_id_str = str(object_id)
+            self.api_client.delete(f"{self.ENDPOINT}/{object_id_str}")
+        except APIError as e:
+            if e.http_status_code == 404:
+                raise ObjectNotPresentError(f"Resource with ID {object_id} not found")
+            raise
+
+    def list(
+        self,
+        **filters: Any,
+    ) -> List[ResourceResponseModel]:
+        """List resources with optional filters.
+
+        Args:
+            **filters: Additional filters for the API.
+                Common filters include:
+                - folder (str): Filter by folder name (server-side)
+                - labels (List[str]): Filter by labels (client-side)
+                - type (str): Filter by type (client-side)
+
+        Returns:
+            List[ResourceResponseModel]: A list of resources matching the filters.
+
+        Raises:
+            APIError: If the API request fails.
+
+        """
+        params: Dict[str, Any] = {}
+        limit = self.max_limit
+        offset = 0
+        all_objects: List[ResourceResponseModel] = []
+
+        # TODO: Add server-side filter handling here
+        # Example:
+        # if "folder" in filters:
+        #     params["folder"] = filters["folder"]
+
+        while True:
+            params.update({"limit": limit, "offset": offset})
+            params.update({k: v for k, v in filters.items() if v is not None})
+            response = self.api_client.get(self.ENDPOINT, params=params)
+            data_items = response["data"] if "data" in response else response
+            object_instances = [
+                ResourceResponseModel.model_validate(item) for item in data_items
+            ]
+            all_objects.extend(object_instances)
+
+            if len(data_items) < limit:
+                break
+            offset += limit
+
+        # Apply client-side filters
+        # TODO: Customize filters based on your resource
+        filtered_results = self._apply_filters(
+            all_objects,
+            {k: v for k, v in filters.items() if k not in ["folder"]},
+        )
+
+        return filtered_results
+
+    def fetch(
+        self,
+        name: str,
+        folder: str,
+    ) -> Optional[ResourceResponseModel]:
+        """Get a resource by its name and folder.
+
+        Args:
+            name: The name of the resource to retrieve.
+            folder: The folder in which the resource is defined.
+
+        Returns:
+            Optional[ResourceResponseModel]: The requested resource, or None if not found.
+
+        Raises:
+            InvalidObjectError: If name or folder is empty.
+
+        """
+        if not name:
+            raise InvalidObjectError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        if not folder:
+            raise InvalidObjectError(
+                message="Field 'folder' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "folder",
+                    "error": '"folder" is not allowed to be empty',
+                },
+            )
+
+        results = self.list(folder=folder)
+
+        if not results:
+            return None
+
+        exact_matches = [r for r in results if r.name == name]
+        return exact_matches[0] if exact_matches else None
+
+    @staticmethod
+    def _apply_filters(
+        data: List["ResourceResponseModel"],
+        filters: Dict[str, Any],
+    ) -> List["ResourceResponseModel"]:
+        """Apply client-side filters to a list of resources.
+
+        Args:
+            data: The list of resources to filter.
+            filters: Dictionary of filter criteria.
+
+        Returns:
+            List[ResourceResponseModel]: Filtered list of resources.
+
+        """
+        filtered = data
+
+        if not filters:
+            return filtered
+
+        # TODO: Implement resource-specific filters
+        # Example filters:
+
+        # Filter by labels (intersection: any label matches)
+        if "labels" in filters:
+            required_labels = set(filters["labels"])
+            filtered = [
+                f
+                for f in filtered
+                if getattr(f, "labels", None)
+                and required_labels.intersection(set(f.labels))
+            ]
+
+        # Filter by type (exact match)
+        if "type" in filters:
+            type_val = filters["type"]
+            filtered = [f for f in filtered if getattr(f, "type", None) == type_val]
+
+        # Filter by parent (exact match)
+        if "parent" in filters:
+            parent_val = filters["parent"]
+            filtered = [f for f in filtered if getattr(f, "parent", None) == parent_val]
+
+        return filtered
+
+    def _get_paginated_results(
+        self,
+        endpoint: str,
+        params: Dict[str, Any],
+        limit: int,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Get paginated results from an API endpoint.
+
+        Args:
+            endpoint: The API endpoint URL.
+            params: Query parameters for the request.
+            limit: Maximum number of items to return.
+            offset: Starting position for pagination.
+
+        Returns:
+            List[Dict[str, Any]]: List of result items.
+
+        Raises:
+            APIError: If the API request fails.
+
+        """
+        request_params = params.copy()
+        request_params["limit"] = limit
+        request_params["offset"] = offset
+
+        response = self.api_client.get(endpoint, params=request_params)
+
+        if isinstance(response, dict) and "data" in response:
+            return response["data"]
+
+        if isinstance(response, list):
+            return response
+
+        return []

--- a/SDK_STYLING_GUIDE.md
+++ b/SDK_STYLING_GUIDE.md
@@ -1,0 +1,557 @@
+# SDK Service Class Styling Guide
+
+This guide defines the standards and patterns for writing SDK service classes in the pan-scm-sdk project.
+
+## Table of Contents
+
+1. [File Structure](#file-structure)
+2. [Class Structure](#class-structure)
+3. [Constants](#constants)
+4. [Constructor](#constructor)
+5. [CRUD Methods](#crud-methods)
+6. [Pagination](#pagination)
+7. [Filtering](#filtering)
+8. [Error Handling](#error-handling)
+9. [Docstrings](#docstrings)
+10. [Import Organization](#import-organization)
+
+## File Structure
+
+Each service class should be in its own file within the appropriate category directory:
+
+```
+scm/config/
+├── __init__.py          # Contains BaseObject
+├── objects/             # Address, Tag, Service, etc.
+├── security/            # SecurityRule, AntiSpywareProfile, etc.
+├── network/             # NatRule, IkeGateway, etc.
+├── deployment/          # ServiceConnection, RemoteNetwork, etc.
+├── mobile_agent/        # AuthSetting, AgentVersion, etc.
+└── setup/               # Folder, Snippet, Variable, etc.
+```
+
+## Class Structure
+
+### Required Components
+
+Every service class must include:
+
+1. Module docstring
+2. Imports (organized by type)
+3. Class definition inheriting from `BaseObject`
+4. Class docstring with Attributes section
+5. Class constants (`ENDPOINT`, `DEFAULT_MAX_LIMIT`, `ABSOLUTE_MAX_LIMIT`)
+6. Constructor (`__init__`)
+7. `max_limit` property and setter
+8. CRUD methods (`create`, `get`, `update`, `delete`, `list`, `fetch`)
+
+### Example Structure
+
+```python
+"""Service classes for interacting with Resources in Palo Alto Networks' Strata Cloud Manager.
+
+This module provides the Resource class for performing CRUD operations on Resource
+objects in the Strata Cloud Manager.
+"""
+
+# Standard library imports
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import APIError, InvalidObjectError, ObjectNotPresentError
+from scm.models.category.resource import (
+    ResourceCreateModel,
+    ResourceResponseModel,
+    ResourceUpdateModel,
+)
+
+
+class Resource(BaseObject):
+    """Manages Resource objects in Palo Alto Networks' Strata Cloud Manager.
+
+    This class provides methods for creating, retrieving, updating, and deleting
+    Resource objects.
+
+    Attributes:
+        ENDPOINT: The API endpoint for Resource resources.
+        DEFAULT_MAX_LIMIT: The default maximum number of items per request.
+        ABSOLUTE_MAX_LIMIT: The maximum allowed items per request.
+
+    """
+
+    ENDPOINT = "/config/category/v1/resources"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000
+```
+
+## Constants
+
+### ENDPOINT
+
+- Use the full API path starting with `/config/`
+- Follow the pattern: `/config/{category}/v1/{resource_plural}`
+
+```python
+ENDPOINT = "/config/objects/v1/addresses"
+ENDPOINT = "/config/security/v1/security-rules"
+ENDPOINT = "/config/setup/v1/variables"
+```
+
+### Pagination Limits
+
+```python
+DEFAULT_MAX_LIMIT = 2500    # Default items per API request
+ABSOLUTE_MAX_LIMIT = 5000   # Maximum allowed by the API
+```
+
+## Constructor
+
+```python
+def __init__(
+    self,
+    api_client,
+    max_limit: int = DEFAULT_MAX_LIMIT,
+):
+    """Initialize the Resource service class.
+
+    Args:
+        api_client: The API client instance for making HTTP requests.
+        max_limit: Maximum number of items to return in a single request.
+                  Defaults to DEFAULT_MAX_LIMIT.
+
+    """
+    super().__init__(api_client)
+    self.max_limit = min(max_limit, self.ABSOLUTE_MAX_LIMIT)
+```
+
+### max_limit Property
+
+Always implement as a property with validation:
+
+```python
+@property
+def max_limit(self) -> int:
+    """Get the maximum number of items to return in a single request."""
+    return self._max_limit
+
+@max_limit.setter
+def max_limit(self, value: int) -> None:
+    """Set a new maximum limit for API requests."""
+    self._max_limit = self._validate_max_limit(value)
+
+def _validate_max_limit(self, limit: Optional[int]) -> int:
+    """Validate the max_limit parameter."""
+    if limit is None:
+        return self.DEFAULT_MAX_LIMIT
+
+    try:
+        limit_int = int(limit)
+    except (TypeError, ValueError):
+        raise InvalidObjectError(
+            message="max_limit must be an integer",
+            error_code="E003",
+            http_status_code=400,
+            details={"error": "Invalid max_limit type"},
+        )
+
+    if limit_int < 1:
+        raise InvalidObjectError(
+            message="max_limit must be greater than 0",
+            error_code="E003",
+            http_status_code=400,
+            details={"error": "Invalid max_limit value"},
+        )
+
+    if limit_int > self.ABSOLUTE_MAX_LIMIT:
+        return self.ABSOLUTE_MAX_LIMIT
+
+    return limit_int
+```
+
+## CRUD Methods
+
+### create()
+
+```python
+def create(
+    self,
+    data: Dict[str, Any],
+) -> ResourceResponseModel:
+    """Create a new resource in the Strata Cloud Manager.
+
+    Args:
+        data: Dictionary containing resource data.
+
+    Returns:
+        ResourceResponseModel: The created resource.
+
+    Raises:
+        InvalidObjectError: If the resource data is invalid.
+        APIError: If the API request fails.
+
+    """
+    create_model = ResourceCreateModel(**data)
+    payload = create_model.model_dump(exclude_unset=True)
+    response = self.api_client.post(self.ENDPOINT, json=payload)
+    return ResourceResponseModel.model_validate(response)
+```
+
+### get()
+
+```python
+def get(
+    self,
+    object_id: Union[str, UUID],
+) -> ResourceResponseModel:
+    """Get a resource by its ID.
+
+    Args:
+        object_id: The ID of the resource to retrieve.
+
+    Returns:
+        ResourceResponseModel: The requested resource.
+
+    Raises:
+        ObjectNotPresentError: If the resource doesn't exist.
+        APIError: If the API request fails.
+
+    """
+    object_id_str = str(object_id)
+    try:
+        response = self.api_client.get(f"{self.ENDPOINT}/{object_id_str}")
+        return ResourceResponseModel.model_validate(response)
+    except APIError as e:
+        if e.http_status_code == 404:
+            raise ObjectNotPresentError(f"Resource with ID {object_id} not found")
+        raise
+```
+
+### update()
+
+```python
+def update(
+    self,
+    resource: ResourceUpdateModel,
+) -> ResourceResponseModel:
+    """Update an existing resource.
+
+    Args:
+        resource: The ResourceUpdateModel containing the updated data.
+
+    Returns:
+        ResourceResponseModel: The updated resource.
+
+    Raises:
+        InvalidObjectError: If the update data is invalid.
+        ObjectNotPresentError: If the resource doesn't exist.
+        APIError: If the API request fails.
+
+    """
+    payload = resource.model_dump(exclude_unset=True)
+    object_id = str(resource.id)
+    payload.pop("id", None)
+    endpoint = f"{self.ENDPOINT}/{object_id}"
+    response = self.api_client.put(endpoint, json=payload)
+    return ResourceResponseModel.model_validate(response)
+```
+
+### delete()
+
+```python
+def delete(
+    self,
+    object_id: Union[str, UUID],
+) -> None:
+    """Delete a resource.
+
+    Args:
+        object_id: The ID of the resource to delete.
+
+    Raises:
+        ObjectNotPresentError: If the resource doesn't exist.
+        APIError: If the API request fails.
+
+    """
+    try:
+        object_id_str = str(object_id)
+        self.api_client.delete(f"{self.ENDPOINT}/{object_id_str}")
+    except APIError as e:
+        if e.http_status_code == 404:
+            raise ObjectNotPresentError(f"Resource with ID {object_id} not found")
+        raise
+```
+
+### list()
+
+```python
+def list(
+    self,
+    **filters: Any,
+) -> List[ResourceResponseModel]:
+    """List resources with optional filters.
+
+    Args:
+        **filters: Additional filters for the API.
+
+    Returns:
+        List[ResourceResponseModel]: A list of resources matching the filters.
+
+    Raises:
+        APIError: If the API request fails.
+
+    """
+    params: Dict[str, Any] = {}
+    limit = self.max_limit
+    offset = 0
+    all_objects: List[ResourceResponseModel] = []
+
+    while True:
+        params.update({"limit": limit, "offset": offset})
+        params.update({k: v for k, v in filters.items() if v is not None})
+        response = self.api_client.get(self.ENDPOINT, params=params)
+        data_items = response["data"] if "data" in response else response
+        object_instances = [ResourceResponseModel.model_validate(item) for item in data_items]
+        all_objects.extend(object_instances)
+
+        if len(data_items) < limit:
+            break
+        offset += limit
+
+    return all_objects
+```
+
+### fetch()
+
+For resources with container scoping (folder/snippet/device):
+
+```python
+def fetch(
+    self,
+    name: str,
+    folder: str,
+) -> Optional[ResourceResponseModel]:
+    """Get a resource by its name and folder.
+
+    Args:
+        name: The name of the resource to retrieve.
+        folder: The folder in which the resource is defined.
+
+    Returns:
+        Optional[ResourceResponseModel]: The requested resource, or None if not found.
+
+    """
+    if not name:
+        raise InvalidObjectError(
+            message="Field 'name' cannot be empty",
+            error_code="E003",
+            http_status_code=400,
+            details={"field": "name", "error": '"name" is not allowed to be empty'},
+        )
+
+    if not folder:
+        raise InvalidObjectError(
+            message="Field 'folder' cannot be empty",
+            error_code="E003",
+            http_status_code=400,
+            details={"field": "folder", "error": '"folder" is not allowed to be empty'},
+        )
+
+    results = self.list(folder=folder)
+
+    if not results:
+        return None
+
+    exact_matches = [r for r in results if r.name == name]
+    return exact_matches[0] if exact_matches else None
+```
+
+For resources without container scoping:
+
+```python
+def fetch(
+    self,
+    name: str,
+) -> Optional[ResourceResponseModel]:
+    """Get a resource by its name.
+
+    Args:
+        name: The name of the resource to retrieve.
+
+    Returns:
+        Optional[ResourceResponseModel]: The requested resource, or None if not found.
+
+    """
+    results = self.list()
+
+    if not results:
+        return None
+
+    exact_matches = [r for r in results if r.name == name]
+    return exact_matches[0] if exact_matches else None
+```
+
+## Pagination
+
+Always implement auto-pagination in `list()`:
+
+```python
+while True:
+    params.update({"limit": limit, "offset": offset})
+    response = self.api_client.get(self.ENDPOINT, params=params)
+    data_items = response["data"] if "data" in response else response
+    all_objects.extend([...])
+
+    if len(data_items) < limit:
+        break
+    offset += limit
+```
+
+## Filtering
+
+### Server-Side Filters
+
+Pass directly to API params:
+
+```python
+if "folder" in filters:
+    params["folder"] = filters["folder"]
+if "labels" in filters:
+    params["labels"] = ",".join(filters["labels"])
+```
+
+### Client-Side Filters
+
+Implement `_apply_filters()` static method:
+
+```python
+@staticmethod
+def _apply_filters(
+    data: List["ResourceResponseModel"],
+    filters: Dict[str, Any],
+) -> List["ResourceResponseModel"]:
+    """Apply client-side filters to a list of resources."""
+    filtered = data
+
+    if not filters:
+        return filtered
+
+    # Filter by labels (intersection: any label matches)
+    if "labels" in filters:
+        required_labels = set(filters["labels"])
+        filtered = [
+            f for f in filtered
+            if getattr(f, "labels", None) and required_labels.intersection(set(f.labels))
+        ]
+
+    # Filter by exact match
+    if "type" in filters:
+        type_val = filters["type"]
+        filtered = [f for f in filtered if getattr(f, "type", None) == type_val]
+
+    return filtered
+```
+
+## Error Handling
+
+### Standard Exception Pattern
+
+```python
+from scm.exceptions import APIError, InvalidObjectError, ObjectNotPresentError
+
+# For validation errors
+raise InvalidObjectError(
+    message="Descriptive error message",
+    error_code="E003",
+    http_status_code=400,
+    details={"field": "field_name", "error": "Specific error"},
+)
+
+# For not found errors
+raise ObjectNotPresentError(f"Resource with ID {object_id} not found")
+
+# For API errors, catch and re-raise or convert
+except APIError as e:
+    if e.http_status_code == 404:
+        raise ObjectNotPresentError(...)
+    raise
+```
+
+## Docstrings
+
+Use Google-style docstrings:
+
+```python
+def method_name(
+    self,
+    param1: str,
+    param2: Optional[int] = None,
+) -> ReturnType:
+    """Short description of what the method does.
+
+    Longer description if needed, explaining behavior, side effects,
+    or important details.
+
+    Args:
+        param1: Description of param1.
+        param2: Description of param2. Defaults to None.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ExceptionType: When this exception is raised.
+
+    """
+```
+
+## Import Organization
+
+Organize imports in this order with blank lines between groups:
+
+```python
+"""Module docstring."""
+
+# Standard library imports
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import APIError, InvalidObjectError, ObjectNotPresentError
+from scm.models.category.resource import (
+    ResourceCreateModel,
+    ResourceResponseModel,
+    ResourceUpdateModel,
+)
+```
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Class name | PascalCase, singular | `Address`, `SecurityRule` |
+| File name | snake_case, singular | `address.py`, `security_rule.py` |
+| Method name | snake_case | `create`, `get`, `list`, `fetch` |
+| Constant | UPPER_SNAKE_CASE | `ENDPOINT`, `DEFAULT_MAX_LIMIT` |
+| Parameter | snake_case | `object_id`, `max_limit` |
+
+## Type Hints
+
+Always use type hints:
+
+```python
+def method(
+    self,
+    data: Dict[str, Any],
+    object_id: Union[str, UUID],
+    name: Optional[str] = None,
+) -> List[ResourceResponseModel]:
+```
+
+Common types:
+- `Dict[str, Any]` for arbitrary dictionaries
+- `Union[str, UUID]` for IDs that can be string or UUID
+- `Optional[T]` for optional parameters
+- `List[T]` for lists


### PR DESCRIPTION
## Summary

- Add `SDK_STYLING_GUIDE.md` - comprehensive guide for SDK service class patterns
- Add `PYDANTIC_MODELS_GUIDE.md` - Pydantic model conventions and standards
- Add `SDK_SERVICE_TEMPLATE.py` - copy-paste template for new services
- Update `CONTRIBUTING.md` with development workflow and code patterns
- Update `README.md` to reference new guide files

These guides provide the foundation for contributors (human or AI-assisted) to understand and follow project conventions when adding new resources or modifying existing code.