### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-02-17
+
+### Fixed
+- **DeviceResponseModel & ApplicationResponseModel**: Restored `extra="allow"` on these two models that intentionally expose undocumented API fields via `__pydantic_extra__`. The v0.5.0 migration incorrectly changed them to `extra="ignore"` which silently dropped extra fields.
+
 ## [0.5.0] - 2026-02-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version to 0.5.1
- Add v0.5.1 entry to CHANGELOG.md documenting the `extra="allow"` fix from PR #236

## Test plan

- [x] No code changes, version and changelog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)