### PR TITLE
chore: fix PyPI version badge showing stale 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Banner Image](https://raw.githubusercontent.com/cdot65/pan-scm-sdk/main/docs/images/logo.svg)
 [![codecov](https://codecov.io/github/cdot65/pan-scm-sdk/graph/badge.svg?token=BB39SMLYFP)](https://codecov.io/github/cdot65/pan-scm-sdk)
 [![Build Status](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml)
-[![PyPI version](https://badge.fury.io/py/pan-scm-sdk.svg)](https://badge.fury.io/py/pan-scm-sdk)
+[![PyPI version](https://img.shields.io/pypi/v/pan-scm-sdk.svg)](https://pypi.org/project/pan-scm-sdk/)
 [![Python versions](https://img.shields.io/pypi/pyversions/pan-scm-sdk.svg)](https://pypi.org/project/pan-scm-sdk/)
 [![License](https://img.shields.io/github/license/cdot65/pan-scm-sdk.svg)](https://github.com/cdot65/pan-scm-sdk/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cdot65/pan-scm-sdk)


### PR DESCRIPTION
## Summary
- Replace `badge.fury.io` PyPI version badge with `shields.io` badge
- PyPI caches badge images at upload time, so the old badge was frozen at 0.4.1 despite the package being at 0.7.0
- The `shields.io` badge fetches the version dynamically from PyPI's API on each page load

## Test plan
- [ ] Verify the badge on the GitHub README renders correctly with 0.7.0
- [ ] After merge + re-publish, verify the PyPI project description page shows the correct version badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)