### PR TITLE
docs: constrain hero logo size

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -64,8 +64,8 @@
 }
 
 .hero-logo {
-  width: 320px;
-  max-width: 80%;
+  width: 200px;
+  max-width: 60%;
   height: auto;
   margin-bottom: 0.5rem;
   filter: drop-shadow(0 4px 12px rgba(248, 182, 32, 0.25));


### PR DESCRIPTION
## Summary
- Reduce hero logo from 320px to 200px width
- Reduce max-width from 80% to 60%

🤖 Generated with [Claude Code](https://claude.com/claude-code)