### PR TITLE
fix: preserve extra="allow" on Device and Application response models

### DIFF
--- a/scm/models/objects/application.py
+++ b/scm/models/objects/application.py
@@ -191,7 +191,7 @@ class ApplicationResponseModel(ApplicationBaseModel):
     """
 
     model_config = ConfigDict(
-        extra="ignore",
+        extra="allow",
         validate_assignment=True,
         arbitrary_types_allowed=True,
         populate_by_name=True,

--- a/scm/models/setup/device.py
+++ b/scm/models/setup/device.py
@@ -196,7 +196,7 @@ class DeviceResponseModel(DeviceBaseModel):
     vm_state: Optional[str] = Field(None, description="VM state.")
 
     model_config = ConfigDict(
-        extra="ignore",
+        extra="allow",
         populate_by_name=True,
     )
 
@@ -205,7 +205,7 @@ class DeviceListResponseModel(BaseModel):
     """Model for the paginated response from GET /devices."""
 
     model_config = ConfigDict(
-        extra="ignore",
+        extra="allow",
         populate_by_name=True,
     )
 

--- a/tests/scm/models/setup/test_device.py
+++ b/tests/scm/models/setup/test_device.py
@@ -157,9 +157,9 @@ class TestDeviceListResponseModel:
         assert isinstance(model.offset, int)
         assert isinstance(model.total, int)
 
-    def test_extra_fields_ignored(self):
-        """Test that extra fields are silently ignored on ResponseModel."""
+    def test_extra_fields_allowed(self):
+        """Test that extra fields are allowed on DeviceListResponseModel (API compatibility)."""
         data = DeviceListResponseModelDictFactory.build()
-        data["unknown_field"] = "should_be_ignored"
+        data["unknown_field"] = "should_be_allowed"
         model = DeviceListResponseModel.model_validate(data)
-        assert not hasattr(model, "unknown_field")
+        assert hasattr(model, "__pydantic_extra__")


### PR DESCRIPTION
## Summary

- Revert `DeviceResponseModel`, `DeviceListResponseModel`, and `ApplicationResponseModel` from `extra="ignore"` back to `extra="allow"`

## Details

The v0.5.0 release migrated all ResponseModels from `extra="forbid"` to `extra="ignore"`. However, `DeviceResponseModel` and `ApplicationResponseModel` previously used `extra="allow"` intentionally — the API returns many undocumented fields (compliance flags, SaaS attributes, device metadata) that consumers may access via `__pydantic_extra__`.

Changing these two models to `extra="ignore"` silently drops those fields, which is a breaking change for anyone relying on them. This PR restores the original `extra="allow"` behavior for these specific models.

## Test plan

- [x] `test_device.py` - `test_extra_fields_allowed` passes
- [x] `test_application_models.py` - `test_application_response_model_extra_fields_allowed` passes
- [x] All 34 tests in affected files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)