### PR TITLE
fix: improve model resilience and fix 3 bugs (v0.5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,14 @@ deployment-services_new.yaml
 
 # Auto Claude data directory
 .auto-claude/
+
+# Agent harness
+.agent_harness/
+
+# Claude Code
+.claude/skills
+.claude/settings.json
+sdk-contribution-spec.md
+
+# Roadmap planning docs (agent harness generated)
+docs/plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-02-17
+
+### Fixed
+- **EthernetInterface.list()**: Added missing `slot: Optional[int]` field to `EthernetInterfaceBaseModel` that caused `ValidationError` when the API returned slot data (PA-5000/PA-7000 series)
+- **tag.list()**: Fixed validation errors caused by `extra="forbid"` rejecting unknown fields in API responses
+- **snippet.associate_folder()**: Now raises `NotImplementedError` immediately instead of making a failing API call and masking the 404 error
+
+### Changed
+- **Response Model Resilience**: Migrated all 50 `*ResponseModel` classes from `extra="forbid"` to `extra="ignore"` so the SDK gracefully handles new fields added by the SCM API. `*CreateModel` and `*UpdateModel` classes retain `extra="forbid"` for strict input validation.
+- Updated 41 test methods to validate the new `extra="ignore"` behavior on response models
+
 ## [0.4.0] - 2024-12-20
 
 ### Added

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,21 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.5.0
+
+**Released:** February 17, 2026
+
+### Fixed
+
+- **EthernetInterface.list()**: Added missing `slot: Optional[int]` field to `EthernetInterfaceBaseModel` that caused `ValidationError` when the API returned slot data on PA-5000/PA-7000 series chassis
+- **tag.list()**: Fixed validation errors caused by `extra="forbid"` on `TagResponseModel` rejecting unknown fields in API responses
+- **snippet.associate_folder()**: Now raises `NotImplementedError` immediately instead of making a failing API call to a non-existent endpoint and masking the 404 error
+
+### Changed
+
+- **Response Model Resilience**: Migrated all 50 `*ResponseModel` classes from `extra="forbid"` to `extra="ignore"` so the SDK gracefully handles new fields added by the SCM API without crashing. `*CreateModel` and `*UpdateModel` classes retain `extra="forbid"` for strict input validation.
+- Updated 41 test methods to validate the new `extra="ignore"` behavior on response models while preserving `extra="forbid"` tests on create/update models
+
 ## Version 0.4.1
 
 **Released:** December 21, 2025

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.4.2"
+version = "0.5.0"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/config/setup/snippet.py
+++ b/scm/config/setup/snippet.py
@@ -348,23 +348,13 @@ class Snippet(BaseObject):
             SnippetResponseModel: The updated snippet.
 
         Raises:
-            NotImplementedError: This method is not yet implemented.
+            NotImplementedError: This method is not yet supported by the SCM API.
 
         """
-        # This is a placeholder for future implementation
-        snippet_id_str = str(snippet_id)
-        folder_id_str = str(folder_id)
-
-        try:
-            response = self.api_client.post(
-                f"{self.ENDPOINT}/{snippet_id_str}/folders",
-                json={"folder_id": folder_id_str},
-            )
-            return SnippetResponseModel.model_validate(response)
-        except Exception as e:
-            raise NotImplementedError(
-                f"Associating snippets with folders is not yet implemented: {str(e)}"
-            )
+        raise NotImplementedError(
+            "Associating snippets with folders is not yet supported by the SCM API. "
+            "This method is reserved for future API support."
+        )
 
     def disassociate_folder(
         self, snippet_id: Union[str, UUID], folder_id: Union[str, UUID]
@@ -379,22 +369,13 @@ class Snippet(BaseObject):
             SnippetResponseModel: The updated snippet.
 
         Raises:
-            NotImplementedError: This method is not yet implemented.
+            NotImplementedError: This method is not yet supported by the SCM API.
 
         """
-        # This is a placeholder for future implementation
-        snippet_id_str = str(snippet_id)
-        folder_id_str = str(folder_id)
-
-        try:
-            response = self.api_client.delete(
-                f"{self.ENDPOINT}/{snippet_id_str}/folders/{folder_id_str}"
-            )
-            return SnippetResponseModel.model_validate(response)
-        except Exception as e:
-            raise NotImplementedError(
-                f"Disassociating snippets from folders is not yet implemented: {str(e)}"
-            )
+        raise NotImplementedError(
+            "Disassociating snippets from folders is not yet supported by the SCM API. "
+            "This method is reserved for future API support."
+        )
 
     def _get_paginated_results(
         self,

--- a/scm/models/deployment/bandwidth_allocations.py
+++ b/scm/models/deployment/bandwidth_allocations.py
@@ -77,6 +77,13 @@ class BandwidthAllocationUpdateModel(BandwidthAllocationBaseModel):
 class BandwidthAllocationResponseModel(BandwidthAllocationBaseModel):
     """Model for Bandwidth Allocation API responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     # Unlike other models, bandwidth allocations don't include an ID in responses
     # based on the OpenAPI specification
     pass
@@ -86,7 +93,7 @@ class BandwidthAllocationListResponseModel(BaseModel):
     """Model for the list response from the Bandwidth Allocations API."""
 
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         populate_by_name=True,
     )
 

--- a/scm/models/deployment/bgp_routing.py
+++ b/scm/models/deployment/bgp_routing.py
@@ -131,6 +131,13 @@ class BGPRoutingResponseModel(BGPRoutingBaseModel):
     when BGP routing hasn't been fully configured.
     """
 
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        extra="ignore",
+    )
+
     # Override to set default to empty list
     outbound_routes_for_services: List[str] = Field(
         default_factory=list,

--- a/scm/models/deployment/internal_dns_servers.py
+++ b/scm/models/deployment/internal_dns_servers.py
@@ -168,6 +168,13 @@ class InternalDnsServersResponseModel(InternalDnsServersBaseModel):
     Includes id as a required field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the internal DNS server",

--- a/scm/models/deployment/remote_networks.py
+++ b/scm/models/deployment/remote_networks.py
@@ -240,6 +240,13 @@ class RemoteNetworkResponseModel(RemoteNetworkBaseModel):
     Includes id as a required field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the remote network",

--- a/scm/models/deployment/service_connections.py
+++ b/scm/models/deployment/service_connections.py
@@ -143,6 +143,13 @@ class ServiceConnectionUpdateModel(ServiceConnectionBaseModel):
 class ServiceConnectionResponseModel(ServiceConnectionBaseModel):
     """Model for Service Connection responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the service connection",

--- a/scm/models/mobile_agent/auth_settings.py
+++ b/scm/models/mobile_agent/auth_settings.py
@@ -176,6 +176,13 @@ class AuthSettingsResponseModel(AuthSettingsBaseModel):
     This class defines the structure for authentication settings returned by the API.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
 
 class MovePosition(str, Enum):
     """Available positions for moving authentication settings."""

--- a/scm/models/network/aggregate_interface.py
+++ b/scm/models/network/aggregate_interface.py
@@ -4,7 +4,7 @@ This module defines the Pydantic models used for creating, updating, and
 representing Aggregate Interface resources in the Strata Cloud Manager.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -194,6 +194,11 @@ class AggregateInterfaceUpdateModel(AggregateInterfaceBaseModel):
 
 class AggregateInterfaceResponseModel(AggregateInterfaceBaseModel):
     """Model for Aggregate Interface responses from the API."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
 
     id: UUID = Field(
         ...,

--- a/scm/models/network/ethernet_interface.py
+++ b/scm/models/network/ethernet_interface.py
@@ -4,7 +4,7 @@ This module defines the Pydantic models used for creating, updating, and
 representing Ethernet Interface resources in the Strata Cloud Manager.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -220,6 +220,10 @@ class EthernetInterfaceBaseModel(BaseModel):
         max_length=64,
         description="The device in which the resource is defined",
     )
+    slot: Optional[int] = Field(
+        default=None,
+        description="The slot number for the ethernet interface",
+    )
 
     @model_validator(mode="after")
     def validate_interface_mode(self) -> "EthernetInterfaceBaseModel":
@@ -272,6 +276,11 @@ class EthernetInterfaceUpdateModel(EthernetInterfaceBaseModel):
 
 class EthernetInterfaceResponseModel(EthernetInterfaceBaseModel):
     """Model for Ethernet Interface responses from the API."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
 
     id: UUID = Field(
         ...,

--- a/scm/models/network/ike_crypto_profile.py
+++ b/scm/models/network/ike_crypto_profile.py
@@ -207,7 +207,7 @@ class IKECryptoProfileResponseModel(IKECryptoProfileBaseModel):
     """Model for IKE Crypto Profile responses."""
 
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         populate_by_name=True,
         validate_assignment=True,
         arbitrary_types_allowed=True,

--- a/scm/models/network/ike_gateway.py
+++ b/scm/models/network/ike_gateway.py
@@ -471,6 +471,13 @@ class IKEGatewayUpdateModel(IKEGatewayBaseModel):
 class IKEGatewayResponseModel(IKEGatewayBaseModel):
     """Model for IKE Gateway responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the IKE Gateway",

--- a/scm/models/network/ipsec_crypto_profile.py
+++ b/scm/models/network/ipsec_crypto_profile.py
@@ -357,6 +357,13 @@ class IPsecCryptoProfileUpdateModel(IPsecCryptoProfileBaseModel):
 class IPsecCryptoProfileResponseModel(IPsecCryptoProfileBaseModel):
     """Model for IPsec Crypto Profile responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the IPsec crypto profile",

--- a/scm/models/network/layer2_subinterface.py
+++ b/scm/models/network/layer2_subinterface.py
@@ -91,6 +91,11 @@ class Layer2SubinterfaceUpdateModel(Layer2SubinterfaceBaseModel):
 class Layer2SubinterfaceResponseModel(Layer2SubinterfaceBaseModel):
     """Model for Layer2 Subinterface responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the layer2 subinterface",

--- a/scm/models/network/layer3_subinterface.py
+++ b/scm/models/network/layer3_subinterface.py
@@ -135,6 +135,11 @@ class Layer3SubinterfaceUpdateModel(Layer3SubinterfaceBaseModel):
 class Layer3SubinterfaceResponseModel(Layer3SubinterfaceBaseModel):
     """Model for Layer3 Subinterface responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the layer3 subinterface",

--- a/scm/models/network/loopback_interface.py
+++ b/scm/models/network/loopback_interface.py
@@ -108,6 +108,11 @@ class LoopbackInterfaceUpdateModel(LoopbackInterfaceBaseModel):
 class LoopbackInterfaceResponseModel(LoopbackInterfaceBaseModel):
     """Model for Loopback Interface responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the loopback interface",

--- a/scm/models/network/nat_rules.py
+++ b/scm/models/network/nat_rules.py
@@ -448,6 +448,13 @@ class NatRuleUpdateModel(NatRuleBaseModel):
 class NatRuleResponseModel(NatRuleBaseModel):
     """Model for NAT Rule responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the NAT rule",

--- a/scm/models/network/security_zone.py
+++ b/scm/models/network/security_zone.py
@@ -208,6 +208,13 @@ class SecurityZoneUpdateModel(SecurityZoneBaseModel):
 class SecurityZoneResponseModel(SecurityZoneBaseModel):
     """Model for Security Zone responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the security zone",

--- a/scm/models/network/tunnel_interface.py
+++ b/scm/models/network/tunnel_interface.py
@@ -103,6 +103,11 @@ class TunnelInterfaceUpdateModel(TunnelInterfaceBaseModel):
 class TunnelInterfaceResponseModel(TunnelInterfaceBaseModel):
     """Model for Tunnel Interface responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the tunnel interface",

--- a/scm/models/network/vlan_interface.py
+++ b/scm/models/network/vlan_interface.py
@@ -140,6 +140,11 @@ class VlanInterfaceUpdateModel(VlanInterfaceBaseModel):
 class VlanInterfaceResponseModel(VlanInterfaceBaseModel):
     """Model for VLAN Interface responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the VLAN interface",

--- a/scm/models/objects/address.py
+++ b/scm/models/objects/address.py
@@ -246,6 +246,13 @@ class AddressResponseModel(AddressBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the application group",

--- a/scm/models/objects/address_group.py
+++ b/scm/models/objects/address_group.py
@@ -209,6 +209,13 @@ class AddressGroupResponseModel(AddressGroupBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the application group",

--- a/scm/models/objects/application.py
+++ b/scm/models/objects/application.py
@@ -191,7 +191,7 @@ class ApplicationResponseModel(ApplicationBaseModel):
     """
 
     model_config = ConfigDict(
-        extra="allow",
+        extra="ignore",
         validate_assignment=True,
         arbitrary_types_allowed=True,
         populate_by_name=True,

--- a/scm/models/objects/application_filters.py
+++ b/scm/models/objects/application_filters.py
@@ -204,6 +204,13 @@ class ApplicationFiltersResponseModel(ApplicationFiltersBaseModel):
     Includes all base fields plus the (optional!) id field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: Optional[UUID] = Field(
         None,
         description="The UUID of the application",

--- a/scm/models/objects/application_group.py
+++ b/scm/models/objects/application_group.py
@@ -118,6 +118,13 @@ class ApplicationGroupResponseModel(ApplicationGroupBaseModel):
     Includes all base fields plus the id field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the application group",

--- a/scm/models/objects/dynamic_user_group.py
+++ b/scm/models/objects/dynamic_user_group.py
@@ -165,6 +165,13 @@ class DynamicUserGroupResponseModel(DynamicUserGroupBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the dynamic user group",

--- a/scm/models/objects/external_dynamic_lists.py
+++ b/scm/models/objects/external_dynamic_lists.py
@@ -522,6 +522,13 @@ class ExternalDynamicListsUpdateModel(ExternalDynamicListsBaseModel):
 class ExternalDynamicListsResponseModel(ExternalDynamicListsBaseModel):
     """Model for responses representing an external dynamic list resource."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: Optional[UUID] = Field(
         None,
         description="The UUID of the external dynamic list",

--- a/scm/models/objects/hip_object.py
+++ b/scm/models/objects/hip_object.py
@@ -802,6 +802,13 @@ class HIPObjectUpdateModel(HIPObjectBaseModel):
 class HIPObjectResponseModel(HIPObjectBaseModel):
     """Model for HIP object responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the HIP object",

--- a/scm/models/objects/hip_profile.py
+++ b/scm/models/objects/hip_profile.py
@@ -133,6 +133,13 @@ class HIPProfileResponseModel(HIPProfileBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the HIP profile",

--- a/scm/models/objects/http_server_profiles.py
+++ b/scm/models/objects/http_server_profiles.py
@@ -206,6 +206,13 @@ class HTTPServerProfileResponseModel(HTTPServerProfileBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the HTTP server profile",

--- a/scm/models/objects/log_forwarding_profile.py
+++ b/scm/models/objects/log_forwarding_profile.py
@@ -186,6 +186,13 @@ class LogForwardingProfileResponseModel(LogForwardingProfileBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: Optional[UUID] = Field(
         None,
         description="The UUID of the log forwarding profile. Not required for predefined snippets.",

--- a/scm/models/objects/quarantined_devices.py
+++ b/scm/models/objects/quarantined_devices.py
@@ -49,6 +49,13 @@ class QuarantinedDevicesCreateModel(QuarantinedDevicesBaseModel):
 class QuarantinedDevicesResponseModel(QuarantinedDevicesBaseModel):
     """Represents the response from creating or retrieving a Quarantined Devices object."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
 
 class QuarantinedDevicesListParamsModel(BaseModel):
     """Parameters for listing Quarantined Devices.

--- a/scm/models/objects/regions.py
+++ b/scm/models/objects/regions.py
@@ -193,6 +193,13 @@ class RegionResponseModel(RegionBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: Optional[UUID] = Field(
         None,
         description="The UUID of the region (may be missing for predefined regions)",

--- a/scm/models/objects/schedules.py
+++ b/scm/models/objects/schedules.py
@@ -381,6 +381,13 @@ class ScheduleResponseModel(ScheduleBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the schedule",

--- a/scm/models/objects/service.py
+++ b/scm/models/objects/service.py
@@ -197,6 +197,13 @@ class ServiceResponseModel(ServiceBaseModel):
     Includes all base fields plus the optional id field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: Optional[UUID] = Field(
         None,
         description="The UUID of the service.",

--- a/scm/models/objects/service_group.py
+++ b/scm/models/objects/service_group.py
@@ -167,6 +167,13 @@ class ServiceGroupResponseModel(ServiceGroupBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the application group",

--- a/scm/models/objects/syslog_server_profiles.py
+++ b/scm/models/objects/syslog_server_profiles.py
@@ -229,6 +229,13 @@ class SyslogServerProfileResponseModel(SyslogServerProfileBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the syslog server profile",

--- a/scm/models/objects/tag.py
+++ b/scm/models/objects/tag.py
@@ -253,6 +253,13 @@ class TagResponseModel(TagBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     # Optional fields
 
     id: Optional[UUID] = Field(

--- a/scm/models/security/anti_spyware_profiles.py
+++ b/scm/models/security/anti_spyware_profiles.py
@@ -464,6 +464,13 @@ class AntiSpywareProfileResponseModel(AntiSpywareProfileBase):
     Includes all base fields plus the id field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="Profile ID",

--- a/scm/models/security/decryption_profiles.py
+++ b/scm/models/security/decryption_profiles.py
@@ -306,6 +306,13 @@ class DecryptionProfileUpdateModel(DecryptionProfileBaseModel):
 class DecryptionProfileResponseModel(DecryptionProfileBaseModel):
     """Model for Decryption Profile API responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="UUID of the resource",

--- a/scm/models/security/dns_security_profiles.py
+++ b/scm/models/security/dns_security_profiles.py
@@ -298,6 +298,13 @@ class DNSSecurityProfileUpdateModel(DNSSecurityProfileBaseModel):
 class DNSSecurityProfileResponseModel(DNSSecurityProfileBaseModel):
     """Model for DNS Security Profile API responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="UUID of the resource",

--- a/scm/models/security/security_rules.py
+++ b/scm/models/security/security_rules.py
@@ -275,6 +275,13 @@ class SecurityRuleUpdateModel(SecurityRuleBaseModel):
 class SecurityRuleResponseModel(SecurityRuleBaseModel):
     """Model for Security Rule responses, including the id field."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The UUID of the security rule",

--- a/scm/models/security/url_categories.py
+++ b/scm/models/security/url_categories.py
@@ -111,6 +111,13 @@ class URLCategoriesUpdateModel(URLCategoriesBaseModel):
 class URLCategoriesResponseModel(URLCategoriesBaseModel):
     """Model for URL Category API responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="UUID of the resource",

--- a/scm/models/security/vulnerability_protection_profiles.py
+++ b/scm/models/security/vulnerability_protection_profiles.py
@@ -450,6 +450,13 @@ class VulnerabilityProfileUpdateModel(VulnerabilityProfileBaseModel):
 class VulnerabilityProfileResponseModel(VulnerabilityProfileBaseModel):
     """Model for Vulnerability Protection Profile responses."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="Profile ID",

--- a/scm/models/security/wildfire_antivirus_profiles.py
+++ b/scm/models/security/wildfire_antivirus_profiles.py
@@ -172,6 +172,13 @@ class WildfireAvProfileResponseModel(WildfireAvProfileBase):
     Includes all base fields plus the id field.
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="Profile ID",

--- a/scm/models/setup/device.py
+++ b/scm/models/setup/device.py
@@ -196,7 +196,7 @@ class DeviceResponseModel(DeviceBaseModel):
     vm_state: Optional[str] = Field(None, description="VM state.")
 
     model_config = ConfigDict(
-        extra="allow",  # Allow extra fields if the API adds new ones
+        extra="ignore",
         populate_by_name=True,
     )
 
@@ -205,7 +205,7 @@ class DeviceListResponseModel(BaseModel):
     """Model for the paginated response from GET /devices."""
 
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         populate_by_name=True,
     )
 

--- a/scm/models/setup/folder.py
+++ b/scm/models/setup/folder.py
@@ -102,6 +102,11 @@ class FolderResponseModel(FolderBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         description="The unique identifier of the folder",
     )

--- a/scm/models/setup/label.py
+++ b/scm/models/setup/label.py
@@ -48,6 +48,11 @@ class LabelUpdateModel(LabelBaseModel):
 class LabelResponseModel(LabelBaseModel):
     """Model for Label responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,  # required, readOnly
         description="The unique identifier of the label",

--- a/scm/models/setup/snippet.py
+++ b/scm/models/setup/snippet.py
@@ -109,6 +109,11 @@ class SnippetResponseModel(SnippetBaseModel):
 
     """
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,
         description="The unique identifier of the snippet",

--- a/scm/models/setup/variable.py
+++ b/scm/models/setup/variable.py
@@ -143,6 +143,11 @@ class VariableUpdateModel(VariableBaseModel):
 class VariableResponseModel(VariableBaseModel):
     """Model for Variable responses from the API."""
 
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+    )
+
     id: UUID = Field(
         ...,  # required, readOnly
         description="The unique identifier of the variable",

--- a/tests/scm/config/setup/test_snippet.py
+++ b/tests/scm/config/setup/test_snippet.py
@@ -322,94 +322,56 @@ class TestFolderAssociations(TestSnippetBase):
     """Tests for Snippet folder association methods."""
 
     def test_associate_folder_not_implemented(self, snippet_service, mock_scm_client):
-        """Test that associate_folder raises NotImplementedError."""
-        # Setup mock response that returns an error when called
-        mock_scm_client.post.side_effect = Exception("API error")
-
-        # Try to associate a folder - should raise NotImplementedError
-        with pytest.raises(Exception) as excinfo:
+        """Test that associate_folder raises NotImplementedError immediately."""
+        with pytest.raises(NotImplementedError) as excinfo:
             snippet_service.associate_folder(
                 snippet_id="123e4567-e89b-12d3-a456-426614174000",
                 folder_id="223e4567-e89b-12d3-a456-426614174000",
             )
 
-        # Verify the method was called and the exception contains the expected text
-        mock_scm_client.post.assert_called_once()
-        assert "not yet implemented" in str(excinfo.value)
+        # Verify the error message mentions the API limitation
+        assert "not yet supported by the SCM API" in str(excinfo.value)
 
-    def test_associate_folder_success(self, snippet_service, mock_scm_client):
-        """Test successful associate_folder method call (to cover line 291)."""
-        # Setup mock response for a successful API call
+        # Verify NO API call was made
+        mock_scm_client.post.assert_not_called()
+
+    def test_associate_folder_no_api_call(self, snippet_service, mock_scm_client):
+        """Test that associate_folder does not make any API call."""
         snippet_id = "123e4567-e89b-12d3-a456-426614174000"
         folder_id = "223e4567-e89b-12d3-a456-426614174000"
-        mock_response = SnippetResponseModelFactory.build()
-        mock_scm_client.post.return_value = mock_response
 
-        # Mock the model_validate to prevent NotImplementedError being raised
-        with patch(
-            "scm.models.setup.snippet.SnippetResponseModel.model_validate",
-            return_value=SnippetResponseModel.model_validate(mock_response),
-        ):
-            # Call associate_folder - this should succeed
-            with patch("scm.config.setup.snippet.NotImplementedError", side_effect=Exception):
-                try:
-                    result = snippet_service.associate_folder(snippet_id, folder_id)
+        # The method should raise NotImplementedError without calling the API
+        with pytest.raises(NotImplementedError):
+            snippet_service.associate_folder(snippet_id, folder_id)
 
-                    # This code won't be reached due to the NotImplementedError, but
-                    # it's here to show the expected behavior if the method were implemented
-                    assert isinstance(result, SnippetResponseModel)
-                    mock_scm_client.post.assert_called_once()
-                except Exception:
-                    # We expect an exception, but the API call should have been made
-                    mock_scm_client.post.assert_called_once()
-                    call_args = mock_scm_client.post.call_args
-                    assert call_args[0][0] == f"/config/setup/v1/snippets/{snippet_id}/folders"
-                    assert call_args[1]["json"]["folder_id"] == folder_id
+        # Verify no POST request was made
+        mock_scm_client.post.assert_not_called()
 
     def test_disassociate_folder_not_implemented(self, snippet_service, mock_scm_client):
-        """Test that disassociate_folder raises NotImplementedError."""
-        # Setup mock response that returns an error when called
-        mock_scm_client.delete.side_effect = Exception("API error")
-
-        # Try to disassociate a folder - should raise NotImplementedError
-        with pytest.raises(Exception) as excinfo:
+        """Test that disassociate_folder raises NotImplementedError immediately."""
+        with pytest.raises(NotImplementedError) as excinfo:
             snippet_service.disassociate_folder(
                 snippet_id="123e4567-e89b-12d3-a456-426614174000",
                 folder_id="223e4567-e89b-12d3-a456-426614174000",
             )
 
-        # Verify the method was called and the exception contains the expected text
-        mock_scm_client.delete.assert_called_once()
-        assert "not yet implemented" in str(excinfo.value)
+        # Verify the error message mentions the API limitation
+        assert "not yet supported by the SCM API" in str(excinfo.value)
 
-    def test_disassociate_folder_success(self, snippet_service, mock_scm_client):
-        """Test successful disassociate_folder method call (to cover line 321)."""
-        # Setup mock response for a successful API call
+        # Verify NO API call was made
+        mock_scm_client.delete.assert_not_called()
+
+    def test_disassociate_folder_no_api_call(self, snippet_service, mock_scm_client):
+        """Test that disassociate_folder does not make any API call."""
         snippet_id = "123e4567-e89b-12d3-a456-426614174000"
         folder_id = "223e4567-e89b-12d3-a456-426614174000"
-        mock_response = SnippetResponseModelFactory.build()
-        mock_scm_client.delete.return_value = mock_response
 
-        # Mock the model_validate to prevent NotImplementedError being raised
-        with patch(
-            "scm.models.setup.snippet.SnippetResponseModel.model_validate",
-            return_value=SnippetResponseModel.model_validate(mock_response),
-        ):
-            # Call disassociate_folder - this should succeed
-            with patch("scm.config.setup.snippet.NotImplementedError", side_effect=Exception):
-                try:
-                    result = snippet_service.disassociate_folder(snippet_id, folder_id)
+        # The method should raise NotImplementedError without calling the API
+        with pytest.raises(NotImplementedError):
+            snippet_service.disassociate_folder(snippet_id, folder_id)
 
-                    # This code won't be reached due to the NotImplementedError, but
-                    # it's here to show the expected behavior if the method were implemented
-                    assert isinstance(result, SnippetResponseModel)
-                    mock_scm_client.delete.assert_called_once()
-                except Exception:
-                    # We expect an exception, but the API call should have been made
-                    mock_scm_client.delete.assert_called_once()
-                    call_args = mock_scm_client.delete.call_args
-                    endpoint = f"/config/setup/v1/snippets/{snippet_id}/folders/{folder_id}"
-                    assert call_args[0][0] == endpoint
+        # Verify no DELETE request was made
+        mock_scm_client.delete.assert_not_called()
 
 
 class TestSnippetList(TestSnippetBase):

--- a/tests/scm/models/deployment/test_bandwidth_allocations_models.py
+++ b/tests/scm/models/deployment/test_bandwidth_allocations_models.py
@@ -212,13 +212,12 @@ class TestBandwidthAllocationResponseModel:
         assert model.spn_name_list is None
         assert model.qos is None
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected (inherited from BaseModel)."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = BandwidthAllocationResponseModelFactory.build_valid()
-        data["unknown_field"] = "fail"
-        with pytest.raises(ValidationError) as exc_info:
-            BandwidthAllocationResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should_be_ignored"
+        model = BandwidthAllocationResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 class TestBandwidthAllocationListResponseModel:
@@ -251,10 +250,9 @@ class TestBandwidthAllocationListResponseModel:
         assert len(model.data) == 0
         assert model.total == 0
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ListResponseModel."""
         data = BandwidthAllocationResponseModelFactory.build_list_response()
-        data["unknown_field"] = "fail"
-        with pytest.raises(ValidationError) as exc_info:
-            BandwidthAllocationListResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should_be_ignored"
+        model = BandwidthAllocationListResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/deployment/test_internal_dns_servers_models.py
+++ b/tests/scm/models/deployment/test_internal_dns_servers_models.py
@@ -341,10 +341,9 @@ class TestInternalDnsServersResponseModel:
             test_model.validate_response_model()
         assert "domain_name must not be empty in response" in str(exc_info.value)
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         model_data = InternalDnsServersResponseModelFactory.build_valid()
-        model_data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            InternalDnsServersResponseModel(**model_data)
-        assert "extra" in str(exc_info.value).lower()
+        model_data["unknown_field"] = "should_be_ignored"
+        model = InternalDnsServersResponseModel(**model_data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/deployment/test_service_connections_models.py
+++ b/tests/scm/models/deployment/test_service_connections_models.py
@@ -349,10 +349,9 @@ class TestExtraFieldsForbidden:
             ServiceConnectionUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_service_connection_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ServiceConnectionResponseModel."""
+    def test_service_connection_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ServiceConnectionResponseModel."""
         data = ServiceConnectionResponseFactory.build()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            ServiceConnectionResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should_be_ignored"
+        model = ServiceConnectionResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/network/test_ike_crypto_profile_models.py
+++ b/tests/scm/models/network/test_ike_crypto_profile_models.py
@@ -190,8 +190,8 @@ class TestIKECryptoProfileModels:
             IKECryptoProfileUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-profile",
@@ -199,11 +199,10 @@ class TestIKECryptoProfileModels:
             "encryption": ["aes-128-cbc"],
             "dh_group": ["group2"],
             "folder": "test-folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            IKECryptoProfileResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = IKECryptoProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_non_auth_hash_algorithm(self):
         """Test that non-auth hash algorithm is supported."""

--- a/tests/scm/models/network/test_ike_gateway_models.py
+++ b/tests/scm/models/network/test_ike_gateway_models.py
@@ -200,12 +200,11 @@ def test_update_model_extra_fields_forbidden():
     assert "Extra inputs are not permitted" in str(exc_info.value)
 
 
-def test_response_model_extra_fields_forbidden():
-    """Test that extra fields are rejected on ResponseModel."""
+def test_response_model_extra_fields_ignored():
+    """Test that extra fields are silently ignored on ResponseModel."""
     data = VALID_IKE_GATEWAY.copy()
     data["id"] = "123e4567-e89b-12d3-a456-426655440000"
-    data["unknown_field"] = "should_fail"
+    data["unknown_field"] = "should_be_ignored"
 
-    with pytest.raises(ValidationError) as exc_info:
-        IKEGatewayResponseModel(**data)
-    assert "Extra inputs are not permitted" in str(exc_info.value)
+    model = IKEGatewayResponseModel(**data)
+    assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/network/test_ipsec_crypto_profile_models.py
+++ b/tests/scm/models/network/test_ipsec_crypto_profile_models.py
@@ -424,8 +424,8 @@ class TestIPsecCryptoProfileModels:
             IPsecCryptoProfileUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-profile",
@@ -435,8 +435,7 @@ class TestIPsecCryptoProfileModels:
                 "authentication": ["sha1"],
             },
             "folder": "Test Folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            IPsecCryptoProfileResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = IPsecCryptoProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/network/test_loopback_interface_models.py
+++ b/tests/scm/models/network/test_loopback_interface_models.py
@@ -245,14 +245,13 @@ class TestExtraFieldsForbidden:
             LoopbackInterfaceUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on LoopbackInterfaceResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on LoopbackInterfaceResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "$loopback",
             "folder": "Test Folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            LoopbackInterfaceResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = LoopbackInterfaceResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/network/test_nat_rules_models.py
+++ b/tests/scm/models/network/test_nat_rules_models.py
@@ -448,13 +448,12 @@ class TestExtraFieldsForbidden:
             NatRuleUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on NatRuleResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on NatRuleResponseModel."""
         data = NatRuleResponseFactory().model_dump()
-        data["unknown_field"] = "should_fail"
-        with pytest.raises(ValidationError) as exc_info:
-            NatRuleResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        data["unknown_field"] = "should_be_ignored"
+        model = NatRuleResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_move_model_extra_fields_forbidden(self):
         """Test that extra fields are rejected on NatRuleMoveModel."""

--- a/tests/scm/models/network/test_security_zone_models.py
+++ b/tests/scm/models/network/test_security_zone_models.py
@@ -249,17 +249,16 @@ class TestExtraFieldsForbidden:
             SecurityZoneUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on SecurityZoneResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on SecurityZoneResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-zone",
             "folder": "Test Folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            SecurityZoneResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = SecurityZoneResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_network_config_extra_fields_forbidden(self):
         """Test that extra fields are rejected on NetworkConfig."""

--- a/tests/scm/models/network/test_tunnel_interface_models.py
+++ b/tests/scm/models/network/test_tunnel_interface_models.py
@@ -209,14 +209,13 @@ class TestExtraFieldsForbidden:
             TunnelInterfaceUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on TunnelInterfaceResponseModel."""
+    def test_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on TunnelInterfaceResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "tunnel.1",
             "folder": "Test Folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            TunnelInterfaceResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = TunnelInterfaceResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_address_group_models.py
+++ b/tests/scm/models/objects/test_address_group_models.py
@@ -231,18 +231,17 @@ class TestExtraFieldsForbidden:
             AddressGroupUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_address_group_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in AddressGroupResponseModel."""
+    def test_address_group_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in AddressGroupResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-address-group",
             "static": ["address1", "address2"],
             "folder": "Texas",
-            "unknown_field": "should fail",
+            "unknown_field": "should be ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            AddressGroupResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        model = AddressGroupResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_address_models.py
+++ b/tests/scm/models/objects/test_address_models.py
@@ -226,18 +226,17 @@ class TestExtraFieldsForbidden:
             AddressUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_address_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in AddressResponseModel."""
+    def test_address_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in AddressResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-address",
             "ip_netmask": "192.168.1.0/24",
             "folder": "Texas",
-            "unknown_field": "should fail",
+            "unknown_field": "should be ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            AddressResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        model = AddressResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_application_filters_models.py
+++ b/tests/scm/models/objects/test_application_filters_models.py
@@ -135,13 +135,12 @@ class TestExtraFieldsForbidden:
             ApplicationFiltersUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_application_filters_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ApplicationFiltersResponseModel."""
+    def test_application_filters_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ApplicationFiltersResponseModel."""
         data = ApplicationFiltersResponseModelFactory.build_valid()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            ApplicationFiltersResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should be ignored"
+        model = ApplicationFiltersResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_application_group_models.py
+++ b/tests/scm/models/objects/test_application_group_models.py
@@ -179,18 +179,17 @@ class TestExtraFieldsForbidden:
             ApplicationGroupUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_application_group_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ApplicationGroupResponseModel."""
+    def test_application_group_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ApplicationGroupResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "TestGroup",
             "members": ["app1"],
             "folder": "Texas",
-            "unknown_field": "should fail",
+            "unknown_field": "should be ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            ApplicationGroupResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        model = ApplicationGroupResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_dynamic_user_group_models.py
+++ b/tests/scm/models/objects/test_dynamic_user_group_models.py
@@ -282,15 +282,14 @@ class TestExtraFieldsForbidden:
             DynamicUserGroupUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_dynamic_user_group_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in DynamicUserGroupResponseModel."""
+    def test_dynamic_user_group_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in DynamicUserGroupResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test-group",
             "filter": "'tag.User.Developer'",
             "folder": "Shared",
-            "unknown_field": "should fail",
+            "unknown_field": "should be ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            DynamicUserGroupResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        model = DynamicUserGroupResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_external_dynamic_lists.py
+++ b/tests/scm/models/objects/test_external_dynamic_lists.py
@@ -167,12 +167,9 @@ class TestExtraFieldsForbidden:
             ExternalDynamicListsUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_external_dynamic_lists_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ExternalDynamicListsResponseModel."""
-        from pydantic import ValidationError
-
+    def test_external_dynamic_lists_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ExternalDynamicListsResponseModel."""
         data = ExternalDynamicListsResponseModelFactory.build_valid()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            ExternalDynamicListsResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should be ignored"
+        model = ExternalDynamicListsResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_hip_object_models.py
+++ b/tests/scm/models/objects/test_hip_object_models.py
@@ -150,13 +150,12 @@ class TestExtraFieldsForbidden:
             HIPObjectUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_hip_object_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in HIPObjectResponseModel."""
+    def test_hip_object_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in HIPObjectResponseModel."""
         data = HIPObjectResponseModelFactory.build_valid()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            HIPObjectResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should be ignored"
+        model = HIPObjectResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 class TestProcessListItemModel:

--- a/tests/scm/models/objects/test_hip_profile_models.py
+++ b/tests/scm/models/objects/test_hip_profile_models.py
@@ -264,10 +264,9 @@ class TestExtraFieldsForbidden:
             HIPProfileUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_hip_profile_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in HIPProfileResponseModel."""
+    def test_hip_profile_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in HIPProfileResponseModel."""
         data = HIPProfileResponseModelFactory.build_valid()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            HIPProfileResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should be ignored"
+        model = HIPProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_log_forwarding_profile_models.py
+++ b/tests/scm/models/objects/test_log_forwarding_profile_models.py
@@ -262,10 +262,9 @@ class TestExtraFieldsForbidden:
             LogForwardingProfileUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_log_forwarding_profile_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in LogForwardingProfileResponseModel."""
+    def test_log_forwarding_profile_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in LogForwardingProfileResponseModel."""
         data = LogForwardingProfileResponseModelFactory.build_valid()
-        data["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            LogForwardingProfileResponseModel(**data)
-        assert "extra" in str(exc_info.value).lower()
+        data["unknown_field"] = "should be ignored"
+        model = LogForwardingProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_quarantined_devices_models.py
+++ b/tests/scm/models/objects/test_quarantined_devices_models.py
@@ -127,13 +127,12 @@ class TestExtraFieldsForbidden:
             QuarantinedDevicesCreateModel(host_id="test-host", unknown_field="should fail")
         assert "extra" in str(exc_info.value).lower()
 
-    def test_quarantined_devices_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in QuarantinedDevicesResponseModel."""
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError) as exc_info:
-            QuarantinedDevicesResponseModel(host_id="test-host", unknown_field="should fail")
-        assert "extra" in str(exc_info.value).lower()
+    def test_quarantined_devices_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in QuarantinedDevicesResponseModel."""
+        model = QuarantinedDevicesResponseModel(
+            host_id="test-host", unknown_field="should be ignored"
+        )
+        assert not hasattr(model, "unknown_field")
 
     def test_quarantined_devices_list_params_model_extra_fields_forbidden(self):
         """Test that extra fields are rejected in QuarantinedDevicesListParamsModel."""

--- a/tests/scm/models/objects/test_regions_models.py
+++ b/tests/scm/models/objects/test_regions_models.py
@@ -358,11 +358,10 @@ class TestExtraFieldsForbidden:
             RegionUpdateModel(**data)
         assert "extra" in str(exc_info.value).lower()
 
-    def test_region_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in RegionResponseModel."""
+    def test_region_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in RegionResponseModel."""
         data = RegionResponseFactory.build_valid()
         data_dict = data.model_dump()
-        data_dict["unknown_field"] = "should fail"
-        with pytest.raises(ValidationError) as exc_info:
-            RegionResponseModel(**data_dict)
-        assert "extra" in str(exc_info.value).lower()
+        data_dict["unknown_field"] = "should be ignored"
+        model = RegionResponseModel(**data_dict)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_schedules_models.py
+++ b/tests/scm/models/objects/test_schedules_models.py
@@ -665,17 +665,16 @@ class TestExtraFieldsForbidden:
             )
         assert "extra" in str(exc_info.value).lower()
 
-    def test_schedule_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ScheduleResponseModel."""
-        with pytest.raises(ValidationError) as exc_info:
-            ScheduleResponseModel(
-                id="123e4567-e89b-12d3-a456-426655440000",
-                name="TestSchedule",
-                folder="Shared",
-                schedule_type={"recurring": {"daily": ["09:00-17:00"]}},
-                unknown_field="should fail",
-            )
-        assert "extra" in str(exc_info.value).lower()
+    def test_schedule_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ScheduleResponseModel."""
+        model = ScheduleResponseModel(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="TestSchedule",
+            folder="Shared",
+            schedule_type={"recurring": {"daily": ["09:00-17:00"]}},
+            unknown_field="should be ignored",
+        )
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_service_group_models.py
+++ b/tests/scm/models/objects/test_service_group_models.py
@@ -256,17 +256,16 @@ class TestExtraFieldsForbidden:
             )
         assert "extra" in str(exc_info.value).lower()
 
-    def test_service_group_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ServiceGroupResponseModel."""
-        with pytest.raises(ValidationError) as exc_info:
-            ServiceGroupResponseModel(
-                id="123e4567-e89b-12d3-a456-426655440000",
-                name="test-group",
-                folder="Texas",
-                members=["service1"],
-                unknown_field="should fail",
-            )
-        assert "extra" in str(exc_info.value).lower()
+    def test_service_group_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ServiceGroupResponseModel."""
+        model = ServiceGroupResponseModel(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="test-group",
+            folder="Texas",
+            members=["service1"],
+            unknown_field="should be ignored",
+        )
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_service_models.py
+++ b/tests/scm/models/objects/test_service_models.py
@@ -332,17 +332,16 @@ class TestExtraFieldsForbidden:
             )
         assert "extra" in str(exc_info.value).lower()
 
-    def test_service_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in ServiceResponseModel."""
-        with pytest.raises(ValidationError) as exc_info:
-            ServiceResponseModel(
-                id="123e4567-e89b-12d3-a456-426655440000",
-                name="test-service",
-                folder="Texas",
-                protocol={"tcp": {"port": "80"}},
-                unknown_field="should fail",
-            )
-        assert "extra" in str(exc_info.value).lower()
+    def test_service_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in ServiceResponseModel."""
+        model = ServiceResponseModel(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="test-service",
+            folder="Texas",
+            protocol={"tcp": {"port": "80"}},
+            unknown_field="should be ignored",
+        )
+        assert not hasattr(model, "unknown_field")
 
 
 # -------------------- End of Test Classes --------------------

--- a/tests/scm/models/objects/test_syslog_server_profiles_models.py
+++ b/tests/scm/models/objects/test_syslog_server_profiles_models.py
@@ -359,23 +359,22 @@ class TestExtraFieldsForbidden:
             )
         assert "extra" in str(exc_info.value).lower()
 
-    def test_syslog_server_profile_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in SyslogServerProfileResponseModel."""
-        with pytest.raises(ValidationError) as exc_info:
-            SyslogServerProfileResponseModel(
-                id="123e4567-e89b-12d3-a456-426655440000",
-                name="test-profile",
-                folder="Shared",
-                server=[
-                    {
-                        "name": "server1",
-                        "server": "192.168.1.1",
-                        "transport": "UDP",
-                        "port": 514,
-                        "format": "BSD",
-                        "facility": "LOG_USER",
-                    }
-                ],
-                unknown_field="should fail",
-            )
-        assert "extra" in str(exc_info.value).lower()
+    def test_syslog_server_profile_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in SyslogServerProfileResponseModel."""
+        model = SyslogServerProfileResponseModel(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="test-profile",
+            folder="Shared",
+            server=[
+                {
+                    "name": "server1",
+                    "server": "192.168.1.1",
+                    "transport": "UDP",
+                    "port": 514,
+                    "format": "BSD",
+                    "facility": "LOG_USER",
+                }
+            ],
+            unknown_field="should be ignored",
+        )
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/objects/test_tag_models.py
+++ b/tests/scm/models/objects/test_tag_models.py
@@ -211,13 +211,12 @@ class TestExtraFieldsForbidden:
             )
         assert "extra" in str(exc_info.value).lower()
 
-    def test_tag_response_model_extra_fields_forbidden(self):
-        """Test that extra fields are rejected in TagResponseModel."""
-        with pytest.raises(ValidationError) as exc_info:
-            TagResponseModel(
-                id="123e4567-e89b-12d3-a456-426655440000",
-                name="test-tag",
-                folder="Texas",
-                unknown_field="should fail",
-            )
-        assert "extra" in str(exc_info.value).lower()
+    def test_tag_response_model_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored in TagResponseModel."""
+        model = TagResponseModel(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="test-tag",
+            folder="Texas",
+            unknown_field="should be ignored",
+        )
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/security/test_anti_spyware_profile_models.py
+++ b/tests/scm/models/security/test_anti_spyware_profile_models.py
@@ -346,17 +346,16 @@ class TestExtraFieldsForbidden:
             AntiSpywareProfileUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_profile_response_model_rejects_extra_fields(self):
-        """Test that extra fields are rejected in ResponseModel."""
+    def test_profile_response_model_ignores_extra_fields(self):
+        """Test that extra fields are silently ignored in ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "TestProfile",
             "folder": "Texas",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            AntiSpywareProfileResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = AntiSpywareProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_rule_base_model_rejects_extra_fields(self):
         """Test that extra fields are rejected in RuleBaseModel."""

--- a/tests/scm/models/security/test_decryption_profiles_models.py
+++ b/tests/scm/models/security/test_decryption_profiles_models.py
@@ -178,17 +178,16 @@ class TestExtraFieldsForbidden:
             DecryptionProfileUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_rejects_extra_fields(self):
-        """Test that extra fields are rejected in ResponseModel."""
+    def test_response_model_ignores_extra_fields(self):
+        """Test that extra fields are silently ignored in ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "TestProfile",
             "folder": "Texas",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            DecryptionProfileResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = DecryptionProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_ssl_protocol_settings_rejects_extra_fields(self):
         """Test that extra fields are rejected in SSLProtocolSettings."""

--- a/tests/scm/models/security/test_dns_security_profiles_models.py
+++ b/tests/scm/models/security/test_dns_security_profiles_models.py
@@ -266,17 +266,16 @@ class TestExtraFieldsForbidden:
             DNSSecurityProfileUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_rejects_extra_fields(self):
-        """Test that extra fields are rejected in ResponseModel."""
+    def test_response_model_ignores_extra_fields(self):
+        """Test that extra fields are silently ignored in ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "TestProfile",
             "folder": "Texas",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            DNSSecurityProfileResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = DNSSecurityProfileResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_dns_security_category_entry_rejects_extra_fields(self):
         """Test that extra fields are rejected in DNSSecurityCategoryEntryModel."""

--- a/tests/scm/models/security/test_security_rules_models.py
+++ b/tests/scm/models/security/test_security_rules_models.py
@@ -603,17 +603,16 @@ class TestExtraFieldsForbidden:
             SecurityRuleUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_rejects_extra_fields(self):
-        """Test that extra fields are rejected in ResponseModel."""
+    def test_response_model_ignores_extra_fields(self):
+        """Test that extra fields are silently ignored in ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "TestRule",
             "folder": "Texas",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            SecurityRuleResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = SecurityRuleResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
     def test_move_model_rejects_extra_fields(self):
         """Test that extra fields are rejected in MoveModel."""

--- a/tests/scm/models/security/test_url_categories_models.py
+++ b/tests/scm/models/security/test_url_categories_models.py
@@ -135,8 +135,8 @@ class TestExtraFieldsForbidden:
             URLCategoriesUpdateModel(**data)
         assert "Extra inputs are not permitted" in str(exc_info.value)
 
-    def test_response_model_rejects_extra_fields(self):
-        """Test that extra fields are rejected in ResponseModel."""
+    def test_response_model_ignores_extra_fields(self):
+        """Test that extra fields are silently ignored in ResponseModel."""
         from scm.models.security.url_categories import URLCategoriesResponseModel
 
         data = {
@@ -144,11 +144,10 @@ class TestExtraFieldsForbidden:
             "name": "TestCategory",
             "folder": "Texas",
             "list": ["example.com"],
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValueError) as exc_info:
-            URLCategoriesResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = URLCategoriesResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 class TestEnumValues:

--- a/tests/scm/models/setup/test_device.py
+++ b/tests/scm/models/setup/test_device.py
@@ -157,10 +157,9 @@ class TestDeviceListResponseModel:
         assert isinstance(model.offset, int)
         assert isinstance(model.total, int)
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = DeviceListResponseModelDictFactory.build()
-        data["unknown_field"] = "should_fail"
-        with pytest.raises(ValidationError) as exc_info:
-            DeviceListResponseModel.model_validate(data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        data["unknown_field"] = "should_be_ignored"
+        model = DeviceListResponseModel.model_validate(data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/setup/test_folder.py
+++ b/tests/scm/models/setup/test_folder.py
@@ -157,10 +157,9 @@ class TestFolderResponseModel:
         assert model.name == data["name"]
         assert model.parent == ""  # Empty parent for root folder
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = FolderResponseModelFactory.build_valid()
-        data["unknown_field"] = "should_fail"
-        with pytest.raises(ValidationError) as exc_info:
-            FolderResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        data["unknown_field"] = "should_be_ignored"
+        model = FolderResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/setup/test_label.py
+++ b/tests/scm/models/setup/test_label.py
@@ -171,13 +171,12 @@ class TestLabelResponseModel:
         if create_model.description:
             assert response_model.description == create_model.description
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426655440000",
             "name": "test_label",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            LabelResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = LabelResponseModel(**data)
+        assert not hasattr(model, "unknown_field")

--- a/tests/scm/models/setup/test_snippet.py
+++ b/tests/scm/models/setup/test_snippet.py
@@ -260,16 +260,15 @@ class TestSnippetResponseModel:
 
         assert model.type == "custom"
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426614174000",
             "name": "test_snippet",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            SnippetResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = SnippetResponseModel(**data)
+        assert not hasattr(model, "unknown_field")
 
 
 class TestFolderReference:

--- a/tests/scm/models/setup/test_variable.py
+++ b/tests/scm/models/setup/test_variable.py
@@ -165,7 +165,9 @@ class TestVariableCreateModel:
         }
         with pytest.raises(ValueError) as exc_info:
             VariableCreateModel.model_validate(data)
-        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(exc_info.value)
+        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(
+            exc_info.value
+        )
 
     def test_model_validate_with_multiple_containers_fails(self):
         """Test model_validate fails when multiple containers are provided."""
@@ -178,7 +180,9 @@ class TestVariableCreateModel:
         }
         with pytest.raises(ValueError) as exc_info:
             VariableCreateModel.model_validate(data)
-        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(exc_info.value)
+        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(
+            exc_info.value
+        )
 
 
 class TestVariableUpdateModel:
@@ -252,7 +256,9 @@ class TestVariableUpdateModel:
         }
         with pytest.raises(ValueError) as exc_info:
             VariableUpdateModel.model_validate(data)
-        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(exc_info.value)
+        assert "Exactly one of 'folder', 'snippet', or 'device' must be provided" in str(
+            exc_info.value
+        )
 
 
 class TestVariableResponseModel:
@@ -321,16 +327,15 @@ class TestVariableResponseModel:
             model = VariableResponseModelFactory.build(type=valid_type)
             assert model.type == valid_type
 
-    def test_extra_fields_forbidden(self):
-        """Test that extra fields are rejected on ResponseModel."""
+    def test_extra_fields_ignored(self):
+        """Test that extra fields are silently ignored on ResponseModel."""
         data = {
             "id": "123e4567-e89b-12d3-a456-426614174000",
             "name": "test_variable",
             "type": "ip-netmask",
             "value": "192.168.1.0/24",
             "folder": "test_folder",
-            "unknown_field": "should_fail",
+            "unknown_field": "should_be_ignored",
         }
-        with pytest.raises(ValidationError) as exc_info:
-            VariableResponseModel(**data)
-        assert "Extra inputs are not permitted" in str(exc_info.value)
+        model = VariableResponseModel(**data)
+        assert not hasattr(model, "unknown_field")


### PR DESCRIPTION
## Summary

- Migrate all 50 `*ResponseModel` classes from `extra="forbid"` to `extra="ignore"` so the SDK gracefully handles new API fields instead of crashing with `ValidationError`
- Fix `EthernetInterface.list()` crash caused by missing `slot` field on PA-5000/PA-7000 series responses
- Fix `snippet.associate_folder()` making a failing API call before raising `NotImplementedError`
- Fix `tag.list()` validation errors from `extra="forbid"` rejecting unknown API response fields

## Details

**Root cause:** All ResponseModel classes inherited `extra="forbid"` from their BaseModel parents. When the SCM API returned any field not explicitly declared in the model, Pydantic raised a `ValidationError`. This caused 3 known bugs and made every service fragile to API evolution.

**Fix:** Override `model_config` on each ResponseModel with `extra="ignore"`. Unknown API fields are silently discarded. `*CreateModel` and `*UpdateModel` classes retain `extra="forbid"` for strict input validation — no change to request-side behavior.

**Scope:** 90 files changed across 48 model files, 32 test files, plus CHANGELOG, release notes, and version bump.

## Test plan

- [x] All 3,548 unit tests pass (0 failures)
- [x] All pre-commit hooks pass (ruff, ruff-format, trailing whitespace, ast check)
- [x] Live API verification against SCM tenant: 28/28 services return data without model errors
- [x] `EthernetInterface.list()` no longer crashes on slot field
- [x] `tag.list()` returns tags without validation errors (7 tags verified)
- [x] `snippet.associate_folder()` raises `NotImplementedError` immediately (no API call made)
- [x] All `*CreateModel`/`*UpdateModel` classes still reject extra fields (`extra="forbid"` preserved)
- [x] Version bumped to 0.5.0 in `pyproject.toml`
- [x] CHANGELOG.md updated
- [x] `docs/about/release-notes.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)