### PR TITLE
Update SECURITY.md versions, bump to 0.12.5

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Currently, we are providing security updates only for the latest version of our 
 
 | Version | Supported          |
 |---------| ------------------ |
-| 0.1.x   | :white_check_mark: |
-| < 0.1   | :x:                |
+| 0.12.x  | :white_check_mark: |
+| < 0.12  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.12.4"
+version = "0.12.5"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary
- Update SECURITY.md supported versions from 0.1.x to 0.12.x
- Bump version to 0.12.5 for patch release

Closes #319

## Test plan
- [x] No code changes — docs and version only

🤖 Generated with [Claude Code](https://claude.com/claude-code)