### PR TITLE
docs: create identity service and model documentation

### DIFF
--- a/docs/sdk/config/identity/authentication_profile.md
+++ b/docs/sdk/config/identity/authentication_profile.md
@@ -1,0 +1,232 @@
+# Authentication Profile
+
+The `AuthenticationProfile` service manages authentication profile objects in Strata Cloud Manager, defining how users authenticate using methods such as LDAP, RADIUS, SAML, Kerberos, TACACS+, local database, or cloud.
+
+## Class Overview
+
+The `AuthenticationProfile` class provides CRUD operations for authentication profile objects. It is accessed through the `client.authentication_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the AuthenticationProfile service
+auth_profiles = client.authentication_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `method` | `AuthProfileMethod` | No | Authentication method configuration |
+| `allow_list` | `List[str]` | No | Allow list (defaults to `["all"]`) |
+| `lockout` | `AuthProfileLockout` | No | Account lockout configuration |
+| `multi_factor_auth` | `Dict` | No | Multi-factor authentication configuration |
+| `single_sign_on` | `Dict` | No | Single sign-on configuration |
+| `user_domain` | `str` | No | User domain |
+| `username_modifier` | `str` | No | Username modifier |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List Authentication Profiles
+
+Retrieves a list of authentication profile objects with optional filtering.
+
+```python
+# List all authentication profiles in a folder
+profiles = client.authentication_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch an Authentication Profile
+
+Retrieves a single authentication profile by name and container.
+
+```python
+# Fetch a specific authentication profile by name
+profile = client.authentication_profile.fetch(
+    name="corp-auth",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, ID: {profile.id}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the authentication profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create an Authentication Profile
+
+Creates a new authentication profile object.
+
+```python
+# Create with LDAP method
+profile = client.authentication_profile.create({
+    "name": "corp-auth",
+    "folder": "Texas",
+    "method": {
+        "ldap": {
+            "server_profile": "corp-ldap",
+            "login_attribute": "sAMAccountName",
+            "passwd_exp_days": 90
+        }
+    },
+    "allow_list": ["all"],
+    "user_domain": "example.com"
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update an Authentication Profile
+
+Updates an existing authentication profile object.
+
+```python
+# Fetch, modify, update
+profile = client.authentication_profile.fetch(name="corp-auth", folder="Texas")
+profile.user_domain = "internal.example.com"
+updated = client.authentication_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete an Authentication Profile
+
+Deletes an authentication profile object by ID.
+
+```python
+# Delete by ID
+client.authentication_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### SAML-Based Single Sign-On
+
+```python
+# Create an authentication profile with SAML
+profile = client.authentication_profile.create({
+    "name": "saml-sso-profile",
+    "folder": "Texas",
+    "method": {
+        "saml_idp": {
+            "server_profile": "corp-saml-idp",
+            "attribute_name_username": "email",
+            "attribute_name_usergroup": "groups",
+            "enable_single_logout": True
+        }
+    },
+    "allow_list": ["all"]
+})
+```
+
+### RADIUS Authentication with Lockout
+
+```python
+# Create an authentication profile with RADIUS and account lockout
+profile = client.authentication_profile.create({
+    "name": "radius-auth-profile",
+    "folder": "Texas",
+    "method": {
+        "radius": {
+            "server_profile": "corp-radius",
+            "checkgroup": True
+        }
+    },
+    "lockout": {
+        "failed_attempts": 5,
+        "lockout_time": 30
+    },
+    "allow_list": ["all"]
+})
+```
+
+### List and Filter Profiles
+
+```python
+# List profiles with exact match and exclusions
+profiles = client.authentication_profile.list(
+    folder="Texas",
+    exact_match=True,
+    exclude_folders=["All"]
+)
+
+for profile in profiles:
+    print(f"Profile: {profile.name}, Domain: {profile.user_domain}")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.authentication_profile.fetch(
+        name="corp-auth",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [Authentication Profile Models](../../models/identity/authentication_profile_models.md)
+- [LDAP Server Profile](ldap_server_profile.md)
+- [RADIUS Server Profile](radius_server_profile.md)
+- [SAML Server Profile](saml_server_profile.md)
+- [Kerberos Server Profile](kerberos_server_profile.md)
+- [TACACS+ Server Profile](tacacs_server_profile.md)

--- a/docs/sdk/config/identity/index.md
+++ b/docs/sdk/config/identity/index.md
@@ -1,0 +1,68 @@
+# Identity and Authentication Services
+
+This section covers the identity and authentication services provided by the Palo Alto Networks Strata Cloud Manager SDK. Each service corresponds to a resource in the Strata Cloud Manager and provides methods for CRUD (Create, Read, Update, Delete) operations.
+
+## Available Identity Services
+
+### Authentication
+
+- [Authentication Profile](authentication_profile.md) - Configure authentication profiles with methods such as LDAP, RADIUS, SAML, Kerberos, TACACS+, and local database
+
+### Server Profiles
+
+- [Kerberos Server Profile](kerberos_server_profile.md) - Configure Kerberos server profiles for Kerberos-based authentication
+- [LDAP Server Profile](ldap_server_profile.md) - Configure LDAP server profiles for directory-based authentication
+- [RADIUS Server Profile](radius_server_profile.md) - Configure RADIUS server profiles for centralized authentication
+- [SAML Server Profile](saml_server_profile.md) - Configure SAML server profiles for single sign-on authentication
+- [TACACS+ Server Profile](tacacs_server_profile.md) - Configure TACACS+ server profiles for terminal access controller authentication
+
+## Common Features
+
+All identity service objects provide standard operations:
+
+- Create new identity configurations
+- Read existing identity objects
+- Update identity properties
+- Delete identity objects
+- List and filter identity objects with pagination support
+
+The identity objects also enforce:
+
+- Container validation (folder/device/snippet)
+- Data validation with detailed error messages
+- Consistent API patterns across all identity object types
+
+## Usage Example
+
+```python
+from scm.client import ScmClient
+
+# Initialize client
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Create an LDAP server profile
+client.ldap_server_profile.create({
+    "name": "corp-ldap",
+    "server": [
+        {
+            "name": "ldap-primary",
+            "address": "ldap.example.com",
+            "port": 389
+        }
+    ],
+    "base": "dc=example,dc=com",
+    "ldap_type": "active-directory",
+    "folder": "Texas"
+})
+
+# List authentication profiles
+profiles = client.authentication_profile.list(folder="Texas")
+for profile in profiles:
+    print(f"Profile: {profile.name}")
+```
+
+Select a service from the list above to view detailed documentation, including methods, parameters, and examples.

--- a/docs/sdk/config/identity/kerberos_server_profile.md
+++ b/docs/sdk/config/identity/kerberos_server_profile.md
@@ -1,0 +1,205 @@
+# Kerberos Server Profile
+
+The `KerberosServerProfile` service manages Kerberos server profile objects in Strata Cloud Manager, defining Kerberos Key Distribution Center (KDC) servers used for authentication.
+
+## Class Overview
+
+The `KerberosServerProfile` class provides CRUD operations for Kerberos server profile objects. It is accessed through the `client.kerberos_server_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the KerberosServerProfile service
+kerberos_profiles = client.kerberos_server_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `server` | `List[KerberosServer]` | No | List of Kerberos servers |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List Kerberos Server Profiles
+
+Retrieves a list of Kerberos server profile objects with optional filtering.
+
+```python
+# List all Kerberos server profiles in a folder
+profiles = client.kerberos_server_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch a Kerberos Server Profile
+
+Retrieves a single Kerberos server profile by name and container.
+
+```python
+# Fetch a specific Kerberos server profile by name
+profile = client.kerberos_server_profile.fetch(
+    name="corp-kerberos",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, ID: {profile.id}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the Kerberos server profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create a Kerberos Server Profile
+
+Creates a new Kerberos server profile object.
+
+```python
+# Create a new Kerberos server profile
+profile = client.kerberos_server_profile.create({
+    "name": "corp-kerberos",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "kdc-primary",
+            "host": "kdc.example.com",
+            "port": 88
+        }
+    ]
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update a Kerberos Server Profile
+
+Updates an existing Kerberos server profile object.
+
+```python
+# Fetch, modify, update
+profile = client.kerberos_server_profile.fetch(name="corp-kerberos", folder="Texas")
+profile.server = [
+    {"name": "kdc-primary", "host": "kdc1.example.com", "port": 88},
+    {"name": "kdc-secondary", "host": "kdc2.example.com", "port": 88}
+]
+updated = client.kerberos_server_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete a Kerberos Server Profile
+
+Deletes a Kerberos server profile object by ID.
+
+```python
+# Delete by ID
+client.kerberos_server_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### Multiple KDC Servers
+
+```python
+# Create a profile with primary and backup KDC servers
+profile = client.kerberos_server_profile.create({
+    "name": "corp-kerberos-ha",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "kdc-primary",
+            "host": "kdc1.example.com",
+            "port": 88
+        },
+        {
+            "name": "kdc-backup",
+            "host": "kdc2.example.com",
+            "port": 88
+        }
+    ]
+})
+```
+
+### Bulk Profile Management
+
+```python
+# List and audit all Kerberos server profiles
+profiles = client.kerberos_server_profile.list(
+    folder="Texas",
+    exact_match=True
+)
+
+for profile in profiles:
+    server_count = len(profile.server) if profile.server else 0
+    print(f"Profile: {profile.name}, Servers: {server_count}")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.kerberos_server_profile.fetch(
+        name="corp-kerberos",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [Kerberos Server Profile Models](../../models/identity/kerberos_server_profile_models.md)
+- [Authentication Profile](authentication_profile.md)

--- a/docs/sdk/config/identity/ldap_server_profile.md
+++ b/docs/sdk/config/identity/ldap_server_profile.md
@@ -1,0 +1,225 @@
+# LDAP Server Profile
+
+The `LdapServerProfile` service manages LDAP server profile objects in Strata Cloud Manager, defining LDAP directory servers used for user authentication and group lookups.
+
+## Class Overview
+
+The `LdapServerProfile` class provides CRUD operations for LDAP server profile objects. It is accessed through the `client.ldap_server_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the LdapServerProfile service
+ldap_profiles = client.ldap_server_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `server` | `List[LdapServer]` | No | List of LDAP servers |
+| `base` | `str` | No | Base distinguished name (max 255 chars) |
+| `bind_dn` | `str` | No | Bind distinguished name (max 255 chars) |
+| `bind_password` | `str` | No | Bind password (max 121 chars) |
+| `bind_timelimit` | `str` | No | Bind time limit |
+| `ldap_type` | `LdapType` | No | LDAP server type |
+| `retry_interval` | `int` | No | Retry interval in seconds |
+| `ssl` | `bool` | No | Enable SSL |
+| `timelimit` | `int` | No | Time limit in seconds |
+| `verify_server_certificate` | `bool` | No | Verify server certificate |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List LDAP Server Profiles
+
+Retrieves a list of LDAP server profile objects with optional filtering.
+
+```python
+# List all LDAP server profiles in a folder
+profiles = client.ldap_server_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}, Type: {profile.ldap_type}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch an LDAP Server Profile
+
+Retrieves a single LDAP server profile by name and container.
+
+```python
+# Fetch a specific LDAP server profile by name
+profile = client.ldap_server_profile.fetch(
+    name="corp-ldap",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, Base DN: {profile.base}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the LDAP server profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create an LDAP Server Profile
+
+Creates a new LDAP server profile object.
+
+```python
+# Create a new LDAP server profile
+profile = client.ldap_server_profile.create({
+    "name": "corp-ldap",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "ldap-primary",
+            "address": "ldap.example.com",
+            "port": 389
+        }
+    ],
+    "base": "dc=example,dc=com",
+    "bind_dn": "cn=admin,dc=example,dc=com",
+    "bind_password": "admin-password",
+    "ldap_type": "active-directory",
+    "ssl": True
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update an LDAP Server Profile
+
+Updates an existing LDAP server profile object.
+
+```python
+# Fetch, modify, update
+profile = client.ldap_server_profile.fetch(name="corp-ldap", folder="Texas")
+profile.ssl = True
+profile.verify_server_certificate = True
+updated = client.ldap_server_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete an LDAP Server Profile
+
+Deletes an LDAP server profile object by ID.
+
+```python
+# Delete by ID
+client.ldap_server_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### Active Directory Integration
+
+```python
+# Create an LDAP profile for Active Directory
+profile = client.ldap_server_profile.create({
+    "name": "ad-integration",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "dc-primary",
+            "address": "dc1.example.com",
+            "port": 636
+        },
+        {
+            "name": "dc-secondary",
+            "address": "dc2.example.com",
+            "port": 636
+        }
+    ],
+    "base": "dc=example,dc=com",
+    "bind_dn": "cn=svc-firewall,ou=services,dc=example,dc=com",
+    "bind_password": "service-password",
+    "ldap_type": "active-directory",
+    "ssl": True,
+    "verify_server_certificate": True,
+    "timelimit": 30,
+    "bind_timelimit": "30"
+})
+```
+
+### Audit LDAP Configurations
+
+```python
+# List and audit all LDAP profiles for SSL compliance
+profiles = client.ldap_server_profile.list(
+    folder="Texas",
+    exact_match=True
+)
+
+for profile in profiles:
+    ssl_status = "Enabled" if profile.ssl else "Disabled"
+    print(f"Profile: {profile.name}, SSL: {ssl_status}")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.ldap_server_profile.fetch(
+        name="corp-ldap",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [LDAP Server Profile Models](../../models/identity/ldap_server_profile_models.md)
+- [Authentication Profile](authentication_profile.md)

--- a/docs/sdk/config/identity/radius_server_profile.md
+++ b/docs/sdk/config/identity/radius_server_profile.md
@@ -1,0 +1,222 @@
+# RADIUS Server Profile
+
+The `RadiusServerProfile` service manages RADIUS server profile objects in Strata Cloud Manager, defining RADIUS servers used for centralized authentication, authorization, and accounting (AAA).
+
+## Class Overview
+
+The `RadiusServerProfile` class provides CRUD operations for RADIUS server profile objects. It is accessed through the `client.radius_server_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the RadiusServerProfile service
+radius_profiles = client.radius_server_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `server` | `List[RadiusServer]` | No | List of RADIUS servers |
+| `protocol` | `RadiusProtocol` | No | RADIUS protocol configuration |
+| `retries` | `int` | No | Number of retries (1-5) |
+| `timeout` | `int` | No | Timeout in seconds (1-120) |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List RADIUS Server Profiles
+
+Retrieves a list of RADIUS server profile objects with optional filtering.
+
+```python
+# List all RADIUS server profiles in a folder
+profiles = client.radius_server_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch a RADIUS Server Profile
+
+Retrieves a single RADIUS server profile by name and container.
+
+```python
+# Fetch a specific RADIUS server profile by name
+profile = client.radius_server_profile.fetch(
+    name="corp-radius",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, ID: {profile.id}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the RADIUS server profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create a RADIUS Server Profile
+
+Creates a new RADIUS server profile object.
+
+```python
+# Create a new RADIUS server profile
+profile = client.radius_server_profile.create({
+    "name": "corp-radius",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "radius-primary",
+            "ip_address": "10.0.1.100",
+            "port": 1812,
+            "secret": "shared-secret"
+        }
+    ],
+    "protocol": {"CHAP": {}},
+    "timeout": 5,
+    "retries": 3
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update a RADIUS Server Profile
+
+Updates an existing RADIUS server profile object.
+
+```python
+# Fetch, modify, update
+profile = client.radius_server_profile.fetch(name="corp-radius", folder="Texas")
+profile.timeout = 10
+profile.retries = 5
+updated = client.radius_server_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete a RADIUS Server Profile
+
+Deletes a RADIUS server profile object by ID.
+
+```python
+# Delete by ID
+client.radius_server_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### High-Availability RADIUS Setup
+
+```python
+# Create a profile with primary and backup RADIUS servers
+profile = client.radius_server_profile.create({
+    "name": "corp-radius-ha",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "radius-primary",
+            "ip_address": "10.0.1.100",
+            "port": 1812,
+            "secret": "primary-secret"
+        },
+        {
+            "name": "radius-backup",
+            "ip_address": "10.0.1.101",
+            "port": 1812,
+            "secret": "backup-secret"
+        }
+    ],
+    "protocol": {"PAP": {}},
+    "timeout": 3,
+    "retries": 3
+})
+```
+
+### EAP-TTLS with PAP Protocol
+
+```python
+# Create a RADIUS profile with EAP-TTLS
+profile = client.radius_server_profile.create({
+    "name": "eap-radius",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "radius-eap",
+            "ip_address": "10.0.1.100",
+            "port": 1812,
+            "secret": "eap-secret"
+        }
+    ],
+    "protocol": {"EAP_TTLS_with_PAP": {}},
+    "timeout": 10,
+    "retries": 3
+})
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.radius_server_profile.fetch(
+        name="corp-radius",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [RADIUS Server Profile Models](../../models/identity/radius_server_profile_models.md)
+- [Authentication Profile](authentication_profile.md)

--- a/docs/sdk/config/identity/saml_server_profile.md
+++ b/docs/sdk/config/identity/saml_server_profile.md
@@ -1,0 +1,208 @@
+# SAML Server Profile
+
+The `SamlServerProfile` service manages SAML server profile objects in Strata Cloud Manager, defining SAML Identity Provider (IdP) configurations for single sign-on authentication.
+
+## Class Overview
+
+The `SamlServerProfile` class provides CRUD operations for SAML server profile objects. It is accessed through the `client.saml_server_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the SamlServerProfile service
+saml_profiles = client.saml_server_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `entity_id` | `str` | Yes | Entity ID (max 1024 chars) |
+| `certificate` | `str` | Yes | Certificate name (max 63 chars) |
+| `sso_url` | `str` | Yes | Single Sign-On URL (max 255 chars) |
+| `sso_bindings` | `SamlSsoBindings` | Yes | SSO binding type (`post` or `redirect`) |
+| `slo_bindings` | `SamlSloBindings` | No | SLO binding type (`post` or `redirect`) |
+| `max_clock_skew` | `int` | No | Maximum clock skew in seconds (1-900) |
+| `validate_idp_certificate` | `bool` | No | Validate IDP certificate |
+| `want_auth_requests_signed` | `bool` | No | Want authentication requests signed |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List SAML Server Profiles
+
+Retrieves a list of SAML server profile objects with optional filtering.
+
+```python
+# List all SAML server profiles in a folder
+profiles = client.saml_server_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}, Entity ID: {profile.entity_id}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch a SAML Server Profile
+
+Retrieves a single SAML server profile by name and container.
+
+```python
+# Fetch a specific SAML server profile by name
+profile = client.saml_server_profile.fetch(
+    name="corp-saml-idp",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, SSO URL: {profile.sso_url}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the SAML server profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create a SAML Server Profile
+
+Creates a new SAML server profile object.
+
+```python
+# Create a new SAML server profile
+profile = client.saml_server_profile.create({
+    "name": "corp-saml-idp",
+    "folder": "Texas",
+    "entity_id": "https://idp.example.com/saml/metadata",
+    "certificate": "idp-signing-cert",
+    "sso_url": "https://idp.example.com/saml/sso",
+    "sso_bindings": "post",
+    "slo_bindings": "post",
+    "max_clock_skew": 60,
+    "validate_idp_certificate": True
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update a SAML Server Profile
+
+Updates an existing SAML server profile object.
+
+```python
+# Fetch, modify, update
+profile = client.saml_server_profile.fetch(name="corp-saml-idp", folder="Texas")
+profile.max_clock_skew = 120
+profile.want_auth_requests_signed = True
+updated = client.saml_server_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete a SAML Server Profile
+
+Deletes a SAML server profile object by ID.
+
+```python
+# Delete by ID
+client.saml_server_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### Okta SAML Integration
+
+```python
+# Create a SAML profile for Okta
+profile = client.saml_server_profile.create({
+    "name": "okta-saml",
+    "folder": "Texas",
+    "entity_id": "http://www.okta.com/exk1234567890",
+    "certificate": "okta-signing-cert",
+    "sso_url": "https://company.okta.com/app/paloalto/exk1234567890/sso/saml",
+    "sso_bindings": "post",
+    "slo_bindings": "redirect",
+    "max_clock_skew": 60,
+    "validate_idp_certificate": True,
+    "want_auth_requests_signed": True
+})
+```
+
+### Azure AD SAML Integration
+
+```python
+# Create a SAML profile for Azure AD
+profile = client.saml_server_profile.create({
+    "name": "azure-ad-saml",
+    "folder": "Texas",
+    "entity_id": "https://sts.windows.net/tenant-id/",
+    "certificate": "azure-ad-cert",
+    "sso_url": "https://login.microsoftonline.com/tenant-id/saml2",
+    "sso_bindings": "redirect",
+    "max_clock_skew": 120,
+    "validate_idp_certificate": True
+})
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.saml_server_profile.fetch(
+        name="corp-saml-idp",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [SAML Server Profile Models](../../models/identity/saml_server_profile_models.md)
+- [Authentication Profile](authentication_profile.md)

--- a/docs/sdk/config/identity/tacacs_server_profile.md
+++ b/docs/sdk/config/identity/tacacs_server_profile.md
@@ -1,0 +1,216 @@
+# TACACS+ Server Profile
+
+The `TacacsServerProfile` service manages TACACS+ server profile objects in Strata Cloud Manager, defining TACACS+ servers used for terminal access controller authentication, authorization, and accounting.
+
+## Class Overview
+
+The `TacacsServerProfile` class provides CRUD operations for TACACS+ server profile objects. It is accessed through the `client.tacacs_server_profile` attribute on an initialized `ScmClient` instance.
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Access the TacacsServerProfile service
+tacacs_profiles = client.tacacs_server_profile
+```
+
+### Key Attributes
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `id` | `UUID` | Yes* | Unique identifier (*response only) |
+| `server` | `List[TacacsServer]` | No | List of TACACS+ servers |
+| `protocol` | `TacacsProtocol` | No | Protocol type (`CHAP` or `PAP`) |
+| `timeout` | `int` | No | Timeout in seconds (1-30) |
+| `use_single_connection` | `bool` | No | Use single connection |
+| `folder` | `str` | No* | Folder location |
+| `snippet` | `str` | No* | Snippet location |
+| `device` | `str` | No* | Device location |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+## Methods
+
+### List TACACS+ Server Profiles
+
+Retrieves a list of TACACS+ server profile objects with optional filtering.
+
+```python
+# List all TACACS+ server profiles in a folder
+profiles = client.tacacs_server_profile.list(folder="Texas")
+
+for profile in profiles:
+    print(f"Name: {profile.name}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+| `exact_match` | `bool` | No | Only return objects exactly in the container |
+| `exclude_folders` | `List[str]` | No | List of folders to exclude |
+| `exclude_snippets` | `List[str]` | No | List of snippets to exclude |
+| `exclude_devices` | `List[str]` | No | List of devices to exclude |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Fetch a TACACS+ Server Profile
+
+Retrieves a single TACACS+ server profile by name and container.
+
+```python
+# Fetch a specific TACACS+ server profile by name
+profile = client.tacacs_server_profile.fetch(
+    name="corp-tacacs",
+    folder="Texas"
+)
+
+print(f"Name: {profile.name}, ID: {profile.id}")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | The name of the TACACS+ server profile |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### Create a TACACS+ Server Profile
+
+Creates a new TACACS+ server profile object.
+
+```python
+# Create a new TACACS+ server profile
+profile = client.tacacs_server_profile.create({
+    "name": "corp-tacacs",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "tacacs-primary",
+            "address": "10.0.1.50",
+            "port": 49,
+            "secret": "shared-secret"
+        }
+    ],
+    "protocol": "CHAP",
+    "timeout": 5,
+    "use_single_connection": True
+})
+
+print(f"Created profile: {profile.name} (ID: {profile.id})")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data` | `Dict[str, Any]` | Yes | Dictionary containing the profile configuration |
+
+### Update a TACACS+ Server Profile
+
+Updates an existing TACACS+ server profile object.
+
+```python
+# Fetch, modify, update
+profile = client.tacacs_server_profile.fetch(name="corp-tacacs", folder="Texas")
+profile.timeout = 10
+profile.use_single_connection = False
+updated = client.tacacs_server_profile.update(profile)
+
+print(f"Updated profile: {updated.name}")
+```
+
+### Delete a TACACS+ Server Profile
+
+Deletes a TACACS+ server profile object by ID.
+
+```python
+# Delete by ID
+client.tacacs_server_profile.delete("abcd1234-5678-9abc-def0-123456789abc")
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object_id` | `str` | Yes | The UUID of the profile to delete |
+
+## Use Cases
+
+### High-Availability TACACS+ Setup
+
+```python
+# Create a profile with primary and backup TACACS+ servers
+profile = client.tacacs_server_profile.create({
+    "name": "corp-tacacs-ha",
+    "folder": "Texas",
+    "server": [
+        {
+            "name": "tacacs-primary",
+            "address": "10.0.1.50",
+            "port": 49,
+            "secret": "primary-secret"
+        },
+        {
+            "name": "tacacs-backup",
+            "address": "10.0.1.51",
+            "port": 49,
+            "secret": "backup-secret"
+        }
+    ],
+    "protocol": "PAP",
+    "timeout": 3,
+    "use_single_connection": True
+})
+```
+
+### Audit TACACS+ Configurations
+
+```python
+# List and audit all TACACS+ profiles
+profiles = client.tacacs_server_profile.list(
+    folder="Texas",
+    exact_match=True
+)
+
+for profile in profiles:
+    server_count = len(profile.server) if profile.server else 0
+    protocol = profile.protocol if profile.protocol else "Not set"
+    print(f"Profile: {profile.name}, Servers: {server_count}, Protocol: {protocol}")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+
+try:
+    profile = client.tacacs_server_profile.fetch(
+        name="corp-tacacs",
+        folder="Texas"
+    )
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+except InvalidObjectError as e:
+    print(f"Invalid object: {e.message}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Related Topics
+
+- [TACACS+ Server Profile Models](../../models/identity/tacacs_server_profile_models.md)
+- [Authentication Profile](authentication_profile.md)

--- a/docs/sdk/models/identity/authentication_profile_models.md
+++ b/docs/sdk/models/identity/authentication_profile_models.md
@@ -1,0 +1,180 @@
+# Authentication Profile Models
+
+Models for authentication profile objects in Strata Cloud Manager, defining how users authenticate using various methods.
+
+## Overview
+
+The Authentication Profile models support the following key attributes:
+
+- Profile name and container assignment
+- Authentication method selection (LDAP, RADIUS, SAML, Kerberos, TACACS+, local database, cloud)
+- Allow list configuration
+- Account lockout settings
+- Multi-factor authentication and single sign-on options
+- User domain and username modifier
+
+## Base Models
+
+### AuthenticationProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `allow_list` | `List[str]` | No | Allow list (defaults to `["all"]`) |
+| `lockout` | `AuthProfileLockout` | No | Account lockout configuration |
+| `method` | `AuthProfileMethod` | No | Authentication method configuration |
+| `multi_factor_auth` | `Dict` | No | Multi-factor authentication configuration |
+| `single_sign_on` | `Dict` | No | Single sign-on configuration |
+| `user_domain` | `str` | No | User domain |
+| `username_modifier` | `str` | No | Username modifier |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### AuthenticationProfileCreateModel
+
+Inherits from `AuthenticationProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### AuthenticationProfileUpdateModel
+
+Inherits from `AuthenticationProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### AuthenticationProfileResponseModel
+
+Inherits from `AuthenticationProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Component Models
+
+### AuthProfileMethod
+
+Authentication method configuration. Exactly one method type should be provided.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `local_database` | `Dict` | Local database method |
+| `saml_idp` | `AuthProfileMethodSamlIdp` | SAML IDP method |
+| `ldap` | `AuthProfileMethodLdap` | LDAP method |
+| `radius` | `AuthProfileMethodRadius` | RADIUS method |
+| `tacplus` | `AuthProfileMethodTacplus` | TACACS+ method |
+| `kerberos` | `AuthProfileMethodKerberos` | Kerberos method |
+| `cloud` | `Dict` | Cloud method |
+
+### AuthProfileMethodSamlIdp
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `attribute_name_usergroup` | `str` | Attribute name for user group |
+| `attribute_name_username` | `str` | Attribute name for username |
+| `certificate_profile` | `str` | Certificate profile name |
+| `enable_single_logout` | `bool` | Enable single logout |
+| `request_signing_certificate` | `str` | Request signing certificate |
+| `server_profile` | `str` | Server profile name |
+
+### AuthProfileMethodLdap
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `login_attribute` | `str` | Login attribute |
+| `passwd_exp_days` | `int` | Password expiration days |
+| `server_profile` | `str` | Server profile name |
+
+### AuthProfileMethodRadius
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `checkgroup` | `bool` | Check group membership |
+| `server_profile` | `str` | Server profile name |
+
+### AuthProfileMethodTacplus
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `checkgroup` | `bool` | Check group membership |
+| `server_profile` | `str` | Server profile name |
+
+### AuthProfileMethodKerberos
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `realm` | `str` | Kerberos realm |
+| `server_profile` | `str` | Server profile name |
+
+### AuthProfileLockout
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `failed_attempts` | `int` | Number of failed attempts before lockout |
+| `lockout_time` | `int` | Lockout duration in minutes |
+
+## Usage Examples
+
+### Creating an Authentication Profile
+
+```python
+from scm.models.identity.authentication_profiles import (
+    AuthenticationProfileCreateModel,
+    AuthProfileMethod,
+    AuthProfileMethodLdap,
+    AuthProfileLockout,
+)
+
+# Create model instance with LDAP method
+profile = AuthenticationProfileCreateModel(
+    name="corp-auth",
+    folder="Texas",
+    method=AuthProfileMethod(
+        ldap=AuthProfileMethodLdap(
+            server_profile="corp-ldap",
+            login_attribute="sAMAccountName",
+            passwd_exp_days=90
+        )
+    ),
+    lockout=AuthProfileLockout(
+        failed_attempts=5,
+        lockout_time=30
+    ),
+    allow_list=["all"],
+    user_domain="example.com"
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.authentication_profile.create(payload)
+```
+
+### Parsing an Authentication Profile Response
+
+```python
+from scm.models.identity.authentication_profiles import (
+    AuthenticationProfileResponseModel,
+)
+
+# Parse API response
+response = AuthenticationProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+print(f"Domain: {response.user_domain}")
+if response.method and response.method.ldap:
+    print(f"LDAP Profile: {response.method.ldap.server_profile}")
+```
+
+## Related Topics
+
+- [Authentication Profile Service](../../config/identity/authentication_profile.md)
+- [LDAP Server Profile Models](ldap_server_profile_models.md)
+- [RADIUS Server Profile Models](radius_server_profile_models.md)
+- [SAML Server Profile Models](saml_server_profile_models.md)

--- a/docs/sdk/models/identity/index.md
+++ b/docs/sdk/models/identity/index.md
@@ -1,0 +1,88 @@
+# Identity Models
+
+## Overview
+
+The Strata Cloud Manager SDK uses Pydantic models for data validation and serialization of identity and authentication configurations. These models ensure that the data being sent to and received from the Strata Cloud Manager API adheres to the expected structure and constraints. This section documents the models for identity service resources.
+
+## Model Types
+
+For each identity resource, there are corresponding model types:
+
+- **Create Models**: Used when creating new identity resources (`{Object}CreateModel`)
+- **Update Models**: Used when updating existing identity resources (`{Object}UpdateModel`)
+- **Response Models**: Used when parsing identity data retrieved from the API (`{Object}ResponseModel`)
+- **Base Models**: Common shared attributes for related identity models (`{Object}BaseModel`)
+
+## Common Model Patterns
+
+Identity models share common patterns:
+
+- Container validation (exactly one of folder/snippet/device)
+- UUID validation for identifiers
+- Server list configurations with host, port, and optional credentials
+- Protocol and method selection patterns
+
+## Models by Category
+
+### Authentication
+
+- [Authentication Profile Models](authentication_profile_models.md) - Authentication profile configurations with method selection
+
+### Server Profiles
+
+- [Kerberos Server Profile Models](kerberos_server_profile_models.md) - Kerberos KDC server configurations
+- [LDAP Server Profile Models](ldap_server_profile_models.md) - LDAP directory server configurations
+- [RADIUS Server Profile Models](radius_server_profile_models.md) - RADIUS AAA server configurations
+- [SAML Server Profile Models](saml_server_profile_models.md) - SAML Identity Provider configurations
+- [TACACS+ Server Profile Models](tacacs_server_profile_models.md) - TACACS+ server configurations
+
+## Usage Examples
+
+```python
+from scm.client import ScmClient
+from scm.models.identity import (
+    LdapServerProfileCreateModel,
+    RadiusServerProfileCreateModel,
+)
+
+# Initialize client
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+# Create using a model instance
+ldap_profile = LdapServerProfileCreateModel(
+    name="corp-ldap",
+    folder="Texas",
+    base="dc=example,dc=com",
+    ldap_type="active-directory",
+    ssl=True
+)
+
+result = client.ldap_server_profile.create(
+    ldap_profile.model_dump(exclude_unset=True)
+)
+```
+
+## Best Practices
+
+1. **Model Validation**
+    - Always validate identity configuration data with models before sending to the API
+    - Handle validation errors appropriately
+    - Use `model_dump(exclude_unset=True)` to avoid sending default values
+
+2. **Server Configuration**
+    - Define multiple servers for high availability
+    - Use SSL/TLS where available for encrypted communication
+    - Store secrets securely and avoid hardcoding credentials
+
+3. **Error Handling**
+    - Catch and handle `ValueError` exceptions from model validation
+    - Validate that referenced server profiles exist before creating authentication profiles
+
+## Related Documentation
+
+- [Identity Services](../../config/identity/index.md) - Working with identity service configurations
+- [Authentication Profile](../../config/identity/authentication_profile.md) - Authentication profile operations

--- a/docs/sdk/models/identity/kerberos_server_profile_models.md
+++ b/docs/sdk/models/identity/kerberos_server_profile_models.md
@@ -1,0 +1,109 @@
+# Kerberos Server Profile Models
+
+Models for Kerberos server profile objects in Strata Cloud Manager, defining KDC server configurations for Kerberos-based authentication.
+
+## Overview
+
+The Kerberos Server Profile models support the following key attributes:
+
+- Profile name and container assignment
+- List of Kerberos KDC servers with host and port configuration
+
+## Base Models
+
+### KerberosServerProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `server` | `List[KerberosServer]` | No | List of Kerberos servers |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### KerberosServerProfileCreateModel
+
+Inherits from `KerberosServerProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### KerberosServerProfileUpdateModel
+
+Inherits from `KerberosServerProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### KerberosServerProfileResponseModel
+
+Inherits from `KerberosServerProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Component Models
+
+### KerberosServer
+
+Represents a single Kerberos server entry.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | No | Server name |
+| `host` | `str` | No | Server hostname or IP address |
+| `port` | `int` | No | Server port number (1-65535) |
+
+## Usage Examples
+
+### Creating a Kerberos Server Profile
+
+```python
+from scm.models.identity.kerberos_server_profiles import (
+    KerberosServerProfileCreateModel,
+    KerberosServer,
+)
+
+# Create model instance
+profile = KerberosServerProfileCreateModel(
+    name="corp-kerberos",
+    folder="Texas",
+    server=[
+        KerberosServer(
+            name="kdc-primary",
+            host="kdc.example.com",
+            port=88
+        )
+    ]
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.kerberos_server_profile.create(payload)
+```
+
+### Parsing a Kerberos Server Profile Response
+
+```python
+from scm.models.identity.kerberos_server_profiles import (
+    KerberosServerProfileResponseModel,
+)
+
+# Parse API response
+response = KerberosServerProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+if response.server:
+    for server in response.server:
+        print(f"  Server: {server.name} ({server.host}:{server.port})")
+```
+
+## Related Topics
+
+- [Kerberos Server Profile Service](../../config/identity/kerberos_server_profile.md)
+- [Authentication Profile Models](authentication_profile_models.md)

--- a/docs/sdk/models/identity/ldap_server_profile_models.md
+++ b/docs/sdk/models/identity/ldap_server_profile_models.md
@@ -1,0 +1,140 @@
+# LDAP Server Profile Models
+
+Models for LDAP server profile objects in Strata Cloud Manager, defining LDAP directory server configurations for user authentication and group lookups.
+
+## Overview
+
+The LDAP Server Profile models support the following key attributes:
+
+- Profile name and container assignment
+- List of LDAP servers with address and port configuration
+- Base DN, bind DN, and bind password for directory access
+- LDAP type selection (Active Directory, eDirectory, Sun, other)
+- SSL and certificate verification settings
+- Timeout and retry configuration
+
+## Base Models
+
+### LdapServerProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `server` | `List[LdapServer]` | No | List of LDAP servers |
+| `base` | `str` | No | Base distinguished name (max 255 chars) |
+| `bind_dn` | `str` | No | Bind distinguished name (max 255 chars) |
+| `bind_password` | `str` | No | Bind password (max 121 chars) |
+| `bind_timelimit` | `str` | No | Bind time limit |
+| `ldap_type` | `LdapType` | No | LDAP server type |
+| `retry_interval` | `int` | No | Retry interval in seconds |
+| `ssl` | `bool` | No | Enable SSL |
+| `timelimit` | `int` | No | Time limit in seconds |
+| `verify_server_certificate` | `bool` | No | Verify server certificate |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### LdapServerProfileCreateModel
+
+Inherits from `LdapServerProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### LdapServerProfileUpdateModel
+
+Inherits from `LdapServerProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### LdapServerProfileResponseModel
+
+Inherits from `LdapServerProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Component Models
+
+### LdapServer
+
+Represents a single LDAP server entry.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | No | Server name |
+| `address` | `str` | No | Server address |
+| `port` | `int` | No | Server port number (1-65535) |
+
+### LdapType
+
+Enumeration of LDAP server types.
+
+| Value | Description |
+| --- | --- |
+| `active-directory` | Microsoft Active Directory |
+| `e-directory` | Novell eDirectory |
+| `sun` | Sun Directory Server |
+| `other` | Other LDAP server |
+
+## Usage Examples
+
+### Creating an LDAP Server Profile
+
+```python
+from scm.models.identity.ldap_server_profiles import (
+    LdapServerProfileCreateModel,
+    LdapServer,
+    LdapType,
+)
+
+# Create model instance
+profile = LdapServerProfileCreateModel(
+    name="corp-ldap",
+    folder="Texas",
+    server=[
+        LdapServer(
+            name="ldap-primary",
+            address="ldap.example.com",
+            port=636
+        )
+    ],
+    base="dc=example,dc=com",
+    bind_dn="cn=admin,dc=example,dc=com",
+    bind_password="admin-password",
+    ldap_type=LdapType.active_directory,
+    ssl=True,
+    verify_server_certificate=True
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.ldap_server_profile.create(payload)
+```
+
+### Parsing an LDAP Server Profile Response
+
+```python
+from scm.models.identity.ldap_server_profiles import (
+    LdapServerProfileResponseModel,
+)
+
+# Parse API response
+response = LdapServerProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+print(f"Type: {response.ldap_type}")
+print(f"Base DN: {response.base}")
+print(f"SSL: {response.ssl}")
+```
+
+## Related Topics
+
+- [LDAP Server Profile Service](../../config/identity/ldap_server_profile.md)
+- [Authentication Profile Models](authentication_profile_models.md)

--- a/docs/sdk/models/identity/radius_server_profile_models.md
+++ b/docs/sdk/models/identity/radius_server_profile_models.md
@@ -1,0 +1,134 @@
+# RADIUS Server Profile Models
+
+Models for RADIUS server profile objects in Strata Cloud Manager, defining RADIUS server configurations for centralized authentication, authorization, and accounting.
+
+## Overview
+
+The RADIUS Server Profile models support the following key attributes:
+
+- Profile name and container assignment
+- List of RADIUS servers with IP address, port, and shared secret
+- Protocol selection (CHAP, PAP, EAP-TTLS with PAP, PEAP-MSCHAPv2, PEAP with GTC)
+- Retry and timeout configuration
+
+## Base Models
+
+### RadiusServerProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `server` | `List[RadiusServer]` | No | List of RADIUS servers |
+| `protocol` | `RadiusProtocol` | No | RADIUS protocol configuration |
+| `retries` | `int` | No | Number of retries (1-5) |
+| `timeout` | `int` | No | Timeout in seconds (1-120) |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### RadiusServerProfileCreateModel
+
+Inherits from `RadiusServerProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### RadiusServerProfileUpdateModel
+
+Inherits from `RadiusServerProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### RadiusServerProfileResponseModel
+
+Inherits from `RadiusServerProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Component Models
+
+### RadiusServer
+
+Represents a single RADIUS server entry.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | No | Server name |
+| `ip_address` | `str` | No | Server IP address |
+| `port` | `int` | No | Server port number (1-65535) |
+| `secret` | `str` | No | Shared secret |
+
+### RadiusProtocol
+
+RADIUS protocol configuration. Exactly one protocol type should be provided.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `CHAP` | `Dict` | CHAP protocol |
+| `PAP` | `Dict` | PAP protocol |
+| `EAP_TTLS_with_PAP` | `Dict` | EAP-TTLS with PAP protocol |
+| `PEAP_MSCHAPv2` | `Dict` | PEAP-MSCHAPv2 protocol |
+| `PEAP_with_GTC` | `Dict` | PEAP with GTC protocol |
+
+## Usage Examples
+
+### Creating a RADIUS Server Profile
+
+```python
+from scm.models.identity.radius_server_profiles import (
+    RadiusServerProfileCreateModel,
+    RadiusServer,
+    RadiusProtocol,
+)
+
+# Create model instance
+profile = RadiusServerProfileCreateModel(
+    name="corp-radius",
+    folder="Texas",
+    server=[
+        RadiusServer(
+            name="radius-primary",
+            ip_address="10.0.1.100",
+            port=1812,
+            secret="shared-secret"
+        )
+    ],
+    protocol=RadiusProtocol(CHAP={}),
+    timeout=5,
+    retries=3
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.radius_server_profile.create(payload)
+```
+
+### Parsing a RADIUS Server Profile Response
+
+```python
+from scm.models.identity.radius_server_profiles import (
+    RadiusServerProfileResponseModel,
+)
+
+# Parse API response
+response = RadiusServerProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+print(f"Timeout: {response.timeout}")
+print(f"Retries: {response.retries}")
+if response.server:
+    for server in response.server:
+        print(f"  Server: {server.name} ({server.ip_address}:{server.port})")
+```
+
+## Related Topics
+
+- [RADIUS Server Profile Service](../../config/identity/radius_server_profile.md)
+- [Authentication Profile Models](authentication_profile_models.md)

--- a/docs/sdk/models/identity/saml_server_profile_models.md
+++ b/docs/sdk/models/identity/saml_server_profile_models.md
@@ -1,0 +1,129 @@
+# SAML Server Profile Models
+
+Models for SAML server profile objects in Strata Cloud Manager, defining SAML Identity Provider (IdP) configurations for single sign-on authentication.
+
+## Overview
+
+The SAML Server Profile models support the following key attributes:
+
+- Profile name and container assignment
+- Entity ID and certificate for IdP identification
+- SSO URL and binding type configuration
+- SLO binding type configuration
+- Clock skew tolerance and certificate validation settings
+
+## Base Models
+
+### SamlServerProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `entity_id` | `str` | Yes | Entity ID (max 1024 chars) |
+| `certificate` | `str` | Yes | Certificate name (max 63 chars) |
+| `sso_url` | `str` | Yes | Single Sign-On URL (max 255 chars) |
+| `sso_bindings` | `SamlSsoBindings` | Yes | SSO binding type |
+| `slo_bindings` | `SamlSloBindings` | No | SLO binding type |
+| `max_clock_skew` | `int` | No | Maximum clock skew in seconds (1-900) |
+| `validate_idp_certificate` | `bool` | No | Validate IDP certificate |
+| `want_auth_requests_signed` | `bool` | No | Want authentication requests signed |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### SamlServerProfileCreateModel
+
+Inherits from `SamlServerProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### SamlServerProfileUpdateModel
+
+Inherits from `SamlServerProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### SamlServerProfileResponseModel
+
+Inherits from `SamlServerProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Enums
+
+### SamlSsoBindings
+
+SSO binding type enumeration.
+
+| Value | Description |
+| --- | --- |
+| `post` | HTTP POST binding |
+| `redirect` | HTTP Redirect binding |
+
+### SamlSloBindings
+
+SLO binding type enumeration.
+
+| Value | Description |
+| --- | --- |
+| `post` | HTTP POST binding |
+| `redirect` | HTTP Redirect binding |
+
+## Usage Examples
+
+### Creating a SAML Server Profile
+
+```python
+from scm.models.identity.saml_server_profiles import (
+    SamlServerProfileCreateModel,
+    SamlSsoBindings,
+    SamlSloBindings,
+)
+
+# Create model instance
+profile = SamlServerProfileCreateModel(
+    name="corp-saml-idp",
+    folder="Texas",
+    entity_id="https://idp.example.com/saml/metadata",
+    certificate="idp-signing-cert",
+    sso_url="https://idp.example.com/saml/sso",
+    sso_bindings=SamlSsoBindings.post,
+    slo_bindings=SamlSloBindings.post,
+    max_clock_skew=60,
+    validate_idp_certificate=True,
+    want_auth_requests_signed=True
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.saml_server_profile.create(payload)
+```
+
+### Parsing a SAML Server Profile Response
+
+```python
+from scm.models.identity.saml_server_profiles import (
+    SamlServerProfileResponseModel,
+)
+
+# Parse API response
+response = SamlServerProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+print(f"Entity ID: {response.entity_id}")
+print(f"SSO URL: {response.sso_url}")
+print(f"SSO Binding: {response.sso_bindings}")
+```
+
+## Related Topics
+
+- [SAML Server Profile Service](../../config/identity/saml_server_profile.md)
+- [Authentication Profile Models](authentication_profile_models.md)

--- a/docs/sdk/models/identity/tacacs_server_profile_models.md
+++ b/docs/sdk/models/identity/tacacs_server_profile_models.md
@@ -1,0 +1,131 @@
+# TACACS+ Server Profile Models
+
+Models for TACACS+ server profile objects in Strata Cloud Manager, defining TACACS+ server configurations for terminal access controller authentication, authorization, and accounting.
+
+## Overview
+
+The TACACS+ Server Profile models support the following key attributes:
+
+- Profile name and container assignment
+- List of TACACS+ servers with address, port, and shared secret
+- Protocol selection (CHAP or PAP)
+- Timeout and single connection settings
+
+## Base Models
+
+### TacacsServerProfileBaseModel
+
+The base model contains fields common to all CRUD operations.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | Yes | Profile name |
+| `server` | `List[TacacsServer]` | No | List of TACACS+ servers |
+| `protocol` | `TacacsProtocol` | No | TACACS+ protocol type |
+| `timeout` | `int` | No | Timeout in seconds (1-30) |
+| `use_single_connection` | `bool` | No | Use single connection |
+| `folder` | `str` | No* | Folder in which the resource is defined |
+| `snippet` | `str` | No* | Snippet in which the resource is defined |
+| `device` | `str` | No* | Device in which the resource is defined |
+
+\* Exactly one of `folder`, `snippet`, or `device` is required.
+
+### TacacsServerProfileCreateModel
+
+Inherits from `TacacsServerProfileBaseModel` and adds container validation ensuring exactly one of `folder`, `snippet`, or `device` is provided.
+
+### TacacsServerProfileUpdateModel
+
+Inherits from `TacacsServerProfileBaseModel` with an additional required field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+### TacacsServerProfileResponseModel
+
+Inherits from `TacacsServerProfileBaseModel` with an additional field:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `UUID` | Yes | The unique identifier of the profile |
+
+!!! note
+    The response model uses `extra="ignore"` to handle any additional fields returned by the API.
+
+## Component Models
+
+### TacacsServer
+
+Represents a single TACACS+ server entry.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `str` | No | Server name |
+| `address` | `str` | No | Server address |
+| `port` | `int` | No | Server port number (1-65535) |
+| `secret` | `str` | No | Shared secret |
+
+### TacacsProtocol
+
+Protocol type enumeration.
+
+| Value | Description |
+| --- | --- |
+| `CHAP` | Challenge-Handshake Authentication Protocol |
+| `PAP` | Password Authentication Protocol |
+
+## Usage Examples
+
+### Creating a TACACS+ Server Profile
+
+```python
+from scm.models.identity.tacacs_server_profiles import (
+    TacacsServerProfileCreateModel,
+    TacacsServer,
+    TacacsProtocol,
+)
+
+# Create model instance
+profile = TacacsServerProfileCreateModel(
+    name="corp-tacacs",
+    folder="Texas",
+    server=[
+        TacacsServer(
+            name="tacacs-primary",
+            address="10.0.1.50",
+            port=49,
+            secret="shared-secret"
+        )
+    ],
+    protocol=TacacsProtocol.CHAP,
+    timeout=5,
+    use_single_connection=True
+)
+
+# Use with SDK
+payload = profile.model_dump(exclude_unset=True)
+result = client.tacacs_server_profile.create(payload)
+```
+
+### Parsing a TACACS+ Server Profile Response
+
+```python
+from scm.models.identity.tacacs_server_profiles import (
+    TacacsServerProfileResponseModel,
+)
+
+# Parse API response
+response = TacacsServerProfileResponseModel(**api_response)
+print(f"Name: {response.name}")
+print(f"Protocol: {response.protocol}")
+print(f"Timeout: {response.timeout}")
+if response.server:
+    for server in response.server:
+        print(f"  Server: {server.name} ({server.address}:{server.port})")
+```
+
+## Related Topics
+
+- [TACACS+ Server Profile Service](../../config/identity/tacacs_server_profile.md)
+- [Authentication Profile Models](authentication_profile_models.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,14 @@ nav:
           - URL Categories: sdk/config/security_services/url_categories.md
           - WildFire Antivirus Profiles: sdk/config/security_services/wildfire_antivirus.md
           - Vulnerability Protection Profiles: sdk/config/security_services/vulnerability_protection_profile.md
+      - Identity:
+          - Overview: sdk/config/identity/index.md
+          - Authentication Profiles: sdk/config/identity/authentication_profile.md
+          - Kerberos Server Profiles: sdk/config/identity/kerberos_server_profile.md
+          - LDAP Server Profiles: sdk/config/identity/ldap_server_profile.md
+          - RADIUS Server Profiles: sdk/config/identity/radius_server_profile.md
+          - SAML Server Profiles: sdk/config/identity/saml_server_profile.md
+          - TACACS+ Server Profiles: sdk/config/identity/tacacs_server_profile.md
       - Setup:
           - Overview: sdk/config/setup/index.md
           - Folders: sdk/config/setup/folder.md
@@ -264,6 +272,14 @@ nav:
           - URL Categories: sdk/models/security_services/url_categories_models.md
           - WildFire Antivirus Profiles: sdk/models/security_services/wildfire_antivirus_profile_models.md
           - Vulnerability Protection Profiles: sdk/models/security_services/vulnerability_protection_profile_models.md
+      - Identity:
+          - Overview: sdk/models/identity/index.md
+          - Authentication Profiles: sdk/models/identity/authentication_profile_models.md
+          - Kerberos Server Profiles: sdk/models/identity/kerberos_server_profile_models.md
+          - LDAP Server Profiles: sdk/models/identity/ldap_server_profile_models.md
+          - RADIUS Server Profiles: sdk/models/identity/radius_server_profile_models.md
+          - SAML Server Profiles: sdk/models/identity/saml_server_profile_models.md
+          - TACACS+ Server Profiles: sdk/models/identity/tacacs_server_profile_models.md
       - Setup:
           - Overview: sdk/models/setup/index.md
           - Folders: sdk/models/setup/folder_models.md


### PR DESCRIPTION
## Summary
- Create 14 new documentation pages for the 6 identity services
- 7 service reference pages (`docs/sdk/config/identity/`)
- 7 model reference pages (`docs/sdk/models/identity/`)
- Add Identity section to mkdocs.yml navigation

Services documented: authentication_profile, kerberos_server_profile, ldap_server_profile, radius_server_profile, saml_server_profile, tacacs_server_profile

Closes #270

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] All 14 pages render correctly on GitHub Pages
- [ ] Navigation includes Identity section

🤖 Generated with [Claude Code](https://claude.com/claude-code)