### PR TITLE
Add HTTP 429, 502, 503 exception mappings

### DIFF
--- a/docs/sdk/exceptions.md
+++ b/docs/sdk/exceptions.md
@@ -81,6 +81,12 @@ All inherit from `BadRequestError`:
 - `MalformedCommandError`: Malformed command (E003)
 - `BadXPathError`: Invalid XPath used (E013)
 
+### Rate Limit Errors (HTTP 429)
+
+Inherits from `RateLimitError`:
+
+- `RateLimitError`: Too many requests (HTTP 429)
+
 ### Not Found Errors (HTTP 404)
 
 All inherit from `NotFoundError`:
@@ -100,6 +106,18 @@ All inherit from `ConflictError`:
 All inherit from `MethodNotAllowedError`:
 
 - `ActionNotSupportedError`: Action not supported (E012)
+
+### Bad Gateway Errors (HTTP 502)
+
+Inherits from `BadGatewayError`:
+
+- `BadGatewayError`: Bad gateway (HTTP 502)
+
+### Service Unavailable Errors (HTTP 503)
+
+Inherits from `ServiceUnavailableError`:
+
+- `ServiceUnavailableError`: Service unavailable (HTTP 503)
 
 ### Not Implemented Errors (HTTP 501)
 
@@ -132,7 +150,10 @@ ERROR_STATUS_CODE_MAP = {
     404: NotFoundError,
     405: MethodNotAllowedError,
     409: ConflictError,
+    429: RateLimitError,
     500: ServerError,
+    502: BadGatewayError,
+    503: ServiceUnavailableError,
     501: APINotImplementedError,
     504: GatewayTimeoutError,
 }

--- a/scm/exceptions/__init__.py
+++ b/scm/exceptions/__init__.py
@@ -153,6 +153,11 @@ class BadXPathError(BadRequestError):
     """Raised when an invalid XPath is used (E013: Bad XPath)."""
 
 
+# Rate Limit Errors (HTTP 429)
+class RateLimitError(ClientError):
+    """Raised when rate limited (HTTP 429 Too Many Requests)."""
+
+
 # Not Found Errors (HTTP 404)
 class NotFoundError(ClientError):
     """Raised when a resource is not found (HTTP 404 Not Found)."""
@@ -201,6 +206,16 @@ class MethodAPINotSupportedError(APINotImplementedError):
     """Raised when the method is not supported (E012: Method Not Supported)."""
 
 
+# Bad Gateway (HTTP 502)
+class BadGatewayError(ServerError):
+    """Raised when a bad gateway error occurs (HTTP 502 Bad Gateway)."""
+
+
+# Service Unavailable (HTTP 503)
+class ServiceUnavailableError(ServerError):
+    """Raised when the service is unavailable (HTTP 503 Service Unavailable)."""
+
+
 # Gateway Timeout (HTTP 504)
 class GatewayTimeoutError(ServerError):
     """Raised when a gateway timeout occurs (HTTP 504 Gateway Timeout)."""
@@ -221,7 +236,10 @@ class ErrorHandler:
         404: NotFoundError,
         405: MethodNotAllowedError,
         409: ConflictError,
+        429: RateLimitError,
         500: ServerError,
+        502: BadGatewayError,
+        503: ServiceUnavailableError,
         501: APINotImplementedError,
         504: GatewayTimeoutError,
     }

--- a/tests/scm/exceptions/test_exceptions.py
+++ b/tests/scm/exceptions/test_exceptions.py
@@ -12,6 +12,7 @@ from scm.exceptions import (
     APINotImplementedError,
     AuthenticationError,
     AuthorizationError,
+    BadGatewayError,
     BadRequestError,
     BadXPathError,
     ClientError,
@@ -38,8 +39,10 @@ from scm.exceptions import (
     ObjectNotUniqueError,
     OutputFormatMismatchError,
     PasswordChangeRequiredError,
+    RateLimitError,
     ReferenceNotZeroError,
     ServerError,
+    ServiceUnavailableError,
     SessionTimeoutError,
     UnauthorizedError,
     VersionAPINotSupportedError,
@@ -470,6 +473,81 @@ class TestErrorHandlerNestedErrorType(TestExceptionsBase):
         assert exception.http_status_code == 400
         assert exception.message == "Invalid Query Parameter"
         assert exception.details == response_data["_errors"][0]["details"]
+
+
+class TestRateLimitError(TestExceptionsBase):
+    """Tests for RateLimitError (HTTP 429)."""
+
+    def test_rate_limit_error_inheritance(self):
+        """Test RateLimitError inherits from ClientError."""
+        error = RateLimitError("Rate limited")
+        assert isinstance(error, APIError)
+        assert isinstance(error, ClientError)
+        assert isinstance(error, RateLimitError)
+
+    def test_error_handler_429_mapping(self):
+        """Test HTTP 429 maps to RateLimitError."""
+        response_data = {
+            "_errors": [
+                {
+                    "code": "RATE_LIMIT",
+                    "message": "Too many requests",
+                }
+            ]
+        }
+        with pytest.raises(RateLimitError) as exc_info:
+            ErrorHandler.raise_for_error(response_data, 429)
+        assert exc_info.value.http_status_code == 429
+
+
+class TestBadGatewayError(TestExceptionsBase):
+    """Tests for BadGatewayError (HTTP 502)."""
+
+    def test_bad_gateway_error_inheritance(self):
+        """Test BadGatewayError inherits from ServerError."""
+        error = BadGatewayError("Bad gateway")
+        assert isinstance(error, APIError)
+        assert isinstance(error, ServerError)
+        assert isinstance(error, BadGatewayError)
+
+    def test_error_handler_502_mapping(self):
+        """Test HTTP 502 maps to BadGatewayError."""
+        response_data = {
+            "_errors": [
+                {
+                    "code": "BAD_GATEWAY",
+                    "message": "Bad gateway",
+                }
+            ]
+        }
+        with pytest.raises(BadGatewayError) as exc_info:
+            ErrorHandler.raise_for_error(response_data, 502)
+        assert exc_info.value.http_status_code == 502
+
+
+class TestServiceUnavailableError(TestExceptionsBase):
+    """Tests for ServiceUnavailableError (HTTP 503)."""
+
+    def test_service_unavailable_error_inheritance(self):
+        """Test ServiceUnavailableError inherits from ServerError."""
+        error = ServiceUnavailableError("Service unavailable")
+        assert isinstance(error, APIError)
+        assert isinstance(error, ServerError)
+        assert isinstance(error, ServiceUnavailableError)
+
+    def test_error_handler_503_mapping(self):
+        """Test HTTP 503 maps to ServiceUnavailableError."""
+        response_data = {
+            "_errors": [
+                {
+                    "code": "SERVICE_UNAVAILABLE",
+                    "message": "Service unavailable",
+                }
+            ]
+        }
+        with pytest.raises(ServiceUnavailableError) as exc_info:
+            ErrorHandler.raise_for_error(response_data, 503)
+        assert exc_info.value.http_status_code == 503
 
 
 # -------------------- End of Test Classes --------------------


### PR DESCRIPTION
## Summary
- Add `RateLimitError` (429), `BadGatewayError` (502), `ServiceUnavailableError` (503)
- Map all three in `ErrorHandler.ERROR_STATUS_CODE_MAP`
- Add tests for inheritance and handler mapping
- Update exceptions docs

Closes #318

## Test plan
- [x] 6 new tests: inheritance + handler mapping for each status code
- [x] All 47 exception tests pass
- [x] All quality gates pass (ruff, flake8, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)