### PR TITLE
test: add 28 missing test factories

### DIFF
--- a/tests/factories/mobile_agent/__init__.py
+++ b/tests/factories/mobile_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Test factories for mobile agent models."""

--- a/tests/factories/mobile_agent/agent_versions.py
+++ b/tests/factories/mobile_agent/agent_versions.py
@@ -1,0 +1,59 @@
+"""Factory definitions for mobile agent Agent Versions objects."""
+
+import factory
+
+from scm.models.mobile_agent.agent_versions import AgentVersionModel, AgentVersionsModel
+
+
+# SDK tests against SCM API
+class AgentVersionModelFactory(factory.Factory):
+    """Factory for creating AgentVersionModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AgentVersionModelFactory."""
+
+        model = AgentVersionModel
+
+    version = factory.Sequence(lambda n: f"5.3.{n}")
+    release_date = None
+    is_recommended = None
+
+
+class AgentVersionsModelFactory(factory.Factory):
+    """Factory for creating AgentVersionsModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AgentVersionsModelFactory."""
+
+        model = AgentVersionsModel
+
+    agent_versions = factory.LazyFunction(lambda: ["5.3.0", "5.2.8", "5.2.7"])
+
+
+# Pydantic modeling tests
+class AgentVersionCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AgentVersionModel validation testing."""
+
+    version = factory.Sequence(lambda n: f"5.3.{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            version="5.3.0",
+            release_date="2023-05-15",
+            is_recommended=True,
+        )
+
+
+class AgentVersionsCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AgentVersionsModel validation testing."""
+
+    agent_versions = ["5.3.0", "5.2.8", "5.2.7"]
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            agent_versions=["5.3.0", "5.2.8", "5.2.7"],
+        )

--- a/tests/factories/mobile_agent/auth_settings.py
+++ b/tests/factories/mobile_agent/auth_settings.py
@@ -1,0 +1,106 @@
+"""Factory definitions for mobile agent Auth Settings objects."""
+
+import factory
+
+from scm.models.mobile_agent.auth_settings import (
+    AuthSettingsCreateModel,
+    AuthSettingsResponseModel,
+    AuthSettingsUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class AuthSettingsCreateApiFactory(factory.Factory):
+    """Factory for creating AuthSettingsCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthSettingsCreateApiFactory."""
+
+        model = AuthSettingsCreateModel
+
+    name = factory.Sequence(lambda n: f"auth_settings_{n}")
+    authentication_profile = "default-auth-profile"
+    os = "Any"
+    user_credential_or_client_cert_required = None
+    folder = "Mobile Users"
+
+
+class AuthSettingsUpdateApiFactory(factory.Factory):
+    """Factory for creating AuthSettingsUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthSettingsUpdateApiFactory."""
+
+        model = AuthSettingsUpdateModel
+
+    name = factory.Sequence(lambda n: f"auth_settings_{n}")
+    authentication_profile = "default-auth-profile"
+    os = None
+    user_credential_or_client_cert_required = None
+    folder = "Mobile Users"
+
+
+class AuthSettingsResponseFactory(factory.Factory):
+    """Factory for creating AuthSettingsResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthSettingsResponseFactory."""
+
+        model = AuthSettingsResponseModel
+
+    name = factory.Sequence(lambda n: f"auth_settings_{n}")
+    authentication_profile = "default-auth-profile"
+    os = "Any"
+    user_credential_or_client_cert_required = None
+    folder = "Mobile Users"
+
+    @classmethod
+    def from_request(cls, request_model: AuthSettingsCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class AuthSettingsCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AuthSettingsCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"auth_settings_{n}")
+    authentication_profile = "default-auth-profile"
+    folder = "Mobile Users"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestAuthSettings",
+            authentication_profile="test-auth-profile",
+            os="Any",
+            folder="Mobile Users",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestAuthSettings",
+            authentication_profile="test-auth-profile",
+            folder=None,
+        )
+
+
+class AuthSettingsUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AuthSettingsUpdateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"auth_settings_{n}")
+    authentication_profile = "default-auth-profile"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating auth settings."""
+        return cls(
+            name="UpdatedAuthSettings",
+            authentication_profile="updated-auth-profile",
+            folder="Mobile Users",
+        )

--- a/tests/factories/network/aggregate_interface.py
+++ b/tests/factories/network/aggregate_interface.py
@@ -1,0 +1,131 @@
+"""Factory definitions for network Aggregate Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.aggregate_interface import (
+    AggregateInterfaceCreateModel,
+    AggregateInterfaceResponseModel,
+    AggregateInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class AggregateInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating AggregateInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AggregateInterfaceCreateApiFactory."""
+
+        model = AggregateInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"aggregate_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    layer2 = None
+    layer3 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class AggregateInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating AggregateInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AggregateInterfaceUpdateApiFactory."""
+
+        model = AggregateInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"aggregate_interface_{n}")
+    default_value = None
+    comment = None
+    layer2 = None
+    layer3 = None
+
+
+class AggregateInterfaceResponseFactory(factory.Factory):
+    """Factory for creating AggregateInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AggregateInterfaceResponseFactory."""
+
+        model = AggregateInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"aggregate_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    layer2 = None
+    layer3 = None
+
+    @classmethod
+    def from_request(cls, request_model: AggregateInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class AggregateInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AggregateInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"aggregate_interface_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestAggregateInterface",
+            folder="Shared",
+            comment="Test aggregate interface",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestAggregateInterface",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestAggregateInterface",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class AggregateInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AggregateInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"aggregate_interface_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an aggregate interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedAggregateInterface",
+            comment="Updated comment",
+        )

--- a/tests/factories/network/bgp_address_family_profile.py
+++ b/tests/factories/network/bgp_address_family_profile.py
@@ -1,0 +1,120 @@
+"""Factory definitions for network BGP Address Family Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_address_family_profile import (
+    BgpAddressFamilyProfileCreateModel,
+    BgpAddressFamilyProfileResponseModel,
+    BgpAddressFamilyProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpAddressFamilyProfileCreateApiFactory(factory.Factory):
+    """Factory for creating BgpAddressFamilyProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAddressFamilyProfileCreateApiFactory."""
+
+        model = BgpAddressFamilyProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_af_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpAddressFamilyProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpAddressFamilyProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAddressFamilyProfileUpdateApiFactory."""
+
+        model = BgpAddressFamilyProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_af_profile_{n}")
+    ipv4 = None
+
+
+class BgpAddressFamilyProfileResponseFactory(factory.Factory):
+    """Factory for creating BgpAddressFamilyProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAddressFamilyProfileResponseFactory."""
+
+        model = BgpAddressFamilyProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_af_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpAddressFamilyProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpAddressFamilyProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpAddressFamilyProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_af_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpAfProfile",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpAfProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpAfProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpAddressFamilyProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpAddressFamilyProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_af_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP address family profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpAfProfile",
+        )

--- a/tests/factories/network/bgp_auth_profile.py
+++ b/tests/factories/network/bgp_auth_profile.py
@@ -1,0 +1,122 @@
+"""Factory definitions for network BGP Authentication Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_auth_profile import (
+    BgpAuthProfileCreateModel,
+    BgpAuthProfileResponseModel,
+    BgpAuthProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpAuthProfileCreateApiFactory(factory.Factory):
+    """Factory for creating BgpAuthProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAuthProfileCreateApiFactory."""
+
+        model = BgpAuthProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_auth_profile_{n}")
+    folder = "Shared"
+    secret = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpAuthProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpAuthProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAuthProfileUpdateApiFactory."""
+
+        model = BgpAuthProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_auth_profile_{n}")
+    secret = None
+
+
+class BgpAuthProfileResponseFactory(factory.Factory):
+    """Factory for creating BgpAuthProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpAuthProfileResponseFactory."""
+
+        model = BgpAuthProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_auth_profile_{n}")
+    folder = "Shared"
+    secret = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpAuthProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpAuthProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpAuthProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_auth_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpAuthProfile",
+            folder="Shared",
+            secret="my-secret-key",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpAuthProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpAuthProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpAuthProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpAuthProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_auth_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP auth profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpAuthProfile",
+            secret="updated-secret",
+        )

--- a/tests/factories/network/bgp_filtering_profile.py
+++ b/tests/factories/network/bgp_filtering_profile.py
@@ -1,0 +1,120 @@
+"""Factory definitions for network BGP Filtering Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_filtering_profile import (
+    BgpFilteringProfileCreateModel,
+    BgpFilteringProfileResponseModel,
+    BgpFilteringProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpFilteringProfileCreateApiFactory(factory.Factory):
+    """Factory for creating BgpFilteringProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpFilteringProfileCreateApiFactory."""
+
+        model = BgpFilteringProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_filtering_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpFilteringProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpFilteringProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpFilteringProfileUpdateApiFactory."""
+
+        model = BgpFilteringProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_filtering_profile_{n}")
+    ipv4 = None
+
+
+class BgpFilteringProfileResponseFactory(factory.Factory):
+    """Factory for creating BgpFilteringProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpFilteringProfileResponseFactory."""
+
+        model = BgpFilteringProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_filtering_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpFilteringProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpFilteringProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpFilteringProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_filtering_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpFilteringProfile",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpFilteringProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpFilteringProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpFilteringProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpFilteringProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_filtering_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP filtering profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpFilteringProfile",
+        )

--- a/tests/factories/network/bgp_redistribution_profile.py
+++ b/tests/factories/network/bgp_redistribution_profile.py
@@ -1,0 +1,120 @@
+"""Factory definitions for network BGP Redistribution Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_redistribution_profile import (
+    BgpRedistributionProfileCreateModel,
+    BgpRedistributionProfileResponseModel,
+    BgpRedistributionProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpRedistributionProfileCreateApiFactory(factory.Factory):
+    """Factory for creating BgpRedistributionProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRedistributionProfileCreateApiFactory."""
+
+        model = BgpRedistributionProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_redist_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpRedistributionProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpRedistributionProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRedistributionProfileUpdateApiFactory."""
+
+        model = BgpRedistributionProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_redist_profile_{n}")
+    ipv4 = None
+
+
+class BgpRedistributionProfileResponseFactory(factory.Factory):
+    """Factory for creating BgpRedistributionProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRedistributionProfileResponseFactory."""
+
+        model = BgpRedistributionProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_redist_profile_{n}")
+    folder = "Shared"
+    ipv4 = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpRedistributionProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpRedistributionProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRedistributionProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_redist_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpRedistProfile",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpRedistProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpRedistProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpRedistributionProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRedistributionProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_redist_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP redistribution profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpRedistProfile",
+        )

--- a/tests/factories/network/bgp_route_map.py
+++ b/tests/factories/network/bgp_route_map.py
@@ -1,0 +1,120 @@
+"""Factory definitions for network BGP Route Map objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_route_map import (
+    BgpRouteMapCreateModel,
+    BgpRouteMapResponseModel,
+    BgpRouteMapUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpRouteMapCreateApiFactory(factory.Factory):
+    """Factory for creating BgpRouteMapCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapCreateApiFactory."""
+
+        model = BgpRouteMapCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_route_map_{n}")
+    folder = "Shared"
+    route_map = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpRouteMapUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpRouteMapUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapUpdateApiFactory."""
+
+        model = BgpRouteMapUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_route_map_{n}")
+    route_map = None
+
+
+class BgpRouteMapResponseFactory(factory.Factory):
+    """Factory for creating BgpRouteMapResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapResponseFactory."""
+
+        model = BgpRouteMapResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_route_map_{n}")
+    folder = "Shared"
+    route_map = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpRouteMapCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpRouteMapCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRouteMapCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_route_map_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpRouteMap",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpRouteMap",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpRouteMap",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpRouteMapUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRouteMapUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_route_map_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP route map."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpRouteMap",
+        )

--- a/tests/factories/network/bgp_route_map_redistribution.py
+++ b/tests/factories/network/bgp_route_map_redistribution.py
@@ -1,0 +1,126 @@
+"""Factory definitions for network BGP Route Map Redistribution objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.bgp_route_map_redistribution import (
+    BgpRouteMapRedistributionCreateModel,
+    BgpRouteMapRedistributionResponseModel,
+    BgpRouteMapRedistributionUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class BgpRouteMapRedistributionCreateApiFactory(factory.Factory):
+    """Factory for creating BgpRouteMapRedistributionCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapRedistributionCreateApiFactory."""
+
+        model = BgpRouteMapRedistributionCreateModel
+
+    name = factory.Sequence(lambda n: f"bgp_route_map_redist_{n}")
+    folder = "Shared"
+    bgp = None
+    ospf = None
+    connected_static = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class BgpRouteMapRedistributionUpdateApiFactory(factory.Factory):
+    """Factory for creating BgpRouteMapRedistributionUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapRedistributionUpdateApiFactory."""
+
+        model = BgpRouteMapRedistributionUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_route_map_redist_{n}")
+    bgp = None
+    ospf = None
+    connected_static = None
+
+
+class BgpRouteMapRedistributionResponseFactory(factory.Factory):
+    """Factory for creating BgpRouteMapRedistributionResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for BgpRouteMapRedistributionResponseFactory."""
+
+        model = BgpRouteMapRedistributionResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"bgp_route_map_redist_{n}")
+    folder = "Shared"
+    bgp = None
+    ospf = None
+    connected_static = None
+
+    @classmethod
+    def from_request(cls, request_model: BgpRouteMapRedistributionCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class BgpRouteMapRedistributionCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRouteMapRedistributionCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"bgp_route_map_redist_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestBgpRouteMapRedist",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestBgpRouteMapRedist",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestBgpRouteMapRedist",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class BgpRouteMapRedistributionUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for BgpRouteMapRedistributionUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"bgp_route_map_redist_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a BGP route map redistribution."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedBgpRouteMapRedist",
+        )

--- a/tests/factories/network/dhcp_interface.py
+++ b/tests/factories/network/dhcp_interface.py
@@ -1,0 +1,127 @@
+"""Factory definitions for network DHCP Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.dhcp_interface import (
+    DhcpInterfaceCreateModel,
+    DhcpInterfaceResponseModel,
+    DhcpInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class DhcpInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating DhcpInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for DhcpInterfaceCreateApiFactory."""
+
+        model = DhcpInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"dhcp_interface_{n}")
+    folder = "Shared"
+    server = None
+    relay = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class DhcpInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating DhcpInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for DhcpInterfaceUpdateApiFactory."""
+
+        model = DhcpInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"dhcp_interface_{n}")
+    server = None
+    relay = None
+
+
+class DhcpInterfaceResponseFactory(factory.Factory):
+    """Factory for creating DhcpInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for DhcpInterfaceResponseFactory."""
+
+        model = DhcpInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"dhcp_interface_{n}")
+    folder = "Shared"
+    server = None
+    relay = None
+
+    @classmethod
+    def from_request(cls, request_model: DhcpInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class DhcpInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for DhcpInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"dhcp_interface_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestDhcpInterface",
+            folder="Shared",
+            server={
+                "mode": "enabled",
+                "ip_pool": ["10.0.0.10-10.0.0.100"],
+            },
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestDhcpInterface",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestDhcpInterface",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class DhcpInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for DhcpInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"dhcp_interface_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a DHCP interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedDhcpInterface",
+        )

--- a/tests/factories/network/ethernet_interface.py
+++ b/tests/factories/network/ethernet_interface.py
@@ -1,0 +1,153 @@
+"""Factory definitions for network Ethernet Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ethernet_interface import (
+    EthernetInterfaceCreateModel,
+    EthernetInterfaceResponseModel,
+    EthernetInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class EthernetInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating EthernetInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for EthernetInterfaceCreateApiFactory."""
+
+        model = EthernetInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"$ethernet_if_{n}")
+    default_value = None
+    comment = None
+    link_speed = "auto"
+    link_duplex = "auto"
+    link_state = "auto"
+    poe = None
+    layer2 = None
+    layer3 = None
+    tap = None
+    folder = "Shared"
+    slot = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class EthernetInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating EthernetInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for EthernetInterfaceUpdateApiFactory."""
+
+        model = EthernetInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"$ethernet_if_{n}")
+    default_value = None
+    comment = None
+    link_speed = "auto"
+    link_duplex = "auto"
+    link_state = "auto"
+    poe = None
+    layer2 = None
+    layer3 = None
+    tap = None
+    slot = None
+
+
+class EthernetInterfaceResponseFactory(factory.Factory):
+    """Factory for creating EthernetInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for EthernetInterfaceResponseFactory."""
+
+        model = EthernetInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"$ethernet_if_{n}")
+    default_value = None
+    comment = None
+    link_speed = "auto"
+    link_duplex = "auto"
+    link_state = "auto"
+    poe = None
+    layer2 = None
+    layer3 = None
+    tap = None
+    folder = "Shared"
+    slot = None
+
+    @classmethod
+    def from_request(cls, request_model: EthernetInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class EthernetInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for EthernetInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"$ethernet_if_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="$ethernet_if_test",
+            folder="Shared",
+            default_value="ethernet1/1",
+            comment="Test ethernet interface",
+            link_speed="auto",
+            link_duplex="auto",
+            link_state="auto",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="$ethernet_if_test",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="$ethernet_if_test",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class EthernetInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for EthernetInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"$ethernet_if_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an ethernet interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="$updated_ethernet_if",
+            comment="Updated ethernet interface",
+        )

--- a/tests/factories/network/ike_crypto_profile.py
+++ b/tests/factories/network/ike_crypto_profile.py
@@ -1,0 +1,151 @@
+"""Factory definitions for network IKE Crypto Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ike_crypto_profile import (
+    IKECryptoProfileCreateModel,
+    IKECryptoProfileResponseModel,
+    IKECryptoProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class IKECryptoProfileCreateApiFactory(factory.Factory):
+    """Factory for creating IKECryptoProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKECryptoProfileCreateApiFactory."""
+
+        model = IKECryptoProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"ike_crypto_profile_{n}")
+    hash = ["sha256"]
+    encryption = ["aes-256-cbc"]
+    dh_group = ["group14"]
+    lifetime = None
+    authentication_multiple = 0
+    folder = "Shared"
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class IKECryptoProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating IKECryptoProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKECryptoProfileUpdateApiFactory."""
+
+        model = IKECryptoProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ike_crypto_profile_{n}")
+    hash = ["sha256"]
+    encryption = ["aes-256-cbc"]
+    dh_group = ["group14"]
+    lifetime = None
+    authentication_multiple = 0
+
+
+class IKECryptoProfileResponseFactory(factory.Factory):
+    """Factory for creating IKECryptoProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKECryptoProfileResponseFactory."""
+
+        model = IKECryptoProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ike_crypto_profile_{n}")
+    hash = ["sha256"]
+    encryption = ["aes-256-cbc"]
+    dh_group = ["group14"]
+    lifetime = None
+    authentication_multiple = 0
+    folder = "Shared"
+
+    @classmethod
+    def from_request(cls, request_model: IKECryptoProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class IKECryptoProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IKECryptoProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ike_crypto_profile_{n}")
+    folder = "Shared"
+    hash = ["sha256"]
+    encryption = ["aes-256-cbc"]
+    dh_group = ["group14"]
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestIKECryptoProfile",
+            folder="Shared",
+            hash=["sha256", "sha384"],
+            encryption=["aes-256-cbc"],
+            dh_group=["group14", "group19"],
+            authentication_multiple=0,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestIKECryptoProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+            hash=["sha256"],
+            encryption=["aes-256-cbc"],
+            dh_group=["group14"],
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestIKECryptoProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+            hash=["sha256"],
+            encryption=["aes-256-cbc"],
+            dh_group=["group14"],
+        )
+
+
+class IKECryptoProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IKECryptoProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ike_crypto_profile_{n}")
+    hash = ["sha256"]
+    encryption = ["aes-256-cbc"]
+    dh_group = ["group14"]
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an IKE crypto profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedIKECryptoProfile",
+            hash=["sha512"],
+            encryption=["aes-256-cbc"],
+            dh_group=["group20"],
+        )

--- a/tests/factories/network/ike_gateway.py
+++ b/tests/factories/network/ike_gateway.py
@@ -1,0 +1,153 @@
+"""Factory definitions for network IKE Gateway objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ike_gateway import (
+    IKEGatewayCreateModel,
+    IKEGatewayResponseModel,
+    IKEGatewayUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class IKEGatewayCreateApiFactory(factory.Factory):
+    """Factory for creating IKEGatewayCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKEGatewayCreateApiFactory."""
+
+        model = IKEGatewayCreateModel
+
+    name = factory.Sequence(lambda n: f"ike_gateway_{n}")
+    authentication = {"pre_shared_key": {"key": "test-secret-key"}}
+    peer_id = None
+    local_id = None
+    protocol = {"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}}
+    protocol_common = None
+    peer_address = {"ip": "10.0.0.1"}
+    folder = "Shared"
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class IKEGatewayUpdateApiFactory(factory.Factory):
+    """Factory for creating IKEGatewayUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKEGatewayUpdateApiFactory."""
+
+        model = IKEGatewayUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ike_gateway_{n}")
+    authentication = {"pre_shared_key": {"key": "test-secret-key"}}
+    peer_id = None
+    local_id = None
+    protocol = {"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}}
+    protocol_common = None
+    peer_address = {"ip": "10.0.0.1"}
+
+
+class IKEGatewayResponseFactory(factory.Factory):
+    """Factory for creating IKEGatewayResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IKEGatewayResponseFactory."""
+
+        model = IKEGatewayResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ike_gateway_{n}")
+    authentication = {"pre_shared_key": {"key": "test-secret-key"}}
+    peer_id = None
+    local_id = None
+    protocol = {"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}}
+    protocol_common = None
+    peer_address = {"ip": "10.0.0.1"}
+    folder = "Shared"
+
+    @classmethod
+    def from_request(cls, request_model: IKEGatewayCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class IKEGatewayCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IKEGatewayCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ike_gateway_{n}")
+    folder = "Shared"
+    authentication = {"pre_shared_key": {"key": "test-secret-key"}}
+    protocol = {"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}}
+    peer_address = {"ip": "10.0.0.1"}
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestIKEGateway",
+            folder="Shared",
+            authentication={"pre_shared_key": {"key": "my-secret-key"}},
+            protocol={"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}},
+            peer_address={"ip": "10.0.0.1"},
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestIKEGateway",
+            folder="Shared",
+            snippet="TestSnippet",
+            authentication={"pre_shared_key": {"key": "test-secret-key"}},
+            protocol={"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}},
+            peer_address={"ip": "10.0.0.1"},
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestIKEGateway",
+            folder=None,
+            snippet=None,
+            device=None,
+            authentication={"pre_shared_key": {"key": "test-secret-key"}},
+            protocol={"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}},
+            peer_address={"ip": "10.0.0.1"},
+        )
+
+
+class IKEGatewayUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IKEGatewayUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ike_gateway_{n}")
+    authentication = {"pre_shared_key": {"key": "test-secret-key"}}
+    protocol = {"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}}
+    peer_address = {"ip": "10.0.0.1"}
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an IKE gateway."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedIKEGateway",
+            authentication={"pre_shared_key": {"key": "updated-secret-key"}},
+            protocol={"version": "ikev2-preferred", "ikev2": {"ike_crypto_profile": "default"}},
+            peer_address={"ip": "10.0.0.2"},
+        )

--- a/tests/factories/network/interface_management_profile.py
+++ b/tests/factories/network/interface_management_profile.py
@@ -1,0 +1,158 @@
+"""Factory definitions for network Interface Management Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.interface_management_profile import (
+    InterfaceManagementProfileCreateModel,
+    InterfaceManagementProfileResponseModel,
+    InterfaceManagementProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class InterfaceManagementProfileCreateApiFactory(factory.Factory):
+    """Factory for creating InterfaceManagementProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for InterfaceManagementProfileCreateApiFactory."""
+
+        model = InterfaceManagementProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"if_mgmt_profile_{n}")
+    http = None
+    https = None
+    telnet = None
+    ssh = None
+    ping = None
+    snmp = None
+    http_ocsp = None
+    response_pages = None
+    userid_service = None
+    userid_syslog_listener_ssl = None
+    userid_syslog_listener_udp = None
+    permitted_ip = None
+    folder = "Shared"
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class InterfaceManagementProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating InterfaceManagementProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for InterfaceManagementProfileUpdateApiFactory."""
+
+        model = InterfaceManagementProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"if_mgmt_profile_{n}")
+    http = None
+    https = None
+    telnet = None
+    ssh = None
+    ping = None
+    snmp = None
+    http_ocsp = None
+    response_pages = None
+    userid_service = None
+    userid_syslog_listener_ssl = None
+    userid_syslog_listener_udp = None
+    permitted_ip = None
+
+
+class InterfaceManagementProfileResponseFactory(factory.Factory):
+    """Factory for creating InterfaceManagementProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for InterfaceManagementProfileResponseFactory."""
+
+        model = InterfaceManagementProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"if_mgmt_profile_{n}")
+    http = None
+    https = None
+    telnet = None
+    ssh = None
+    ping = None
+    snmp = None
+    http_ocsp = None
+    response_pages = None
+    userid_service = None
+    userid_syslog_listener_ssl = None
+    userid_syslog_listener_udp = None
+    permitted_ip = None
+    folder = "Shared"
+
+    @classmethod
+    def from_request(cls, request_model: InterfaceManagementProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class InterfaceManagementProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for InterfaceManagementProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"if_mgmt_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestIfMgmtProfile",
+            folder="Shared",
+            https=True,
+            ssh=True,
+            ping=True,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestIfMgmtProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestIfMgmtProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class InterfaceManagementProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for InterfaceManagementProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"if_mgmt_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an interface management profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedIfMgmtProfile",
+            https=True,
+            ssh=True,
+        )

--- a/tests/factories/network/ipsec_crypto_profile.py
+++ b/tests/factories/network/ipsec_crypto_profile.py
@@ -1,0 +1,146 @@
+"""Factory definitions for network IPsec Crypto Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ipsec_crypto_profile import (
+    IPsecCryptoProfileCreateModel,
+    IPsecCryptoProfileResponseModel,
+    IPsecCryptoProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class IPsecCryptoProfileCreateApiFactory(factory.Factory):
+    """Factory for creating IPsecCryptoProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecCryptoProfileCreateApiFactory."""
+
+        model = IPsecCryptoProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"ipsec_crypto_profile_{n}")
+    dh_group = "group2"
+    lifetime = {"hours": 1}
+    lifesize = None
+    esp = {"encryption": ["aes-256-cbc"], "authentication": ["sha256"]}
+    ah = None
+    folder = "Shared"
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class IPsecCryptoProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating IPsecCryptoProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecCryptoProfileUpdateApiFactory."""
+
+        model = IPsecCryptoProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ipsec_crypto_profile_{n}")
+    dh_group = "group2"
+    lifetime = {"hours": 1}
+    lifesize = None
+    esp = {"encryption": ["aes-256-cbc"], "authentication": ["sha256"]}
+    ah = None
+
+
+class IPsecCryptoProfileResponseFactory(factory.Factory):
+    """Factory for creating IPsecCryptoProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecCryptoProfileResponseFactory."""
+
+        model = IPsecCryptoProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ipsec_crypto_profile_{n}")
+    dh_group = "group2"
+    lifetime = {"hours": 1}
+    lifesize = None
+    esp = {"encryption": ["aes-256-cbc"], "authentication": ["sha256"]}
+    ah = None
+    folder = "Shared"
+
+    @classmethod
+    def from_request(cls, request_model: IPsecCryptoProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class IPsecCryptoProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IPsecCryptoProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ipsec_crypto_profile_{n}")
+    folder = "Shared"
+    lifetime = {"hours": 1}
+    esp = {"encryption": ["aes-256-cbc"], "authentication": ["sha256"]}
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestIPsecCryptoProfile",
+            folder="Shared",
+            dh_group="group14",
+            lifetime={"hours": 8},
+            esp={"encryption": ["aes-256-cbc"], "authentication": ["sha256"]},
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestIPsecCryptoProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+            lifetime={"hours": 1},
+            esp={"encryption": ["aes-256-cbc"], "authentication": ["sha256"]},
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestIPsecCryptoProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+            lifetime={"hours": 1},
+            esp={"encryption": ["aes-256-cbc"], "authentication": ["sha256"]},
+        )
+
+
+class IPsecCryptoProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IPsecCryptoProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ipsec_crypto_profile_{n}")
+    lifetime = {"hours": 1}
+    esp = {"encryption": ["aes-256-cbc"], "authentication": ["sha256"]}
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an IPsec crypto profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedIPsecCryptoProfile",
+            dh_group="group19",
+            lifetime={"hours": 4},
+            esp={"encryption": ["aes-256-cbc"], "authentication": ["sha512"]},
+        )

--- a/tests/factories/network/ipsec_tunnel.py
+++ b/tests/factories/network/ipsec_tunnel.py
@@ -1,0 +1,168 @@
+"""Factory definitions for network IPsec Tunnel objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ipsec_tunnel import (
+    IPsecTunnelCreateModel,
+    IPsecTunnelResponseModel,
+    IPsecTunnelUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class IPsecTunnelCreateApiFactory(factory.Factory):
+    """Factory for creating IPsecTunnelCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecTunnelCreateApiFactory."""
+
+        model = IPsecTunnelCreateModel
+
+    name = factory.Sequence(lambda n: f"ipsec_tunnel_{n}")
+    auto_key = {
+        "ike_gateway": [{"name": "test-ike-gw"}],
+        "ipsec_crypto_profile": "default",
+    }
+    anti_replay = None
+    copy_tos = False
+    enable_gre_encapsulation = False
+    tunnel_monitor = None
+    folder = "Shared"
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class IPsecTunnelUpdateApiFactory(factory.Factory):
+    """Factory for creating IPsecTunnelUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecTunnelUpdateApiFactory."""
+
+        model = IPsecTunnelUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ipsec_tunnel_{n}")
+    auto_key = {
+        "ike_gateway": [{"name": "test-ike-gw"}],
+        "ipsec_crypto_profile": "default",
+    }
+    anti_replay = None
+    copy_tos = False
+    enable_gre_encapsulation = False
+    tunnel_monitor = None
+
+
+class IPsecTunnelResponseFactory(factory.Factory):
+    """Factory for creating IPsecTunnelResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for IPsecTunnelResponseFactory."""
+
+        model = IPsecTunnelResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ipsec_tunnel_{n}")
+    auto_key = {
+        "ike_gateway": [{"name": "test-ike-gw"}],
+        "ipsec_crypto_profile": "default",
+    }
+    anti_replay = None
+    copy_tos = False
+    enable_gre_encapsulation = False
+    tunnel_monitor = None
+    folder = "Shared"
+
+    @classmethod
+    def from_request(cls, request_model: IPsecTunnelCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class IPsecTunnelCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IPsecTunnelCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ipsec_tunnel_{n}")
+    folder = "Shared"
+    auto_key = {
+        "ike_gateway": [{"name": "test-ike-gw"}],
+        "ipsec_crypto_profile": "default",
+    }
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestIPsecTunnel",
+            folder="Shared",
+            auto_key={
+                "ike_gateway": [{"name": "test-ike-gw"}],
+                "ipsec_crypto_profile": "default",
+            },
+            anti_replay=True,
+            copy_tos=False,
+            enable_gre_encapsulation=False,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestIPsecTunnel",
+            folder="Shared",
+            snippet="TestSnippet",
+            auto_key={
+                "ike_gateway": [{"name": "test-ike-gw"}],
+                "ipsec_crypto_profile": "default",
+            },
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestIPsecTunnel",
+            folder=None,
+            snippet=None,
+            device=None,
+            auto_key={
+                "ike_gateway": [{"name": "test-ike-gw"}],
+                "ipsec_crypto_profile": "default",
+            },
+        )
+
+
+class IPsecTunnelUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for IPsecTunnelUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ipsec_tunnel_{n}")
+    auto_key = {
+        "ike_gateway": [{"name": "test-ike-gw"}],
+        "ipsec_crypto_profile": "default",
+    }
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an IPsec tunnel."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedIPsecTunnel",
+            auto_key={
+                "ike_gateway": [{"name": "updated-ike-gw"}],
+                "ipsec_crypto_profile": "updated-profile",
+            },
+        )

--- a/tests/factories/network/layer2_subinterface.py
+++ b/tests/factories/network/layer2_subinterface.py
@@ -1,0 +1,133 @@
+"""Factory definitions for network Layer2 Subinterface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.layer2_subinterface import (
+    Layer2SubinterfaceCreateModel,
+    Layer2SubinterfaceResponseModel,
+    Layer2SubinterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class Layer2SubinterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating Layer2SubinterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer2SubinterfaceCreateApiFactory."""
+
+        model = Layer2SubinterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    vlan_tag = factory.Sequence(lambda n: str(n + 100))
+    folder = "Shared"
+    parent_interface = None
+    comment = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class Layer2SubinterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating Layer2SubinterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer2SubinterfaceUpdateApiFactory."""
+
+        model = Layer2SubinterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    vlan_tag = factory.Sequence(lambda n: str(n + 100))
+    parent_interface = None
+    comment = None
+
+
+class Layer2SubinterfaceResponseFactory(factory.Factory):
+    """Factory for creating Layer2SubinterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer2SubinterfaceResponseFactory."""
+
+        model = Layer2SubinterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    vlan_tag = factory.Sequence(lambda n: str(n + 100))
+    folder = "Shared"
+    parent_interface = None
+    comment = None
+
+    @classmethod
+    def from_request(cls, request_model: Layer2SubinterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class Layer2SubinterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for Layer2SubinterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    vlan_tag = "100"
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="ethernet1/1.100",
+            vlan_tag="100",
+            folder="Shared",
+            parent_interface="ethernet1/1",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="ethernet1/1.100",
+            vlan_tag="100",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="ethernet1/1.100",
+            vlan_tag="100",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class Layer2SubinterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for Layer2SubinterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    vlan_tag = "100"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Layer2 Subinterface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="ethernet1/1.200",
+            vlan_tag="200",
+        )

--- a/tests/factories/network/layer3_subinterface.py
+++ b/tests/factories/network/layer3_subinterface.py
@@ -1,0 +1,147 @@
+"""Factory definitions for network Layer3 Subinterface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.layer3_subinterface import (
+    Layer3SubinterfaceCreateModel,
+    Layer3SubinterfaceResponseModel,
+    Layer3SubinterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class Layer3SubinterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating Layer3SubinterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer3SubinterfaceCreateApiFactory."""
+
+        model = Layer3SubinterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    folder = "Shared"
+    tag = None
+    parent_interface = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class Layer3SubinterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating Layer3SubinterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer3SubinterfaceUpdateApiFactory."""
+
+        model = Layer3SubinterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    tag = None
+    parent_interface = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+
+class Layer3SubinterfaceResponseFactory(factory.Factory):
+    """Factory for creating Layer3SubinterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for Layer3SubinterfaceResponseFactory."""
+
+        model = Layer3SubinterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    folder = "Shared"
+    tag = None
+    parent_interface = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+    @classmethod
+    def from_request(cls, request_model: Layer3SubinterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class Layer3SubinterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for Layer3SubinterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="ethernet1/1.100",
+            folder="Shared",
+            tag=100,
+            parent_interface="ethernet1/1",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="ethernet1/1.100",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="ethernet1/1.100",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class Layer3SubinterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for Layer3SubinterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ethernet1/1.{n + 100}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Layer3 Subinterface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="ethernet1/1.200",
+            tag=200,
+        )

--- a/tests/factories/network/logical_router.py
+++ b/tests/factories/network/logical_router.py
@@ -1,0 +1,123 @@
+"""Factory definitions for network Logical Router objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.logical_router import (
+    LogicalRouterCreateModel,
+    LogicalRouterResponseModel,
+    LogicalRouterUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class LogicalRouterCreateApiFactory(factory.Factory):
+    """Factory for creating LogicalRouterCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LogicalRouterCreateApiFactory."""
+
+        model = LogicalRouterCreateModel
+
+    name = factory.Sequence(lambda n: f"logical_router_{n}")
+    folder = "Shared"
+    routing_stack = None
+    vrf = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class LogicalRouterUpdateApiFactory(factory.Factory):
+    """Factory for creating LogicalRouterUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LogicalRouterUpdateApiFactory."""
+
+        model = LogicalRouterUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"logical_router_{n}")
+    routing_stack = None
+    vrf = None
+
+
+class LogicalRouterResponseFactory(factory.Factory):
+    """Factory for creating LogicalRouterResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LogicalRouterResponseFactory."""
+
+        model = LogicalRouterResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"logical_router_{n}")
+    folder = "Shared"
+    routing_stack = None
+    vrf = None
+
+    @classmethod
+    def from_request(cls, request_model: LogicalRouterCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class LogicalRouterCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for LogicalRouterCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"logical_router_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestLogicalRouter",
+            folder="Shared",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestLogicalRouter",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestLogicalRouter",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class LogicalRouterUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for LogicalRouterUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"logical_router_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Logical Router."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedLogicalRouter",
+        )

--- a/tests/factories/network/loopback_interface.py
+++ b/tests/factories/network/loopback_interface.py
@@ -1,0 +1,136 @@
+"""Factory definitions for network Loopback Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.loopback_interface import (
+    LoopbackInterfaceCreateModel,
+    LoopbackInterfaceResponseModel,
+    LoopbackInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class LoopbackInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating LoopbackInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LoopbackInterfaceCreateApiFactory."""
+
+        model = LoopbackInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"$loopback_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    ipv6 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class LoopbackInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating LoopbackInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LoopbackInterfaceUpdateApiFactory."""
+
+        model = LoopbackInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"$loopback_{n}")
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    ipv6 = None
+
+
+class LoopbackInterfaceResponseFactory(factory.Factory):
+    """Factory for creating LoopbackInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for LoopbackInterfaceResponseFactory."""
+
+        model = LoopbackInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"$loopback_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    ipv6 = None
+
+    @classmethod
+    def from_request(cls, request_model: LoopbackInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class LoopbackInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for LoopbackInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"$loopback_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="$loopback_test",
+            folder="Shared",
+            default_value="loopback.1",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="$loopback_test",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="$loopback_test",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class LoopbackInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for LoopbackInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"$loopback_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Loopback Interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="$loopback_updated",
+        )

--- a/tests/factories/network/ospf_auth_profile.py
+++ b/tests/factories/network/ospf_auth_profile.py
@@ -1,0 +1,125 @@
+"""Factory definitions for network OSPF Authentication Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.ospf_auth_profile import (
+    OspfAuthProfileCreateModel,
+    OspfAuthProfileResponseModel,
+    OspfAuthProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class OspfAuthProfileCreateApiFactory(factory.Factory):
+    """Factory for creating OspfAuthProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for OspfAuthProfileCreateApiFactory."""
+
+        model = OspfAuthProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"ospf_auth_profile_{n}")
+    folder = "Shared"
+    password = None
+    md5 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class OspfAuthProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating OspfAuthProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for OspfAuthProfileUpdateApiFactory."""
+
+        model = OspfAuthProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ospf_auth_profile_{n}")
+    password = None
+    md5 = None
+
+
+class OspfAuthProfileResponseFactory(factory.Factory):
+    """Factory for creating OspfAuthProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for OspfAuthProfileResponseFactory."""
+
+        model = OspfAuthProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"ospf_auth_profile_{n}")
+    folder = "Shared"
+    password = None
+    md5 = None
+
+    @classmethod
+    def from_request(cls, request_model: OspfAuthProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class OspfAuthProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for OspfAuthProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"ospf_auth_profile_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestOspfAuthProfile",
+            folder="Shared",
+            password="testpassword",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestOspfAuthProfile",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestOspfAuthProfile",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class OspfAuthProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for OspfAuthProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"ospf_auth_profile_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an OSPF Auth Profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedOspfAuthProfile",
+            password="updatedpassword",
+        )

--- a/tests/factories/network/route_access_list.py
+++ b/tests/factories/network/route_access_list.py
@@ -1,0 +1,125 @@
+"""Factory definitions for network Route Access List objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.route_access_list import (
+    RouteAccessListCreateModel,
+    RouteAccessListResponseModel,
+    RouteAccessListUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class RouteAccessListCreateApiFactory(factory.Factory):
+    """Factory for creating RouteAccessListCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RouteAccessListCreateApiFactory."""
+
+        model = RouteAccessListCreateModel
+
+    name = factory.Sequence(lambda n: f"route_access_list_{n}")
+    folder = "Shared"
+    description = None
+    type = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class RouteAccessListUpdateApiFactory(factory.Factory):
+    """Factory for creating RouteAccessListUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RouteAccessListUpdateApiFactory."""
+
+        model = RouteAccessListUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"route_access_list_{n}")
+    description = None
+    type = None
+
+
+class RouteAccessListResponseFactory(factory.Factory):
+    """Factory for creating RouteAccessListResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RouteAccessListResponseFactory."""
+
+        model = RouteAccessListResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"route_access_list_{n}")
+    folder = "Shared"
+    description = None
+    type = None
+
+    @classmethod
+    def from_request(cls, request_model: RouteAccessListCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class RouteAccessListCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for RouteAccessListCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"route_access_list_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestRouteAccessList",
+            folder="Shared",
+            description="Test route access list",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestRouteAccessList",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestRouteAccessList",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class RouteAccessListUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for RouteAccessListUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"route_access_list_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Route Access List."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedRouteAccessList",
+            description="Updated description",
+        )

--- a/tests/factories/network/route_prefix_list.py
+++ b/tests/factories/network/route_prefix_list.py
@@ -1,0 +1,125 @@
+"""Factory definitions for network Route Prefix List objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.route_prefix_list import (
+    RoutePrefixListCreateModel,
+    RoutePrefixListResponseModel,
+    RoutePrefixListUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class RoutePrefixListCreateApiFactory(factory.Factory):
+    """Factory for creating RoutePrefixListCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RoutePrefixListCreateApiFactory."""
+
+        model = RoutePrefixListCreateModel
+
+    name = factory.Sequence(lambda n: f"route_prefix_list_{n}")
+    folder = "Shared"
+    description = None
+    ipv4 = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class RoutePrefixListUpdateApiFactory(factory.Factory):
+    """Factory for creating RoutePrefixListUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RoutePrefixListUpdateApiFactory."""
+
+        model = RoutePrefixListUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"route_prefix_list_{n}")
+    description = None
+    ipv4 = None
+
+
+class RoutePrefixListResponseFactory(factory.Factory):
+    """Factory for creating RoutePrefixListResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for RoutePrefixListResponseFactory."""
+
+        model = RoutePrefixListResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"route_prefix_list_{n}")
+    folder = "Shared"
+    description = None
+    ipv4 = None
+
+    @classmethod
+    def from_request(cls, request_model: RoutePrefixListCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class RoutePrefixListCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for RoutePrefixListCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"route_prefix_list_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestRoutePrefixList",
+            folder="Shared",
+            description="Test route prefix list",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestRoutePrefixList",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestRoutePrefixList",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class RoutePrefixListUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for RoutePrefixListUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"route_prefix_list_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a Route Prefix List."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedRoutePrefixList",
+            description="Updated description",
+        )

--- a/tests/factories/network/security_zone.py
+++ b/tests/factories/network/security_zone.py
@@ -1,0 +1,140 @@
+"""Factory definitions for network Security Zone objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.security_zone import (
+    SecurityZoneCreateModel,
+    SecurityZoneResponseModel,
+    SecurityZoneUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class SecurityZoneCreateApiFactory(factory.Factory):
+    """Factory for creating SecurityZoneCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for SecurityZoneCreateApiFactory."""
+
+        model = SecurityZoneCreateModel
+
+    name = factory.Sequence(lambda n: f"security_zone_{n}")
+    folder = "Shared"
+    enable_user_identification = None
+    enable_device_identification = None
+    dos_profile = None
+    dos_log_setting = None
+    network = None
+    user_acl = None
+    device_acl = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class SecurityZoneUpdateApiFactory(factory.Factory):
+    """Factory for creating SecurityZoneUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for SecurityZoneUpdateApiFactory."""
+
+        model = SecurityZoneUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"security_zone_{n}")
+    enable_user_identification = None
+    enable_device_identification = None
+    dos_profile = None
+    dos_log_setting = None
+    network = None
+    user_acl = None
+    device_acl = None
+
+
+class SecurityZoneResponseFactory(factory.Factory):
+    """Factory for creating SecurityZoneResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for SecurityZoneResponseFactory."""
+
+        model = SecurityZoneResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"security_zone_{n}")
+    folder = "Shared"
+    enable_user_identification = None
+    enable_device_identification = None
+    dos_profile = None
+    dos_log_setting = None
+    network = None
+    user_acl = None
+    device_acl = None
+
+    @classmethod
+    def from_request(cls, request_model: SecurityZoneCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class SecurityZoneCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for SecurityZoneCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"security_zone_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestSecurityZone",
+            folder="Shared",
+            enable_user_identification=True,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestSecurityZone",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestSecurityZone",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class SecurityZoneUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for SecurityZoneUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"security_zone_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a security zone."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedSecurityZone",
+            enable_user_identification=True,
+        )

--- a/tests/factories/network/tunnel_interface.py
+++ b/tests/factories/network/tunnel_interface.py
@@ -1,0 +1,135 @@
+"""Factory definitions for network Tunnel Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.tunnel_interface import (
+    TunnelInterfaceCreateModel,
+    TunnelInterfaceResponseModel,
+    TunnelInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class TunnelInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating TunnelInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for TunnelInterfaceCreateApiFactory."""
+
+        model = TunnelInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"tunnel_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class TunnelInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating TunnelInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for TunnelInterfaceUpdateApiFactory."""
+
+        model = TunnelInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"tunnel_interface_{n}")
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+
+
+class TunnelInterfaceResponseFactory(factory.Factory):
+    """Factory for creating TunnelInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for TunnelInterfaceResponseFactory."""
+
+        model = TunnelInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"tunnel_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+
+    @classmethod
+    def from_request(cls, request_model: TunnelInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class TunnelInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for TunnelInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"tunnel_interface_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestTunnelInterface",
+            folder="Shared",
+            comment="Test tunnel interface",
+            mtu=1500,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestTunnelInterface",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestTunnelInterface",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class TunnelInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for TunnelInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"tunnel_interface_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a tunnel interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedTunnelInterface",
+            comment="Updated tunnel interface",
+        )

--- a/tests/factories/network/vlan_interface.py
+++ b/tests/factories/network/vlan_interface.py
@@ -1,0 +1,147 @@
+"""Factory definitions for network VLAN Interface objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.vlan_interface import (
+    VlanInterfaceCreateModel,
+    VlanInterfaceResponseModel,
+    VlanInterfaceUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class VlanInterfaceCreateApiFactory(factory.Factory):
+    """Factory for creating VlanInterfaceCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for VlanInterfaceCreateApiFactory."""
+
+        model = VlanInterfaceCreateModel
+
+    name = factory.Sequence(lambda n: f"vlan_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    vlan_tag = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class VlanInterfaceUpdateApiFactory(factory.Factory):
+    """Factory for creating VlanInterfaceUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for VlanInterfaceUpdateApiFactory."""
+
+        model = VlanInterfaceUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"vlan_interface_{n}")
+    default_value = None
+    vlan_tag = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+
+class VlanInterfaceResponseFactory(factory.Factory):
+    """Factory for creating VlanInterfaceResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for VlanInterfaceResponseFactory."""
+
+        model = VlanInterfaceResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"vlan_interface_{n}")
+    folder = "Shared"
+    default_value = None
+    vlan_tag = None
+    comment = None
+    mtu = None
+    interface_management_profile = None
+    ip = None
+    dhcp_client = None
+    arp = None
+    ddns_config = None
+
+    @classmethod
+    def from_request(cls, request_model: VlanInterfaceCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class VlanInterfaceCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for VlanInterfaceCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"vlan_interface_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestVlanInterface",
+            folder="Shared",
+            comment="Test VLAN interface",
+            mtu=1500,
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestVlanInterface",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestVlanInterface",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class VlanInterfaceUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for VlanInterfaceUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"vlan_interface_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a VLAN interface."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedVlanInterface",
+            comment="Updated VLAN interface",
+        )

--- a/tests/factories/network/zone_protection_profile.py
+++ b/tests/factories/network/zone_protection_profile.py
@@ -1,0 +1,218 @@
+"""Factory definitions for network Zone Protection Profile objects."""
+
+import uuid
+
+import factory
+
+from scm.models.network.zone_protection_profile import (
+    ZoneProtectionProfileCreateModel,
+    ZoneProtectionProfileResponseModel,
+    ZoneProtectionProfileUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class ZoneProtectionProfileCreateApiFactory(factory.Factory):
+    """Factory for creating ZoneProtectionProfileCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for ZoneProtectionProfileCreateApiFactory."""
+
+        model = ZoneProtectionProfileCreateModel
+
+    name = factory.Sequence(lambda n: f"zone_protection_{n}")
+    folder = "Shared"
+    description = None
+    flood = None
+    scan = None
+    scan_white_list = None
+    spoofed_ip_discard = None
+    strict_ip_check = None
+    fragmented_traffic_discard = None
+    strict_source_routing_discard = None
+    loose_source_routing_discard = None
+    timestamp_discard = None
+    record_route_discard = None
+    security_discard = None
+    stream_id_discard = None
+    unknown_option_discard = None
+    malformed_option_discard = None
+    mismatched_overlapping_tcp_segment_discard = None
+    tcp_handshake_discard = None
+    tcp_syn_with_data_discard = None
+    tcp_synack_with_data_discard = None
+    reject_non_syn_tcp = None
+    asymmetric_path = None
+    mptcp_option_strip = None
+    tcp_timestamp_strip = None
+    tcp_fast_open_and_data_strip = None
+    icmp_ping_zero_id_discard = None
+    icmp_frag_discard = None
+    icmp_large_packet_discard = None
+    discard_icmp_embedded_error = None
+    suppress_icmp_timeexceeded = None
+    suppress_icmp_needfrag = None
+    ipv6 = None
+    non_ip_protocol = None
+    l2_sec_group_tag_protection = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class ZoneProtectionProfileUpdateApiFactory(factory.Factory):
+    """Factory for creating ZoneProtectionProfileUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for ZoneProtectionProfileUpdateApiFactory."""
+
+        model = ZoneProtectionProfileUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"zone_protection_{n}")
+    description = None
+    flood = None
+    scan = None
+    scan_white_list = None
+    spoofed_ip_discard = None
+    strict_ip_check = None
+    fragmented_traffic_discard = None
+    strict_source_routing_discard = None
+    loose_source_routing_discard = None
+    timestamp_discard = None
+    record_route_discard = None
+    security_discard = None
+    stream_id_discard = None
+    unknown_option_discard = None
+    malformed_option_discard = None
+    mismatched_overlapping_tcp_segment_discard = None
+    tcp_handshake_discard = None
+    tcp_syn_with_data_discard = None
+    tcp_synack_with_data_discard = None
+    reject_non_syn_tcp = None
+    asymmetric_path = None
+    mptcp_option_strip = None
+    tcp_timestamp_strip = None
+    tcp_fast_open_and_data_strip = None
+    icmp_ping_zero_id_discard = None
+    icmp_frag_discard = None
+    icmp_large_packet_discard = None
+    discard_icmp_embedded_error = None
+    suppress_icmp_timeexceeded = None
+    suppress_icmp_needfrag = None
+    ipv6 = None
+    non_ip_protocol = None
+    l2_sec_group_tag_protection = None
+
+
+class ZoneProtectionProfileResponseFactory(factory.Factory):
+    """Factory for creating ZoneProtectionProfileResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for ZoneProtectionProfileResponseFactory."""
+
+        model = ZoneProtectionProfileResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"zone_protection_{n}")
+    folder = "Shared"
+    description = None
+    flood = None
+    scan = None
+    scan_white_list = None
+    spoofed_ip_discard = None
+    strict_ip_check = None
+    fragmented_traffic_discard = None
+    strict_source_routing_discard = None
+    loose_source_routing_discard = None
+    timestamp_discard = None
+    record_route_discard = None
+    security_discard = None
+    stream_id_discard = None
+    unknown_option_discard = None
+    malformed_option_discard = None
+    mismatched_overlapping_tcp_segment_discard = None
+    tcp_handshake_discard = None
+    tcp_syn_with_data_discard = None
+    tcp_synack_with_data_discard = None
+    reject_non_syn_tcp = None
+    asymmetric_path = None
+    mptcp_option_strip = None
+    tcp_timestamp_strip = None
+    tcp_fast_open_and_data_strip = None
+    icmp_ping_zero_id_discard = None
+    icmp_frag_discard = None
+    icmp_large_packet_discard = None
+    discard_icmp_embedded_error = None
+    suppress_icmp_timeexceeded = None
+    suppress_icmp_needfrag = None
+    ipv6 = None
+    non_ip_protocol = None
+    l2_sec_group_tag_protection = None
+
+    @classmethod
+    def from_request(cls, request_model: ZoneProtectionProfileCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class ZoneProtectionProfileCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for ZoneProtectionProfileCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"zone_protection_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestZoneProtection",
+            folder="Shared",
+            description="Test zone protection profile",
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestZoneProtection",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestZoneProtection",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class ZoneProtectionProfileUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for ZoneProtectionProfileUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"zone_protection_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating a zone protection profile."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedZoneProtection",
+            description="Updated zone protection profile",
+        )

--- a/tests/factories/security/authentication_rule.py
+++ b/tests/factories/security/authentication_rule.py
@@ -1,0 +1,185 @@
+"""Factory definitions for security Authentication Rule objects."""
+
+import uuid
+
+import factory
+
+from scm.models.security.authentication_rules import (
+    AuthenticationRuleCreateModel,
+    AuthenticationRuleResponseModel,
+    AuthenticationRuleUpdateModel,
+)
+
+
+# SDK tests against SCM API
+class AuthenticationRuleCreateApiFactory(factory.Factory):
+    """Factory for creating AuthenticationRuleCreateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthenticationRuleCreateApiFactory."""
+
+        model = AuthenticationRuleCreateModel
+
+    name = factory.Sequence(lambda n: f"auth_rule_{n}")
+    folder = "Shared"
+    disabled = False
+    description = None
+    tag = factory.LazyFunction(list)
+    from_ = factory.LazyFunction(lambda: ["any"])
+    source = factory.LazyFunction(lambda: ["any"])
+    negate_source = False
+    source_user = factory.LazyFunction(lambda: ["any"])
+    source_hip = factory.LazyFunction(lambda: ["any"])
+    to_ = factory.LazyFunction(lambda: ["any"])
+    destination = factory.LazyFunction(lambda: ["any"])
+    negate_destination = False
+    destination_hip = factory.LazyFunction(lambda: ["any"])
+    service = factory.LazyFunction(lambda: ["any"])
+    category = factory.LazyFunction(lambda: ["any"])
+    authentication_enforcement = None
+    hip_profiles = None
+    group_tag = None
+    timeout = None
+    log_setting = None
+    log_authentication_timeout = False
+    rulebase = None
+
+    @classmethod
+    def with_snippet(cls, snippet: str = "TestSnippet", **kwargs):
+        """Create an instance with snippet container."""
+        return cls(folder=None, snippet=snippet, device=None, **kwargs)
+
+    @classmethod
+    def with_device(cls, device: str = "TestDevice", **kwargs):
+        """Create an instance with device container."""
+        return cls(folder=None, snippet=None, device=device, **kwargs)
+
+
+class AuthenticationRuleUpdateApiFactory(factory.Factory):
+    """Factory for creating AuthenticationRuleUpdateModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthenticationRuleUpdateApiFactory."""
+
+        model = AuthenticationRuleUpdateModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"auth_rule_{n}")
+    disabled = False
+    description = None
+    tag = factory.LazyFunction(list)
+    from_ = factory.LazyFunction(lambda: ["any"])
+    source = factory.LazyFunction(lambda: ["any"])
+    negate_source = False
+    source_user = factory.LazyFunction(lambda: ["any"])
+    source_hip = factory.LazyFunction(lambda: ["any"])
+    to_ = factory.LazyFunction(lambda: ["any"])
+    destination = factory.LazyFunction(lambda: ["any"])
+    negate_destination = False
+    destination_hip = factory.LazyFunction(lambda: ["any"])
+    service = factory.LazyFunction(lambda: ["any"])
+    category = factory.LazyFunction(lambda: ["any"])
+    authentication_enforcement = None
+    hip_profiles = None
+    group_tag = None
+    timeout = None
+    log_setting = None
+    log_authentication_timeout = False
+    rulebase = None
+
+
+class AuthenticationRuleResponseFactory(factory.Factory):
+    """Factory for creating AuthenticationRuleResponseModel instances."""
+
+    class Meta:
+        """Meta class that defines the model for AuthenticationRuleResponseFactory."""
+
+        model = AuthenticationRuleResponseModel
+
+    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    name = factory.Sequence(lambda n: f"auth_rule_{n}")
+    folder = "Shared"
+    disabled = False
+    description = None
+    tag = factory.LazyFunction(list)
+    from_ = factory.LazyFunction(lambda: ["any"])
+    source = factory.LazyFunction(lambda: ["any"])
+    negate_source = False
+    source_user = factory.LazyFunction(lambda: ["any"])
+    source_hip = factory.LazyFunction(lambda: ["any"])
+    to_ = factory.LazyFunction(lambda: ["any"])
+    destination = factory.LazyFunction(lambda: ["any"])
+    negate_destination = False
+    destination_hip = factory.LazyFunction(lambda: ["any"])
+    service = factory.LazyFunction(lambda: ["any"])
+    category = factory.LazyFunction(lambda: ["any"])
+    authentication_enforcement = None
+    hip_profiles = None
+    group_tag = None
+    timeout = None
+    log_setting = None
+    log_authentication_timeout = False
+    rulebase = None
+
+    @classmethod
+    def from_request(cls, request_model: AuthenticationRuleCreateModel, **kwargs):
+        """Create a response model based on a request model."""
+        data = request_model.model_dump()
+        data["id"] = str(uuid.uuid4())
+        data.update(kwargs)
+        return cls(**data)
+
+
+# Pydantic modeling tests
+class AuthenticationRuleCreateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AuthenticationRuleCreateModel validation testing."""
+
+    name = factory.Sequence(lambda n: f"auth_rule_{n}")
+    folder = "Shared"
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict with all expected attributes."""
+        return cls(
+            name="TestAuthRule",
+            folder="Shared",
+            source=["any"],
+            destination=["any"],
+            service=["any"],
+            category=["any"],
+        )
+
+    @classmethod
+    def build_with_multiple_containers(cls):
+        """Return a data dict with multiple containers."""
+        return cls(
+            name="TestAuthRule",
+            folder="Shared",
+            snippet="TestSnippet",
+        )
+
+    @classmethod
+    def build_with_no_container(cls):
+        """Return a data dict without any container."""
+        return cls(
+            name="TestAuthRule",
+            folder=None,
+            snippet=None,
+            device=None,
+        )
+
+
+class AuthenticationRuleUpdateModelFactory(factory.DictFactory):
+    """Factory for creating data dicts for AuthenticationRuleUpdateModel validation testing."""
+
+    id = "123e4567-e89b-12d3-a456-426655440000"
+    name = factory.Sequence(lambda n: f"auth_rule_{n}")
+
+    @classmethod
+    def build_valid(cls):
+        """Return a valid data dict for updating an authentication rule."""
+        return cls(
+            id="123e4567-e89b-12d3-a456-426655440000",
+            name="UpdatedAuthRule",
+            description="Updated authentication rule",
+        )


### PR DESCRIPTION
## Summary
- Add 28 missing test data factories across 3 categories:
  - **Network (25):** aggregate_interface, bgp_address_family_profile, bgp_auth_profile, bgp_filtering_profile, bgp_redistribution_profile, bgp_route_map, bgp_route_map_redistribution, dhcp_interface, ethernet_interface, ike_crypto_profile, ike_gateway, interface_management_profile, ipsec_crypto_profile, ipsec_tunnel, layer2_subinterface, layer3_subinterface, logical_router, loopback_interface, ospf_auth_profile, route_access_list, route_prefix_list, security_zone, tunnel_interface, vlan_interface, zone_protection_profile
  - **Mobile Agent (2):** agent_versions, auth_settings
  - **Security (1):** authentication_rule
- All factories follow established pattern (API factories + dict factories)
- All factory fields match corresponding Pydantic model fields

Closes #271, #276, #277, #278, #279, #280, #281, #282, #283, #284, #285, #286, #287, #288, #289, #290, #291, #292, #293, #294, #295, #296, #297, #298, #299, #300, #301, #302, #303

## Test plan
- [x] All 28 factories import successfully
- [x] All 6012 tests pass (0 failures)
- [x] isort clean
- [x] ruff clean
- [x] No source code changes (test infrastructure only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)