### PR TITLE
fix: implement AutoTagActions service and make DecryptionRule action optional

### DIFF
--- a/scm/config/objects/__init__.py
+++ b/scm/config/objects/__init__.py
@@ -1,6 +1,7 @@
 """scm.config.objects: Object resource service classes."""
 # scm/config/objects/__init__.py
 
+from .auto_tag_actions import AutoTagActions
 from .address import Address
 from .address_group import AddressGroup
 from .application import Application
@@ -21,6 +22,7 @@ from .syslog_server_profiles import SyslogServerProfile
 from .tag import Tag
 
 __all__ = [
+    "AutoTagActions",
     "Address",
     "AddressGroup",
     "Application",

--- a/scm/config/objects/auto_tag_actions.py
+++ b/scm/config/objects/auto_tag_actions.py
@@ -5,347 +5,386 @@ Provides service class for managing auto tag action objects via the SCM API.
 
 # scm/config/objects/auto_tag_actions.py
 
-#
-# # Standard library imports
-# import logging
-# from typing import List, Dict, Any, Optional
-#
-# # Local SDK imports
-# from scm.config import BaseObject
-# from scm.exceptions import (
-#     InvalidObjectError,
-#     MissingQueryParameterError,
-# )
-# from scm.models.objects.auto_tag_actions import (
-#     AutoTagActionCreateModel,
-#     AutoTagActionUpdateModel,
-#     AutoTagActionResponseModel,
-# )
-#
-#
-# class AutoTagAction(BaseObject):
-#     """
-#     Manages Auto-Tag Action objects in Palo Alto Networks' Strata Cloud Manager.
-#     """
-#
-#     ENDPOINT = "/config/objects/v1/auto-tag-actions"
-#     DEFAULT_LIMIT = 10000
-#
-#     def __init__(
-#         self,
-#         api_client,
-#     ):
-#         super().__init__(api_client)
-#         self.logger = logging.getLogger(__name__)
-#
-#     def create(
-#         self,
-#         data: Dict[str, Any],
-#     ) -> AutoTagActionResponseModel:
-#         """
-#         Creates a new Auto-Tag Action object.
-#
-#         Returns:
-#             AutoTagActionResponseModel
-#         """
-#         # Use the dictionary "data" to pass into Pydantic and return a modeled object
-#         auto_tag_action = AutoTagActionCreateModel(**data)
-#
-#         # Convert back to a Python dictionary, removing any unset fields
-#         payload = auto_tag_action.model_dump(exclude_unset=True)
-#
-#         # Send the updated object to the remote API as JSON, expecting a dictionary object to be returned
-#         response: Dict[str, Any] = self.api_client.post(
-#             self.ENDPOINT,
-#             json=payload,
-#         )
-#
-#         # Return the SCM API response as a new Pydantic object
-#         return AutoTagActionResponseModel(**response)
-#
-#     def update(
-#         self,
-#         auto_tag_action: AutoTagActionUpdateModel,
-#     ) -> AutoTagActionResponseModel:
-#         """
-#         Updates an existing auto-tag action object.
-#
-#         Args:
-#             auto_tag_action: AutoTagActionUpdateModel instance containing the update data
-#
-#         Returns:
-#             AutoTagActionResponseModel
-#         """
-#         # Convert to dict for API request, excluding unset fields
-#         payload = auto_tag_action.model_dump(exclude_unset=True)
-#
-#         # Note: The API requires name to identify the object; no endpoint for id-based updates
-#         if "id" in payload:
-#             payload.pop("id", None)
-#
-#         # Send the updated object to the remote API as JSON
-#         response: Dict[str, Any] = self.api_client.put(
-#             self.ENDPOINT,
-#             json=payload,
-#         )
-#
-#         # Return the SCM API response as a new Pydantic object
-#         return AutoTagActionResponseModel(**response)
-#
-#     @staticmethod
-#     def _apply_filters(
-#         auto_tag_actions: List[AutoTagActionResponseModel],
-#         filters: Dict[str, Any],
-#     ) -> List[AutoTagActionResponseModel]:
-#         """
-#         Apply client-side filtering to the list of auto-tag actions.
-#
-#         Args:
-#             auto_tag_actions: List of AutoTagActionResponseModel objects
-#             filters: Dictionary of filter criteria
-#
-#         Returns:
-#             List[AutoTagActionResponseModel]: Filtered list of auto-tag actions
-#         """
-#         # No filters defined in this specification
-#         return auto_tag_actions
-#
-#     @staticmethod
-#     def _build_container_params(
-#         folder: Optional[str],
-#         snippet: Optional[str],
-#         device: Optional[str],
-#     ) -> dict:
-#         """Builds container parameters dictionary."""
-#         return {
-#             k: v
-#             for k, v in {"folder": folder, "snippet": snippet, "device": device}.items()
-#             if v is not None
-#         }
-#
-#     def list(
-#         self,
-#         folder: Optional[str] = None,
-#         snippet: Optional[str] = None,
-#         device: Optional[str] = None,
-#         **filters,
-#     ) -> List[AutoTagActionResponseModel]:
-#         """
-#         Lists auto-tag action objects with optional filtering.
-#
-#         Args:
-#             folder: Optional folder name
-#             snippet: Optional snippet name
-#             device: Optional device name
-#             **filters: Additional filters (no filters defined for auto-tag actions)
-#
-#         Returns:
-#             List[AutoTagActionResponseModel]: A list of auto-tag action objects
-#         """
-#         if folder == "":
-#             raise MissingQueryParameterError(
-#                 message="Field 'folder' cannot be empty",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={
-#                     "field": "folder",
-#                     "error": '"folder" is not allowed to be empty',
-#                 },
-#             )
-#
-#
-#
-#         container_parameters = self._build_container_params(
-#             folder,
-#             snippet,
-#             device,
-#         )
-#
-#         if len(container_parameters) != 1:
-#             raise InvalidObjectError(
-#                 message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={"error": "Invalid container parameters"},
-#             )
-#
-#
-#
-#         response = self.api_client.get(
-#             self.ENDPOINT,
-#             params=params,
-#         )
-#
-#         if not isinstance(response, dict):
-#             raise InvalidObjectError(
-#                 message="Invalid response format: expected dictionary",
-#                 error_code="E003",
-#                 http_status_code=500,
-#                 details={"error": "Response is not a dictionary"},
-#             )
-#
-#         if "data" not in response:
-#             raise InvalidObjectError(
-#                 message="Invalid response format: missing 'data' field",
-#                 error_code="E003",
-#                 http_status_code=500,
-#                 details={
-#                     "field": "data",
-#                     "error": '"data" field missing in the response',
-#                 },
-#             )
-#
-#         if not isinstance(response["data"], list):
-#             raise InvalidObjectError(
-#                 message="Invalid response format: 'data' field must be a list",
-#                 error_code="E003",
-#                 http_status_code=500,
-#                 details={
-#                     "field": "data",
-#                     "error": '"data" field must be a list',
-#                 },
-#             )
-#
-#         auto_tag_actions = [
-#             AutoTagActionResponseModel(**item) for item in response["data"]
-#         ]
-#
-#         return self._apply_filters(
-#             auto_tag_actions,
-#             filters,
-#         )
-#
-#     def fetch(
-#         self,
-#         name: str,
-#         folder: Optional[str] = None,
-#         snippet: Optional[str] = None,
-#         device: Optional[str] = None,
-#     ) -> AutoTagActionResponseModel:
-#         """
-#         Fetches a single auto-tag action by name.
-#
-#         Args:
-#             name: The name of the auto-tag action to fetch
-#             folder: Optional folder name
-#             snippet: Optional snippet name
-#             device: Optional device name
-#
-#         Returns:
-#             AutoTagActionResponseModel: The fetched auto-tag action object
-#         """
-#         if not name:
-#             raise MissingQueryParameterError(
-#                 message="Field 'name' cannot be empty",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={
-#                     "field": "name",
-#                     "error": '"name" is not allowed to be empty',
-#                 },
-#             )
-#
-#         if folder == "":
-#             raise MissingQueryParameterError(
-#                 message="Field 'folder' cannot be empty",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={
-#                     "field": "folder",
-#                     "error": '"folder" is not allowed to be empty',
-#                 },
-#             )
-#
-#         params = {}
-#
-#         container_parameters = self._build_container_params(
-#             folder,
-#             snippet,
-#             device,
-#         )
-#
-#         if len(container_parameters) != 1:
-#             raise InvalidObjectError(
-#                 message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={
-#                     "error": "Exactly one of 'folder', 'snippet', or 'device' must be provided."
-#                 },
-#             )
-#
-#         params.update(container_parameters)
-#         params["name"] = name
-#
-#         response = self.api_client.get(
-#             self.ENDPOINT,
-#             params=params,
-#         )
-#
-#         if not isinstance(response, dict):
-#             raise InvalidObjectError(
-#                 message="Invalid response format: expected dictionary",
-#                 error_code="E003",
-#                 http_status_code=500,
-#                 details={"error": "Response is not a dictionary"},
-#             )
-#
-#         if "id" in response:
-#             return AutoTagActionResponseModel(**response)
-#         else:
-#             raise InvalidObjectError(
-#                 message="Invalid response format: missing 'id' field",
-#                 error_code="E003",
-#                 http_status_code=500,
-#                 details={"error": "Response missing 'id' field"},
-#             )
-#
-#     def delete(
-#         self,
-#         name: str,
-#         folder: Optional[str] = None,
-#         snippet: Optional[str] = None,
-#         device: Optional[str] = None,
-#     ) -> None:
-#         """
-#         Deletes an auto-tag action object by name.
-#
-#         Args:
-#             name: The name of the auto-tag action to delete
-#             folder: Optional folder name
-#             snippet: Optional snippet name
-#             device: Optional device name
-#         """
-#         if not name:
-#             raise MissingQueryParameterError(
-#                 message="Field 'name' cannot be empty",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={
-#                     "field": "name",
-#                     "error": '"name" is not allowed to be empty',
-#                 },
-#             )
-#
-#         container_parameters = self._build_container_params(
-#             folder,
-#             snippet,
-#             device,
-#         )
-#
-#         if len(container_parameters) != 1:
-#             raise InvalidObjectError(
-#                 message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
-#                 error_code="E003",
-#                 http_status_code=400,
-#                 details={"error": "Invalid container parameters"},
-#             )
-#
-#         params = {}
-#         params.update(container_parameters)
-#         params["name"] = name
-#
-#         self.api_client.delete(
-#             self.ENDPOINT,
-#             params=params,
-#         )
+# Standard library imports
+import logging
+from typing import Any, Dict, List, Optional
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import (
+    InvalidObjectError,
+    MissingQueryParameterError,
+)
+from scm.models.objects.auto_tag_actions import (
+    AutoTagActionCreateModel,
+    AutoTagActionResponseModel,
+    AutoTagActionUpdateModel,
+)
+
+
+class AutoTagActions(BaseObject):
+    """Manages Auto-Tag Action objects in Palo Alto Networks' Strata Cloud Manager.
+
+    Args:
+        api_client: The API client instance
+        max_limit (Optional[int]): Maximum number of objects to return in a single API request.
+            Defaults to 2500. Must be between 1 and 5000.
+
+    """
+
+    ENDPOINT = "/config/objects/v1/auto-tag-actions"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000
+
+    def __init__(
+        self,
+        api_client,
+        max_limit: Optional[int] = None,
+    ):
+        """Initialize the AutoTagActions service with the given API client."""
+        super().__init__(api_client)
+        self.logger = logging.getLogger(__name__)
+        self._max_limit = self._validate_max_limit(max_limit)
+
+    @property
+    def max_limit(self) -> int:
+        """Get the current maximum limit for API requests."""
+        return self._max_limit
+
+    @max_limit.setter
+    def max_limit(self, value: int) -> None:
+        """Set a new maximum limit for API requests."""
+        self._max_limit = self._validate_max_limit(value)
+
+    def _validate_max_limit(self, limit: Optional[int]) -> int:
+        """Validate the max_limit parameter."""
+        if limit is None:
+            return self.DEFAULT_MAX_LIMIT
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            raise InvalidObjectError(
+                message="max_limit must be an integer",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit type"},
+            )
+
+        if limit_int < 1:
+            raise InvalidObjectError(
+                message="max_limit must be greater than 0",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit value"},
+            )
+
+        if limit_int > self.ABSOLUTE_MAX_LIMIT:
+            raise InvalidObjectError(
+                message=f"max_limit cannot exceed {self.ABSOLUTE_MAX_LIMIT}",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "max_limit exceeds maximum allowed value"},
+            )
+
+        return limit_int
+
+    def create(
+        self,
+        data: Dict[str, Any],
+    ) -> AutoTagActionResponseModel:
+        """Create a new auto tag action object.
+
+        Returns:
+            AutoTagActionResponseModel
+
+        """
+        auto_tag_action = AutoTagActionCreateModel(**data)
+        payload = auto_tag_action.model_dump(exclude_unset=True)
+
+        response: Dict[str, Any] = self.api_client.post(
+            self.ENDPOINT,
+            json=payload,
+        )
+
+        return AutoTagActionResponseModel(**response)
+
+    def get(
+        self,
+        object_id: str,
+    ) -> AutoTagActionResponseModel:
+        """Get an auto tag action object by ID.
+
+        Returns:
+            AutoTagActionResponseModel
+
+        """
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        response: Dict[str, Any] = self.api_client.get(endpoint)
+        return AutoTagActionResponseModel(**response)
+
+    def update(
+        self,
+        auto_tag_action: AutoTagActionUpdateModel,
+    ) -> AutoTagActionResponseModel:
+        """Update an existing auto tag action object.
+
+        Args:
+            auto_tag_action: AutoTagActionUpdateModel instance containing the update data
+
+        Returns:
+            AutoTagActionResponseModel
+
+        """
+        payload = auto_tag_action.model_dump(exclude_unset=True)
+
+        object_id = str(auto_tag_action.id)
+        payload.pop("id", None)
+
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        response: Dict[str, Any] = self.api_client.put(
+            endpoint,
+            json=payload,
+        )
+
+        return AutoTagActionResponseModel(**response)
+
+    @staticmethod
+    def _apply_filters(
+        auto_tag_actions: List[AutoTagActionResponseModel],
+        filters: Dict[str, Any],
+    ) -> List[AutoTagActionResponseModel]:
+        """Apply client-side filtering to the list of auto-tag actions."""
+        return auto_tag_actions
+
+    @staticmethod
+    def _build_container_params(
+        folder: Optional[str],
+        snippet: Optional[str],
+        device: Optional[str],
+    ) -> dict:
+        """Build container parameters dictionary."""
+        return {
+            k: v
+            for k, v in {"folder": folder, "snippet": snippet, "device": device}.items()
+            if v is not None
+        }
+
+    def list(
+        self,
+        folder: Optional[str] = None,
+        snippet: Optional[str] = None,
+        device: Optional[str] = None,
+        exact_match: bool = False,
+        exclude_folders: Optional[List[str]] = None,
+        exclude_snippets: Optional[List[str]] = None,
+        exclude_devices: Optional[List[str]] = None,
+        **filters,
+    ) -> List[AutoTagActionResponseModel]:
+        """List auto tag action objects with optional filtering.
+
+        Args:
+            folder: Optional folder name
+            snippet: Optional snippet name
+            device: Optional device name
+            exact_match: If True, only return objects whose container exactly matches
+            exclude_folders: List of folder names to exclude from results
+            exclude_snippets: List of snippet values to exclude from results
+            exclude_devices: List of device values to exclude from results
+            **filters: Additional filters
+
+        Returns:
+            List[AutoTagActionResponseModel]: A list of auto tag action objects
+
+        """
+        if folder == "":
+            raise MissingQueryParameterError(
+                message="Field 'folder' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "folder",
+                    "error": '"folder" is not allowed to be empty',
+                },
+            )
+
+        container_parameters = self._build_container_params(
+            folder,
+            snippet,
+            device,
+        )
+
+        if len(container_parameters) != 1:
+            raise InvalidObjectError(
+                message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid container parameters"},
+            )
+
+        # Pagination logic
+        limit = self._max_limit
+        offset = 0
+        all_objects = []
+
+        while True:
+            params = container_parameters.copy()
+            params["limit"] = limit
+            params["offset"] = offset
+
+            response = self.api_client.get(
+                self.ENDPOINT,
+                params=params,
+            )
+
+            if not isinstance(response, dict):
+                raise InvalidObjectError(
+                    message="Invalid response format: expected dictionary",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={"error": "Response is not a dictionary"},
+                )
+
+            if "data" not in response:
+                raise InvalidObjectError(
+                    message="Invalid response format: missing 'data' field",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={
+                        "field": "data",
+                        "error": '"data" field missing in the response',
+                    },
+                )
+
+            if not isinstance(response["data"], list):
+                raise InvalidObjectError(
+                    message="Invalid response format: 'data' field must be a list",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={
+                        "field": "data",
+                        "error": '"data" field must be a list',
+                    },
+                )
+
+            data = response["data"]
+            object_instances = [AutoTagActionResponseModel(**item) for item in data]
+            all_objects.extend(object_instances)
+
+            if len(data) < limit:
+                break
+
+            offset += limit
+
+        filtered_objects = self._apply_filters(
+            all_objects,
+            filters,
+        )
+
+        container_key, container_value = next(iter(container_parameters.items()))
+
+        if exact_match:
+            filtered_objects = [
+                each for each in filtered_objects if getattr(each, container_key) == container_value
+            ]
+
+        if exclude_folders and isinstance(exclude_folders, list):
+            filtered_objects = [
+                each for each in filtered_objects if each.folder not in exclude_folders
+            ]
+
+        if exclude_snippets and isinstance(exclude_snippets, list):
+            filtered_objects = [
+                each for each in filtered_objects if each.snippet not in exclude_snippets
+            ]
+
+        if exclude_devices and isinstance(exclude_devices, list):
+            filtered_objects = [
+                each for each in filtered_objects if each.device not in exclude_devices
+            ]
+
+        return filtered_objects
+
+    def fetch(
+        self,
+        name: str,
+        folder: Optional[str] = None,
+        snippet: Optional[str] = None,
+        device: Optional[str] = None,
+    ) -> AutoTagActionResponseModel:
+        """Fetch a single auto tag action by name.
+
+        Args:
+            name: The name of the auto tag action to fetch
+            folder: Optional folder name
+            snippet: Optional snippet name
+            device: Optional device name
+
+        Returns:
+            AutoTagActionResponseModel
+
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={"field": "name", "error": '"name" is not allowed to be empty'},
+            )
+
+        if folder == "":
+            raise MissingQueryParameterError(
+                message="Field 'folder' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "folder",
+                    "error": '"folder" is not allowed to be empty',
+                },
+            )
+
+        params = {}
+        container_parameters = self._build_container_params(folder, snippet, device)
+
+        if len(container_parameters) != 1:
+            raise InvalidObjectError(
+                message="Exactly one of 'folder', 'snippet', or 'device' must be provided.",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "error": "Exactly one of 'folder', 'snippet', or 'device' must be provided."
+                },
+            )
+
+        params.update(container_parameters)
+        params["name"] = name
+
+        response = self.api_client.get(self.ENDPOINT, params=params)
+
+        if not isinstance(response, dict):
+            raise InvalidObjectError(
+                message="Invalid response format: expected dictionary",
+                error_code="E003",
+                http_status_code=500,
+                details={"error": "Response is not a dictionary"},
+            )
+
+        if "id" in response:
+            return AutoTagActionResponseModel(**response)
+        else:
+            raise InvalidObjectError(
+                message="Invalid response format: missing 'id' field",
+                error_code="E003",
+                http_status_code=500,
+                details={"error": "Response missing 'id' field"},
+            )
+
+    def delete(self, object_id: str) -> None:
+        """Delete an auto tag action object.
+
+        Args:
+            object_id: The ID of the object to delete.
+
+        """
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        self.api_client.delete(endpoint)

--- a/scm/models/objects/__init__.py
+++ b/scm/models/objects/__init__.py
@@ -2,6 +2,11 @@
 # scm/models/objects/__init__.py
 
 from .address import AddressCreateModel, AddressResponseModel, AddressUpdateModel
+from .auto_tag_actions import (
+    AutoTagActionCreateModel,
+    AutoTagActionResponseModel,
+    AutoTagActionUpdateModel,
+)
 from .address_group import (
     AddressGroupCreateModel,
     AddressGroupResponseModel,
@@ -91,6 +96,9 @@ from .tag import (
 )
 
 __all__ = [
+    "AutoTagActionCreateModel",
+    "AutoTagActionUpdateModel",
+    "AutoTagActionResponseModel",
     "AddressCreateModel",
     "AddressUpdateModel",
     "AddressResponseModel",

--- a/scm/models/objects/auto_tag_actions.py
+++ b/scm/models/objects/auto_tag_actions.py
@@ -1,0 +1,172 @@
+"""Auto Tag Actions models for Strata Cloud Manager SDK.
+
+Contains Pydantic models for representing auto tag action objects and related data.
+"""
+
+# scm/models/objects/auto_tag_actions.py
+
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class TaggingModel(BaseModel):
+    """Model for tagging action settings."""
+
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+
+    action: Optional[str] = Field(
+        None,
+        description="Tagging action: 'add-tag' or 'remove-tag'",
+    )
+    target: Optional[str] = Field(
+        None,
+        description="Target: 'source-address' or 'destination-address'",
+    )
+    tags: Optional[List[str]] = Field(
+        None,
+        description="List of tags to apply or remove",
+    )
+    timeout: Optional[int] = Field(
+        None,
+        description="Duration in seconds for tag application",
+    )
+
+
+class ActionTypeModel(BaseModel):
+    """Model for action type containing tagging settings."""
+
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+
+    tagging: Optional[TaggingModel] = Field(
+        None,
+        description="Tagging configuration for this action",
+    )
+
+
+class ActionModel(BaseModel):
+    """Model for an individual action within an auto tag action."""
+
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+    )
+
+    name: str = Field(
+        ...,
+        description="The name of the action",
+    )
+    type: Optional[ActionTypeModel] = Field(
+        None,
+        description="The type configuration for this action",
+    )
+
+
+class AutoTagActionBaseModel(BaseModel):
+    """Base model for Auto Tag Action objects."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    name: str = Field(
+        ...,
+        max_length=63,
+        description="The name of the auto tag action",
+        pattern=r"^[a-zA-Z0-9_ \.\-]+$",
+    )
+    description: Optional[str] = Field(
+        None,
+        max_length=1023,
+        description="The description of the auto tag action",
+    )
+    actions: Optional[List[ActionModel]] = Field(
+        None,
+        description="List of actions to perform",
+    )
+    filter: Optional[str] = Field(
+        None,
+        description="Log filter string that triggers the action",
+    )
+    log_type: Optional[str] = Field(
+        None,
+        description="The type of log that triggers this action",
+    )
+    quarantine: Optional[bool] = Field(
+        None,
+        description="Whether to quarantine the device",
+    )
+    send_to_panorama: Optional[bool] = Field(
+        None,
+        description="Whether to send the tag action to Panorama",
+    )
+
+    # Container Types
+    folder: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z\d\-_. ]+$",
+        max_length=64,
+        description="The folder in which the resource is defined",
+    )
+    snippet: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z\d\-_. ]+$",
+        max_length=64,
+        description="The snippet in which the resource is defined",
+    )
+    device: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z\d\-_. ]+$",
+        max_length=64,
+        description="The device in which the resource is defined",
+    )
+
+
+class AutoTagActionCreateModel(AutoTagActionBaseModel):
+    """Model for creating a new Auto Tag Action."""
+
+    @model_validator(mode="after")
+    def validate_container_type(self) -> "AutoTagActionCreateModel":
+        """Ensure exactly one container field is set."""
+        container_fields = ["folder", "snippet", "device"]
+        provided = [f for f in container_fields if getattr(self, f) is not None]
+        if len(provided) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be provided.")
+        return self
+
+
+class AutoTagActionUpdateModel(AutoTagActionBaseModel):
+    """Model for updating an existing Auto Tag Action."""
+
+    id: Optional[UUID] = Field(
+        None,
+        description="The UUID of the auto tag action",
+        examples=["123e4567-e89b-12d3-a456-426655440000"],
+    )
+
+
+class AutoTagActionResponseModel(AutoTagActionBaseModel):
+    """Model for Auto Tag Action responses."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    id: Optional[UUID] = Field(
+        None,
+        description="The UUID of the auto tag action",
+        examples=["123e4567-e89b-12d3-a456-426655440000"],
+    )

--- a/scm/models/security/decryption_rules.py
+++ b/scm/models/security/decryption_rules.py
@@ -96,8 +96,8 @@ class DecryptionRuleBaseModel(BaseModel):
     name: str = Field(
         ..., description="The name of the decryption rule", pattern=r"^[a-zA-Z0-9_ \.-]+$"
     )
-    action: DecryptionRuleAction = Field(
-        ...,
+    action: Optional[DecryptionRuleAction] = Field(
+        None,
         description="The action to be taken when the rule is matched",
     )
     description: Optional[str] = Field(None, description="The description of the decryption rule")

--- a/tests/factories/objects/auto_tag_actions.py
+++ b/tests/factories/objects/auto_tag_actions.py
@@ -1,0 +1,192 @@
+# tests/factories/objects/auto_tag_actions.py
+
+"""Factory definitions for auto tag action objects."""
+
+# Standard library imports
+from typing import Any, Dict, Union
+from uuid import uuid4
+
+# External libraries
+import factory
+from faker import Faker
+
+# Local SDK imports
+from scm.models.objects.auto_tag_actions import (
+    AutoTagActionBaseModel,
+    AutoTagActionCreateModel,
+    AutoTagActionResponseModel,
+    AutoTagActionUpdateModel,
+)
+
+fake = Faker()
+
+
+class AutoTagActionBaseFactory(factory.Factory):
+    """Base factory for AutoTagAction objects with common fields."""
+
+    class Meta:
+        """Meta class that defines the model for AutoTagActionBaseFactory."""
+
+        model = AutoTagActionBaseModel
+        abstract = True
+
+    name = factory.Sequence(lambda n: f"auto_tag_action_{n}")
+    description = fake.sentence()
+    folder = None
+    snippet = None
+    device = None
+
+
+class AutoTagActionCreateApiFactory(AutoTagActionBaseFactory):
+    """Factory for creating AutoTagActionCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AutoTagActionCreateApiFactory."""
+
+        model = AutoTagActionCreateModel
+
+    folder = "Texas"
+
+    @classmethod
+    def with_folder(cls, folder="Texas", **kwargs):
+        """Create an auto tag action with a specific folder."""
+        return cls(folder=folder, snippet=None, device=None, **kwargs)
+
+    @classmethod
+    def with_snippet(cls, snippet="TestSnippet", **kwargs):
+        """Create an auto tag action with a snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device="TestDevice", **kwargs):
+        """Create an auto tag action with a device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+    @classmethod
+    def build_with_multiple_containers(cls, **kwargs):
+        """Create an auto tag action with multiple containers (should fail)."""
+        return cls(folder="Texas", snippet="TestSnippet", device=None, **kwargs)
+
+    @classmethod
+    def build_with_no_container(cls, **kwargs):
+        """Create an auto tag action without any container (should fail)."""
+        return cls(folder=None, snippet=None, device=None, **kwargs)
+
+
+class AutoTagActionUpdateApiFactory(AutoTagActionBaseFactory):
+    """Factory for creating AutoTagActionUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AutoTagActionUpdateApiFactory."""
+
+        model = AutoTagActionUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid4()))
+
+
+class AutoTagActionResponseFactory(AutoTagActionBaseFactory):
+    """Factory for creating AutoTagActionResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AutoTagActionResponseFactory."""
+
+        model = AutoTagActionResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid4()))
+    folder = "Texas"
+
+    @classmethod
+    def with_folder(cls, folder="Texas", **kwargs):
+        """Create a response model with a specific folder."""
+        return cls(folder=folder, snippet=None, device=None, **kwargs)
+
+    @classmethod
+    def with_snippet(cls, snippet="TestSnippet", **kwargs):
+        """Create a response model with a snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device="TestDevice", **kwargs):
+        """Create a response model with a device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+    @classmethod
+    def from_request(
+        cls,
+        request_model: Union[AutoTagActionCreateModel, AutoTagActionUpdateModel, Dict[str, Any]],
+        **kwargs,
+    ) -> AutoTagActionResponseModel:
+        """Create a response model based on a request model."""
+        if isinstance(request_model, (AutoTagActionCreateModel, AutoTagActionUpdateModel)):
+            data = request_model.model_dump()
+        else:
+            data = request_model.copy()
+
+        if "id" not in data or not data["id"]:
+            data["id"] = str(uuid4())
+
+        data.update(kwargs)
+        return AutoTagActionResponseModel(**data)
+
+
+class AutoTagActionCreateModelFactory(factory.DictFactory):
+    """Factory for creating dictionary data for AutoTagActionCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"auto_tag_action_{n}")
+    description = fake.sentence()
+    folder = "Texas"
+    snippet = None
+    device = None
+
+    @classmethod
+    def build_valid(cls, **kwargs) -> Dict[str, Any]:
+        """Return a valid data dict with all expected attributes."""
+        data = {
+            "name": "TestAutoTagAction",
+            "description": "Test auto tag action",
+            "folder": "Texas",
+        }
+        data.update(kwargs)
+        return data
+
+    @classmethod
+    def build_with_multiple_containers(cls, **kwargs) -> Dict[str, Any]:
+        """Return a data dict with multiple containers (should fail validation)."""
+        data = {
+            "name": "TestAutoTagAction",
+            "folder": "Texas",
+            "snippet": "MySnippet",
+        }
+        data.update(kwargs)
+        return data
+
+    @classmethod
+    def build_with_no_container(cls, **kwargs) -> Dict[str, Any]:
+        """Return a data dict without any containers (should fail validation)."""
+        data = {
+            "name": "TestAutoTagAction",
+            "folder": None,
+            "snippet": None,
+            "device": None,
+        }
+        data.update(kwargs)
+        return data
+
+
+class AutoTagActionUpdateModelFactory(factory.DictFactory):
+    """Factory for creating dictionary data for AutoTagActionUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"auto_tag_action_{n}")
+    description = fake.sentence()
+
+    @classmethod
+    def build_valid(cls, **kwargs) -> Dict[str, Any]:
+        """Return a valid data dict for updating an auto tag action."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "UpdatedAutoTagAction",
+            "description": "Updated auto tag action",
+        }
+        data.update(kwargs)
+        return data

--- a/tests/scm/config/objects/test_auto_tag_actions.py
+++ b/tests/scm/config/objects/test_auto_tag_actions.py
@@ -1,0 +1,398 @@
+# tests/scm/config/objects/test_auto_tag_actions.py
+
+"""Tests for auto tag actions configuration objects."""
+
+# Standard library imports
+from unittest.mock import MagicMock
+
+# External libraries
+import pytest
+
+# Local SDK imports
+from scm.config.objects import AutoTagActions
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+from scm.models.objects import AutoTagActionResponseModel
+
+# Import factories
+from tests.factories.objects.auto_tag_actions import (
+    AutoTagActionCreateApiFactory,
+    AutoTagActionResponseFactory,
+    AutoTagActionUpdateApiFactory,
+)
+
+
+@pytest.mark.usefixtures("load_env")
+class TestAutoTagActionBase:
+    """Base class for AutoTagAction tests."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, mock_scm):
+        """Setup method that runs before each test."""
+        self.mock_scm = mock_scm  # noqa
+        self.mock_scm.get = MagicMock()
+        self.mock_scm.post = MagicMock()
+        self.mock_scm.put = MagicMock()
+        self.mock_scm.delete = MagicMock()
+        self.client = AutoTagActions(self.mock_scm, max_limit=5000)  # noqa
+
+
+class TestAutoTagActionMaxLimit(TestAutoTagActionBase):
+    """Tests for max_limit functionality."""
+
+    def test_default_max_limit(self):
+        """Test that default max_limit is set correctly."""
+        client = AutoTagActions(self.mock_scm)  # noqa
+        assert client.max_limit == AutoTagActions.DEFAULT_MAX_LIMIT
+        assert client.max_limit == 2500
+
+    def test_custom_max_limit(self):
+        """Test setting a custom max_limit."""
+        client = AutoTagActions(self.mock_scm, max_limit=1000)  # noqa
+        assert client.max_limit == 1000
+
+    def test_max_limit_setter(self):
+        """Test the max_limit property setter."""
+        client = AutoTagActions(self.mock_scm)  # noqa
+        client.max_limit = 3000
+        assert client.max_limit == 3000
+
+    def test_invalid_max_limit_type(self):
+        """Test that invalid max_limit type raises error."""
+        with pytest.raises(InvalidObjectError) as exc_info:
+            AutoTagActions(self.mock_scm, max_limit="invalid")  # noqa
+        assert "{'error': 'Invalid max_limit type'} - HTTP error: 400 - API error: E003" in str(
+            exc_info.value
+        )
+
+    def test_max_limit_too_low(self):
+        """Test that max_limit below 1 raises error."""
+        with pytest.raises(InvalidObjectError) as exc_info:
+            AutoTagActions(self.mock_scm, max_limit=0)  # noqa
+        assert "{'error': 'Invalid max_limit value'} - HTTP error: 400 - API error: E003" in str(
+            exc_info.value
+        )
+
+    def test_max_limit_too_high(self):
+        """Test that max_limit above ABSOLUTE_MAX_LIMIT raises error."""
+        with pytest.raises(InvalidObjectError) as exc_info:
+            AutoTagActions(self.mock_scm, max_limit=6000)  # noqa
+        assert "max_limit exceeds maximum allowed value" in str(exc_info.value)
+
+
+class TestAutoTagActionList(TestAutoTagActionBase):
+    """Tests for listing AutoTagAction objects."""
+
+    def test_list_valid(self):
+        """Test listing all auto tag actions without filters."""
+        mock_response = {
+            "data": [
+                AutoTagActionResponseFactory(
+                    name="TestAction1",
+                    folder="Texas",
+                ).model_dump(),
+                AutoTagActionResponseFactory(
+                    name="TestAction2",
+                    folder="Texas",
+                ).model_dump(),
+            ],
+            "offset": 0,
+            "total": 2,
+            "limit": 200,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        existing = self.client.list(folder="Texas")
+
+        self.mock_scm.get.assert_called_once_with(
+            "/config/objects/v1/auto-tag-actions",
+            params={
+                "limit": 5000,
+                "folder": "Texas",
+                "offset": 0,
+            },
+        )
+        assert isinstance(existing, list)
+        assert len(existing) == 2
+        assert existing[0].name == "TestAction1"
+        assert existing[1].name == "TestAction2"
+
+    def test_list_exact_match(self):
+        """Test exact_match=True ensures only objects with the exact folder match are returned."""
+        mock_response = {
+            "data": [
+                AutoTagActionResponseFactory.build(name="ExactMatch", folder="Texas").model_dump(),
+                AutoTagActionResponseFactory.build(name="Inherited", folder="All").model_dump(),
+            ],
+            "offset": 0,
+            "total": 2,
+            "limit": 200,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        result = self.client.list(folder="Texas", exact_match=True)
+        assert len(result) == 1
+        assert result[0].name == "ExactMatch"
+        assert result[0].folder == "Texas"
+
+    def test_list_exclude_folders(self):
+        """Test that exclude_folders filters out the specified folders."""
+        mock_response = {
+            "data": [
+                AutoTagActionResponseFactory.build(name="Action1", folder="Texas").model_dump(),
+                AutoTagActionResponseFactory.build(name="Action2", folder="All").model_dump(),
+            ],
+            "offset": 0,
+            "total": 2,
+            "limit": 200,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        result = self.client.list(folder="Texas", exclude_folders=["All"])
+        assert len(result) == 1
+        assert result[0].folder == "Texas"
+
+    def test_list_exclude_snippets(self):
+        """Test that exclude_snippets filters out the specified snippets."""
+        mock_response = {
+            "data": [
+                AutoTagActionResponseFactory.build(
+                    name="Action1", folder="Texas", snippet=None
+                ).model_dump(),
+                AutoTagActionResponseFactory.build(
+                    name="Action2", folder="Texas", snippet="default"
+                ).model_dump(),
+            ],
+            "offset": 0,
+            "total": 2,
+            "limit": 200,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        result = self.client.list(folder="Texas", exclude_snippets=["default"])
+        assert len(result) == 1
+        assert result[0].name == "Action1"
+
+    def test_list_exclude_devices(self):
+        """Test that exclude_devices filters out the specified devices."""
+        mock_response = {
+            "data": [
+                AutoTagActionResponseFactory.build(
+                    name="Action1", folder="Texas", device=None
+                ).model_dump(),
+                AutoTagActionResponseFactory.build(
+                    name="Action2", folder="Texas", device="DeviceA"
+                ).model_dump(),
+            ],
+            "offset": 0,
+            "total": 2,
+            "limit": 200,
+        }
+
+        self.mock_scm.get.return_value = mock_response
+        result = self.client.list(folder="Texas", exclude_devices=["DeviceA"])
+        assert len(result) == 1
+        assert result[0].name == "Action1"
+
+    def test_list_empty_folder_error(self):
+        """Test that empty folder raises MissingQueryParameterError."""
+        with pytest.raises(MissingQueryParameterError):
+            self.client.list(folder="")
+
+    def test_list_no_container_error(self):
+        """Test that no container raises InvalidObjectError."""
+        with pytest.raises(InvalidObjectError):
+            self.client.list()
+
+    def test_list_multiple_containers_error(self):
+        """Test that multiple containers raises InvalidObjectError."""
+        with pytest.raises(InvalidObjectError):
+            self.client.list(folder="Texas", snippet="MySnippet")
+
+    def test_list_response_not_dict(self):
+        """Test that non-dict response raises InvalidObjectError."""
+        self.mock_scm.get.return_value = "not a dict"
+        with pytest.raises(InvalidObjectError):
+            self.client.list(folder="Texas")
+
+    def test_list_response_missing_data(self):
+        """Test that response missing 'data' raises InvalidObjectError."""
+        self.mock_scm.get.return_value = {"total": 0}
+        with pytest.raises(InvalidObjectError):
+            self.client.list(folder="Texas")
+
+    def test_list_response_data_not_list(self):
+        """Test that response with non-list 'data' raises InvalidObjectError."""
+        self.mock_scm.get.return_value = {"data": "not a list"}
+        with pytest.raises(InvalidObjectError):
+            self.client.list(folder="Texas")
+
+    def test_list_pagination(self):
+        """Test that pagination works correctly."""
+        page1 = {
+            "data": [
+                AutoTagActionResponseFactory.build(name=f"Action{i}", folder="Texas").model_dump()
+                for i in range(5000)
+            ],
+            "offset": 0,
+            "total": 7000,
+            "limit": 5000,
+        }
+        page2 = {
+            "data": [
+                AutoTagActionResponseFactory.build(name=f"Action{i}", folder="Texas").model_dump()
+                for i in range(5000, 7000)
+            ],
+            "offset": 5000,
+            "total": 7000,
+            "limit": 5000,
+        }
+
+        self.mock_scm.get.side_effect = [page1, page2]
+        result = self.client.list(folder="Texas")
+        assert len(result) == 7000
+        assert self.mock_scm.get.call_count == 2
+
+
+class TestAutoTagActionCreate(TestAutoTagActionBase):
+    """Tests for creating AutoTagAction objects."""
+
+    def test_create_valid(self):
+        """Test creating a valid auto tag action."""
+        test_object = AutoTagActionCreateApiFactory.with_folder(
+            name="TestAction",
+            description="Test action",
+        )
+
+        mock_response = AutoTagActionResponseFactory.from_request(test_object)
+        self.mock_scm.post.return_value = mock_response.model_dump()
+
+        created = self.client.create(
+            test_object.model_dump(exclude_unset=True),
+        )
+
+        self.mock_scm.post.assert_called_once()
+        assert isinstance(created, AutoTagActionResponseModel)
+        assert created.name == "TestAction"
+        assert created.folder == "Texas"
+
+    def test_create_with_snippet(self):
+        """Test creating an auto tag action in a snippet container."""
+        test_object = AutoTagActionCreateApiFactory.with_snippet(
+            name="SnippetAction",
+        )
+
+        mock_response = AutoTagActionResponseFactory.from_request(test_object)
+        self.mock_scm.post.return_value = mock_response.model_dump()
+
+        created = self.client.create(
+            test_object.model_dump(exclude_unset=True),
+        )
+
+        assert isinstance(created, AutoTagActionResponseModel)
+        assert created.snippet == "TestSnippet"
+
+
+class TestAutoTagActionGet(TestAutoTagActionBase):
+    """Tests for getting AutoTagAction objects by ID."""
+
+    def test_get_valid(self):
+        """Test getting an auto tag action by ID."""
+        mock_response = AutoTagActionResponseFactory(
+            name="TestAction",
+            folder="Texas",
+        )
+        self.mock_scm.get.return_value = mock_response.model_dump()
+
+        object_id = str(mock_response.id)
+        result = self.client.get(object_id)
+
+        self.mock_scm.get.assert_called_once_with(
+            f"/config/objects/v1/auto-tag-actions/{object_id}"
+        )
+        assert isinstance(result, AutoTagActionResponseModel)
+        assert result.name == "TestAction"
+
+
+class TestAutoTagActionUpdate(TestAutoTagActionBase):
+    """Tests for updating AutoTagAction objects."""
+
+    def test_update_valid(self):
+        """Test updating an auto tag action."""
+        update_data = AutoTagActionUpdateApiFactory(
+            name="UpdatedAction",
+            description="Updated description",
+        )
+
+        mock_response = AutoTagActionResponseFactory.from_request(update_data)
+        self.mock_scm.put.return_value = mock_response.model_dump()
+
+        result = self.client.update(update_data)
+
+        self.mock_scm.put.assert_called_once()
+        assert isinstance(result, AutoTagActionResponseModel)
+        assert result.name == "UpdatedAction"
+
+
+class TestAutoTagActionDelete(TestAutoTagActionBase):
+    """Tests for deleting AutoTagAction objects."""
+
+    def test_delete_valid(self):
+        """Test deleting an auto tag action by ID."""
+        object_id = "123e4567-e89b-12d3-a456-426655440000"
+        self.client.delete(object_id)
+
+        self.mock_scm.delete.assert_called_once_with(
+            f"/config/objects/v1/auto-tag-actions/{object_id}"
+        )
+
+
+class TestAutoTagActionFetch(TestAutoTagActionBase):
+    """Tests for fetching AutoTagAction objects by name."""
+
+    def test_fetch_valid(self):
+        """Test fetching an auto tag action by name."""
+        mock_response = AutoTagActionResponseFactory(
+            name="TestAction",
+            folder="Texas",
+        ).model_dump()
+
+        self.mock_scm.get.return_value = mock_response
+
+        result = self.client.fetch(name="TestAction", folder="Texas")
+
+        self.mock_scm.get.assert_called_once_with(
+            "/config/objects/v1/auto-tag-actions",
+            params={
+                "folder": "Texas",
+                "name": "TestAction",
+            },
+        )
+        assert isinstance(result, AutoTagActionResponseModel)
+        assert result.name == "TestAction"
+
+    def test_fetch_empty_name_error(self):
+        """Test that empty name raises MissingQueryParameterError."""
+        with pytest.raises(MissingQueryParameterError):
+            self.client.fetch(name="", folder="Texas")
+
+    def test_fetch_empty_folder_error(self):
+        """Test that empty folder raises MissingQueryParameterError."""
+        with pytest.raises(MissingQueryParameterError):
+            self.client.fetch(name="TestAction", folder="")
+
+    def test_fetch_no_container_error(self):
+        """Test that no container raises InvalidObjectError."""
+        with pytest.raises(InvalidObjectError):
+            self.client.fetch(name="TestAction")
+
+    def test_fetch_response_not_dict(self):
+        """Test that non-dict response raises InvalidObjectError."""
+        self.mock_scm.get.return_value = "not a dict"
+        with pytest.raises(InvalidObjectError):
+            self.client.fetch(name="TestAction", folder="Texas")
+
+    def test_fetch_response_missing_id(self):
+        """Test that response missing 'id' raises InvalidObjectError."""
+        self.mock_scm.get.return_value = {"name": "TestAction"}
+        with pytest.raises(InvalidObjectError):
+            self.client.fetch(name="TestAction", folder="Texas")

--- a/tests/scm/models/objects/test_auto_tag_actions.py
+++ b/tests/scm/models/objects/test_auto_tag_actions.py
@@ -1,0 +1,139 @@
+# tests/scm/models/objects/test_auto_tag_actions.py
+
+"""Tests for auto tag action model validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from scm.models.objects.auto_tag_actions import (
+    AutoTagActionCreateModel,
+    AutoTagActionResponseModel,
+    AutoTagActionUpdateModel,
+)
+from tests.factories.objects.auto_tag_actions import (
+    AutoTagActionCreateModelFactory,
+    AutoTagActionUpdateModelFactory,
+)
+
+
+class TestAutoTagActionCreateModel:
+    """Tests for AutoTagActionCreateModel validation."""
+
+    def test_create_valid(self):
+        """Test creating a valid auto tag action model."""
+        data = AutoTagActionCreateModelFactory.build_valid()
+        model = AutoTagActionCreateModel(**data)
+        assert model.name == "TestAutoTagAction"
+        assert model.folder == "Texas"
+
+    def test_create_no_container_error(self):
+        """Test that creating without container raises ValidationError."""
+        data = AutoTagActionCreateModelFactory.build_with_no_container()
+        with pytest.raises(ValidationError):
+            AutoTagActionCreateModel(**data)
+
+    def test_create_multiple_containers_error(self):
+        """Test that creating with multiple containers raises ValidationError."""
+        data = AutoTagActionCreateModelFactory.build_with_multiple_containers()
+        with pytest.raises(ValidationError):
+            AutoTagActionCreateModel(**data)
+
+    def test_create_with_snippet(self):
+        """Test creating with snippet container."""
+        data = {"name": "TestAction", "snippet": "MySnippet"}
+        model = AutoTagActionCreateModel(**data)
+        assert model.snippet == "MySnippet"
+        assert model.folder is None
+
+    def test_create_with_device(self):
+        """Test creating with device container."""
+        data = {"name": "TestAction", "device": "MyDevice"}
+        model = AutoTagActionCreateModel(**data)
+        assert model.device == "MyDevice"
+        assert model.folder is None
+
+    def test_create_name_too_long(self):
+        """Test that name exceeding max_length raises ValidationError."""
+        data = {"name": "a" * 64, "folder": "Texas"}
+        with pytest.raises(ValidationError):
+            AutoTagActionCreateModel(**data)
+
+    def test_create_name_invalid_chars(self):
+        """Test that name with invalid characters raises ValidationError."""
+        data = {"name": "invalid@name!", "folder": "Texas"}
+        with pytest.raises(ValidationError):
+            AutoTagActionCreateModel(**data)
+
+
+class TestAutoTagActionUpdateModel:
+    """Tests for AutoTagActionUpdateModel validation."""
+
+    def test_update_valid(self):
+        """Test creating a valid update model."""
+        data = AutoTagActionUpdateModelFactory.build_valid()
+        model = AutoTagActionUpdateModel(**data)
+        assert model.name == "UpdatedAutoTagAction"
+        assert str(model.id) == "123e4567-e89b-12d3-a456-426655440000"
+
+    def test_update_without_id(self):
+        """Test update model without id (allowed)."""
+        data = {"name": "TestAction"}
+        model = AutoTagActionUpdateModel(**data)
+        assert model.id is None
+
+
+class TestAutoTagActionResponseModel:
+    """Tests for AutoTagActionResponseModel validation."""
+
+    def test_response_valid(self):
+        """Test creating a valid response model."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "TestAction",
+            "folder": "Texas",
+        }
+        model = AutoTagActionResponseModel(**data)
+        assert model.name == "TestAction"
+        assert model.folder == "Texas"
+
+    def test_response_ignores_extra_fields(self):
+        """Test that response model ignores extra fields."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "TestAction",
+            "folder": "Texas",
+            "unknown_field": "should be ignored",
+        }
+        model = AutoTagActionResponseModel(**data)
+        assert model.name == "TestAction"
+
+    def test_response_with_actions(self):
+        """Test response model with actions list."""
+        data = {
+            "id": "123e4567-e89b-12d3-a456-426655440000",
+            "name": "TestAction",
+            "folder": "Texas",
+            "actions": [
+                {
+                    "name": "tag-action",
+                    "type": {
+                        "tagging": {
+                            "action": "add-tag",
+                            "target": "source-address",
+                            "tags": ["malware-host"],
+                            "timeout": 86400,
+                        }
+                    },
+                }
+            ],
+            "filter": "( severity eq critical )",
+            "log_type": "threat",
+        }
+        model = AutoTagActionResponseModel(**data)
+        assert model.name == "TestAction"
+        assert len(model.actions) == 1
+        assert model.actions[0].name == "tag-action"
+        assert model.actions[0].type.tagging.action == "add-tag"
+        assert model.actions[0].type.tagging.tags == ["malware-host"]
+        assert model.filter == "( severity eq critical )"
+        assert model.log_type == "threat"

--- a/tests/scm/models/security/test_decryption_rules_models.py
+++ b/tests/scm/models/security/test_decryption_rules_models.py
@@ -397,6 +397,16 @@ class TestDecryptionRuleResponseModel:
                 device={"some_key": "some_value"},
             )
 
+    def test_decryption_rule_response_model_without_action(self):
+        """Test response model accepts missing action field (API may omit it)."""
+        model = DecryptionRuleResponseModel(
+            id=uuid.uuid4(),
+            name="test_rule",
+            folder="Texas",
+        )
+        assert model.action is None
+        assert model.name == "test_rule"
+
     def test_decryption_rule_response_model_with_rulebase(self):
         """Test response model with rulebase field."""
         data = DecryptionRuleResponseFactory(rulebase=DecryptionRuleRulebase.POST).model_dump()


### PR DESCRIPTION
## Summary

- **#253**: Uncommented and modernized the `AutoTagActions` service class (was entirely commented out/non-functional). Created Pydantic models, test factories, and comprehensive tests. Follows the modern service pattern (pagination, `exact_match`, `exclude_folders`/`snippets`/`devices`).
- **#254**: Made `DecryptionRuleBaseModel.action` optional (`Optional[DecryptionRuleAction] = None`) since the SCM API may return decryption rules without the `action` field populated.

## Test plan

- [x] 127 new/modified tests pass
- [x] Full unit test suite (5847 tests) passes
- [x] Ruff lint + format clean

Closes #253
Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)