### PR TITLE
chore: README logo update + v0.12.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Strata Cloud Manager SDK
 
-![Banner Image](https://raw.githubusercontent.com/cdot65/pan-scm-sdk/main/docs/images/logo.svg)
+<p align="center">
+  <a href="https://cdot65.github.io/pan-scm-sdk/"><img src="https://raw.githubusercontent.com/cdot65/pan-scm-sdk/main/docs/images/logo.svg" alt="pan-scm-sdk" width="200"></a>
+</p>
 [![codecov](https://codecov.io/github/cdot65/pan-scm-sdk/graph/badge.svg?token=BB39SMLYFP)](https://codecov.io/github/cdot65/pan-scm-sdk)
 [![Build Status](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/pan-scm-sdk.svg)](https://pypi.org/project/pan-scm-sdk/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.12.3"
+version = "0.12.4"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary
- Constrain README logo to 200px width, centered
- Bump version to 0.12.4 for PyPI release with updated README

🤖 Generated with [Claude Code](https://claude.com/claude-code)