### PR TITLE
docs: fix docstring ordering, add Raises, clean setters

### DIFF
--- a/scm/config/deployment/bandwidth_allocations.py
+++ b/scm/config/deployment/bandwidth_allocations.py
@@ -67,11 +67,7 @@ class BandwidthAllocations(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -187,6 +183,10 @@ class BandwidthAllocations(BaseObject):
             name: Name of the aggregated bandwidth region
             spn_name_list: Comma-separated list of SPN names in the region
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if not name:
             raise MissingQueryParameterError(
@@ -246,6 +246,9 @@ class BandwidthAllocations(BaseObject):
 
         Returns:
             List[BandwidthAllocationResponseModel]: Filtered list of bandwidth allocations
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filtered_allocations = allocations
@@ -345,6 +348,9 @@ class BandwidthAllocations(BaseObject):
         Returns:
             List[BandwidthAllocationResponseModel]: A list of bandwidth allocation objects
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Pagination logic
         limit = self._max_limit
@@ -400,6 +406,10 @@ class BandwidthAllocations(BaseObject):
 
         Returns:
             Optional[BandwidthAllocationResponseModel]: The bandwidth allocation or None if not found
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/deployment/internal_dns_servers.py
+++ b/scm/config/deployment/internal_dns_servers.py
@@ -66,11 +66,7 @@ class InternalDnsServers(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -217,6 +213,9 @@ class InternalDnsServers(BaseObject):
         Returns:
             List[InternalDnsServersResponseModel]: A list of internal DNS server objects
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Pagination logic
         limit = self._max_limit
@@ -300,6 +299,10 @@ class InternalDnsServers(BaseObject):
 
         Returns:
             InternalDnsServersResponseModel: The fetched internal DNS server object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/deployment/network_locations.py
+++ b/scm/config/deployment/network_locations.py
@@ -62,11 +62,7 @@ class NetworkLocations(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -246,6 +242,9 @@ class NetworkLocations(BaseObject):
 
         Returns:
             List[NetworkLocationModel]: A list of network location objects
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # For network locations, the API returns a direct list rather than a paginated response

--- a/scm/config/deployment/remote_networks.py
+++ b/scm/config/deployment/remote_networks.py
@@ -69,11 +69,7 @@ class RemoteNetworks(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -128,12 +124,11 @@ class RemoteNetworks(BaseObject):
     ) -> RemoteNetworkResponseModel:
         """Create a new Remote Network object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             RemoteNetworkResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         remote_network = RemoteNetworkCreateModel(**data)
@@ -150,12 +145,11 @@ class RemoteNetworks(BaseObject):
     ) -> RemoteNetworkResponseModel:
         """Get a Remote Network object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             RemoteNetworkResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         endpoint = f"{self.ENDPOINT}/{object_id}"
@@ -389,6 +383,10 @@ class RemoteNetworks(BaseObject):
         Returns:
             List[RemoteNetworkResponseModel]: A list of remote network objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -513,6 +511,10 @@ class RemoteNetworks(BaseObject):
 
         Returns:
             RemoteNetworkResponseModel: The fetched remote network object.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/deployment/service_connections.py
+++ b/scm/config/deployment/service_connections.py
@@ -67,11 +67,7 @@ class ServiceConnection(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -215,6 +211,9 @@ class ServiceConnection(BaseObject):
         Returns:
             List[ServiceConnectionResponseModel]: A list of service connection objects
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Pagination logic
         limit = self._max_limit
@@ -311,6 +310,10 @@ class ServiceConnection(BaseObject):
 
         Returns:
             ServiceConnectionResponseModel: The fetched service connection object
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+            MissingQueryParameterError: If a required query parameter is missing or empty.
 
         """
         if not name:

--- a/scm/config/identity/authentication_profile.py
+++ b/scm/config/identity/authentication_profile.py
@@ -66,11 +66,7 @@ class AuthenticationProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class AuthenticationProfile(BaseObject):
     ) -> AuthenticationProfileResponseModel:
         """Create a new authentication profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             AuthenticationProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class AuthenticationProfile(BaseObject):
     ) -> AuthenticationProfileResponseModel:
         """Get an authentication profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             AuthenticationProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class AuthenticationProfile(BaseObject):
 
         Returns:
             List[AuthenticationProfileResponseModel]: A list of authentication profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class AuthenticationProfile(BaseObject):
 
         Returns:
             AuthenticationProfileResponseModel: The fetched authentication profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/identity/kerberos_server_profile.py
+++ b/scm/config/identity/kerberos_server_profile.py
@@ -66,11 +66,7 @@ class KerberosServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class KerberosServerProfile(BaseObject):
     ) -> KerberosServerProfileResponseModel:
         """Create a new Kerberos server profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             KerberosServerProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class KerberosServerProfile(BaseObject):
     ) -> KerberosServerProfileResponseModel:
         """Get a Kerberos server profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             KerberosServerProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class KerberosServerProfile(BaseObject):
 
         Returns:
             List[KerberosServerProfileResponseModel]: A list of Kerberos server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class KerberosServerProfile(BaseObject):
 
         Returns:
             KerberosServerProfileResponseModel: The fetched Kerberos server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/identity/ldap_server_profile.py
+++ b/scm/config/identity/ldap_server_profile.py
@@ -66,11 +66,7 @@ class LdapServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class LdapServerProfile(BaseObject):
     ) -> LdapServerProfileResponseModel:
         """Create a new LDAP server profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             LdapServerProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class LdapServerProfile(BaseObject):
     ) -> LdapServerProfileResponseModel:
         """Get an LDAP server profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             LdapServerProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class LdapServerProfile(BaseObject):
 
         Returns:
             List[LdapServerProfileResponseModel]: A list of LDAP server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class LdapServerProfile(BaseObject):
 
         Returns:
             LdapServerProfileResponseModel: The fetched LDAP server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/identity/radius_server_profile.py
+++ b/scm/config/identity/radius_server_profile.py
@@ -66,11 +66,7 @@ class RadiusServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class RadiusServerProfile(BaseObject):
     ) -> RadiusServerProfileResponseModel:
         """Create a new RADIUS server profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             RadiusServerProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class RadiusServerProfile(BaseObject):
     ) -> RadiusServerProfileResponseModel:
         """Get a RADIUS server profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             RadiusServerProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class RadiusServerProfile(BaseObject):
 
         Returns:
             List[RadiusServerProfileResponseModel]: A list of RADIUS server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class RadiusServerProfile(BaseObject):
 
         Returns:
             RadiusServerProfileResponseModel: The fetched RADIUS server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/identity/saml_server_profile.py
+++ b/scm/config/identity/saml_server_profile.py
@@ -66,11 +66,7 @@ class SamlServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class SamlServerProfile(BaseObject):
     ) -> SamlServerProfileResponseModel:
         """Create a new SAML server profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             SamlServerProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class SamlServerProfile(BaseObject):
     ) -> SamlServerProfileResponseModel:
         """Get a SAML server profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             SamlServerProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class SamlServerProfile(BaseObject):
 
         Returns:
             List[SamlServerProfileResponseModel]: A list of SAML server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class SamlServerProfile(BaseObject):
 
         Returns:
             SamlServerProfileResponseModel: The fetched SAML server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/identity/tacacs_server_profile.py
+++ b/scm/config/identity/tacacs_server_profile.py
@@ -66,11 +66,7 @@ class TacacsServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class TacacsServerProfile(BaseObject):
     ) -> TacacsServerProfileResponseModel:
         """Create a new TACACS+ server profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             TacacsServerProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class TacacsServerProfile(BaseObject):
     ) -> TacacsServerProfileResponseModel:
         """Get a TACACS+ server profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             TacacsServerProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -265,6 +259,10 @@ class TacacsServerProfile(BaseObject):
 
         Returns:
             List[TacacsServerProfileResponseModel]: A list of TACACS+ server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -399,6 +397,10 @@ class TacacsServerProfile(BaseObject):
 
         Returns:
             TacacsServerProfileResponseModel: The fetched TACACS+ server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/mobile_agent/agent_versions.py
+++ b/scm/config/mobile_agent/agent_versions.py
@@ -62,11 +62,7 @@ class AgentVersions(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)

--- a/scm/config/mobile_agent/auth_settings.py
+++ b/scm/config/mobile_agent/auth_settings.py
@@ -67,11 +67,7 @@ class AuthSettings(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -242,6 +238,9 @@ class AuthSettings(BaseObject):
         Returns:
             List[AuthSettingsResponseModel]: A list of authentication settings objects
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder != "Mobile Users":
             raise InvalidObjectError(
@@ -296,6 +295,10 @@ class AuthSettings(BaseObject):
 
         Returns:
             AuthSettingsResponseModel: The fetched authentication settings object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/aggregate_interface.py
+++ b/scm/config/network/aggregate_interface.py
@@ -62,11 +62,7 @@ class AggregateInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -174,6 +170,9 @@ class AggregateInterface(BaseObject):
         Returns:
             List[AggregateInterfaceResponseModel]: The filtered list of resources.
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -242,6 +241,10 @@ class AggregateInterface(BaseObject):
 
         Returns:
             List[AggregateInterfaceResponseModel]: A list of resources.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -341,6 +344,10 @@ class AggregateInterface(BaseObject):
 
         Returns:
             AggregateInterfaceResponseModel: The fetched resource.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_address_family_profile.py
+++ b/scm/config/network/bgp_address_family_profile.py
@@ -66,11 +66,7 @@ class BgpAddressFamilyProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpAddressFamilyProfile(BaseObject):
         Returns:
             List[BgpAddressFamilyProfileResponseModel]: A list of BGP address family profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpAddressFamilyProfile(BaseObject):
 
         Returns:
             BgpAddressFamilyProfileResponseModel: The fetched BGP address family profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_auth_profile.py
+++ b/scm/config/network/bgp_auth_profile.py
@@ -66,11 +66,7 @@ class BgpAuthProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpAuthProfile(BaseObject):
         Returns:
             List[BgpAuthProfileResponseModel]: A list of BGP authentication profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpAuthProfile(BaseObject):
 
         Returns:
             BgpAuthProfileResponseModel: The fetched BGP authentication profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_filtering_profile.py
+++ b/scm/config/network/bgp_filtering_profile.py
@@ -66,11 +66,7 @@ class BgpFilteringProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpFilteringProfile(BaseObject):
         Returns:
             List[BgpFilteringProfileResponseModel]: A list of BGP filtering profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpFilteringProfile(BaseObject):
 
         Returns:
             BgpFilteringProfileResponseModel: The fetched BGP filtering profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_redistribution_profile.py
+++ b/scm/config/network/bgp_redistribution_profile.py
@@ -66,11 +66,7 @@ class BgpRedistributionProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpRedistributionProfile(BaseObject):
         Returns:
             List[BgpRedistributionProfileResponseModel]: A list of BGP redistribution profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpRedistributionProfile(BaseObject):
 
         Returns:
             BgpRedistributionProfileResponseModel: The fetched BGP redistribution profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_route_map.py
+++ b/scm/config/network/bgp_route_map.py
@@ -66,11 +66,7 @@ class BgpRouteMap(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpRouteMap(BaseObject):
         Returns:
             List[BgpRouteMapResponseModel]: A list of BGP route map objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpRouteMap(BaseObject):
 
         Returns:
             BgpRouteMapResponseModel: The fetched BGP route map object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/bgp_route_map_redistribution.py
+++ b/scm/config/network/bgp_route_map_redistribution.py
@@ -66,11 +66,7 @@ class BgpRouteMapRedistribution(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class BgpRouteMapRedistribution(BaseObject):
         Returns:
             List[BgpRouteMapRedistributionResponseModel]: A list of BGP route map redistribution objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class BgpRouteMapRedistribution(BaseObject):
 
         Returns:
             BgpRouteMapRedistributionResponseModel: The fetched BGP route map redistribution object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/dhcp_interface.py
+++ b/scm/config/network/dhcp_interface.py
@@ -76,11 +76,7 @@ class DhcpInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -220,6 +216,9 @@ class DhcpInterface(BaseObject):
         Returns:
             List[DhcpInterfaceResponseModel]: Filtered list of DHCP interfaces
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = dhcp_interfaces
 
@@ -291,6 +290,10 @@ class DhcpInterface(BaseObject):
 
         Returns:
             List[DhcpInterfaceResponseModel]: A list of DHCP interface objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -416,6 +419,10 @@ class DhcpInterface(BaseObject):
 
         Returns:
             DhcpInterfaceResponseModel: The fetched DHCP interface object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/dns_proxy.py
+++ b/scm/config/network/dns_proxy.py
@@ -66,11 +66,7 @@ class DnsProxy(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class DnsProxy(BaseObject):
         Returns:
             List[DnsProxyResponseModel]: A list of DNS proxy objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class DnsProxy(BaseObject):
 
         Returns:
             DnsProxyResponseModel: The fetched DNS proxy object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ethernet_interface.py
+++ b/scm/config/network/ethernet_interface.py
@@ -62,11 +62,7 @@ class EthernetInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -174,6 +170,9 @@ class EthernetInterface(BaseObject):
         Returns:
             List[EthernetInterfaceResponseModel]: The filtered list of resources.
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -270,6 +269,10 @@ class EthernetInterface(BaseObject):
 
         Returns:
             List[EthernetInterfaceResponseModel]: A list of resources.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -369,6 +372,10 @@ class EthernetInterface(BaseObject):
 
         Returns:
             EthernetInterfaceResponseModel: The fetched resource.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ike_crypto_profile.py
+++ b/scm/config/network/ike_crypto_profile.py
@@ -66,11 +66,7 @@ class IKECryptoProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -248,6 +244,10 @@ class IKECryptoProfile(BaseObject):
         Returns:
             List[IKECryptoProfileResponseModel]: A list of IKE crypto profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -369,6 +369,10 @@ class IKECryptoProfile(BaseObject):
 
         Returns:
             IKECryptoProfileResponseModel: The fetched IKE crypto profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ike_gateway.py
+++ b/scm/config/network/ike_gateway.py
@@ -66,11 +66,7 @@ class IKEGateway(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -248,6 +244,10 @@ class IKEGateway(BaseObject):
         Returns:
             List[IKEGatewayResponseModel]: A list of IKE Gateway objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -369,6 +369,10 @@ class IKEGateway(BaseObject):
 
         Returns:
             IKEGatewayResponseModel: The fetched IKE Gateway object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/interface_management_profile.py
+++ b/scm/config/network/interface_management_profile.py
@@ -66,11 +66,7 @@ class InterfaceManagementProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class InterfaceManagementProfile(BaseObject):
         Returns:
             List[InterfaceManagementProfileResponseModel]: Filtered list of profiles
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = profiles
 
@@ -308,6 +307,10 @@ class InterfaceManagementProfile(BaseObject):
 
         Returns:
             List[InterfaceManagementProfileResponseModel]: A list of profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -442,6 +445,10 @@ class InterfaceManagementProfile(BaseObject):
 
         Returns:
             InterfaceManagementProfileResponseModel: The fetched profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ipsec_crypto_profile.py
+++ b/scm/config/network/ipsec_crypto_profile.py
@@ -66,11 +66,7 @@ class IPsecCryptoProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -250,6 +246,10 @@ class IPsecCryptoProfile(BaseObject):
         Returns:
             List[IPsecCryptoProfileResponseModel]: A list of IPsec crypto profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -370,6 +370,10 @@ class IPsecCryptoProfile(BaseObject):
 
         Returns:
             IPsecCryptoProfileResponseModel: The fetched IPsec crypto profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ipsec_tunnel.py
+++ b/scm/config/network/ipsec_tunnel.py
@@ -66,11 +66,7 @@ class IPsecTunnel(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class IPsecTunnel(BaseObject):
         Returns:
             List[IPsecTunnelResponseModel]: Filtered list of IPsec tunnels
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = tunnels
 
@@ -285,6 +284,10 @@ class IPsecTunnel(BaseObject):
 
         Returns:
             List[IPsecTunnelResponseModel]: A list of IPsec tunnel objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -419,6 +422,10 @@ class IPsecTunnel(BaseObject):
 
         Returns:
             IPsecTunnelResponseModel: The fetched IPsec tunnel object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/layer2_subinterface.py
+++ b/scm/config/network/layer2_subinterface.py
@@ -62,11 +62,7 @@ class Layer2Subinterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -174,6 +170,9 @@ class Layer2Subinterface(BaseObject):
         Returns:
             List[Layer2SubinterfaceResponseModel]: The filtered list of resources.
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -249,6 +248,10 @@ class Layer2Subinterface(BaseObject):
 
         Returns:
             List[Layer2SubinterfaceResponseModel]: A list of resources.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -348,6 +351,10 @@ class Layer2Subinterface(BaseObject):
 
         Returns:
             Layer2SubinterfaceResponseModel: The fetched resource.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/layer3_subinterface.py
+++ b/scm/config/network/layer3_subinterface.py
@@ -62,11 +62,7 @@ class Layer3Subinterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -174,6 +170,9 @@ class Layer3Subinterface(BaseObject):
         Returns:
             List[Layer3SubinterfaceResponseModel]: The filtered list of resources.
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -260,6 +259,10 @@ class Layer3Subinterface(BaseObject):
 
         Returns:
             List[Layer3SubinterfaceResponseModel]: A list of resources.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -359,6 +362,10 @@ class Layer3Subinterface(BaseObject):
 
         Returns:
             Layer3SubinterfaceResponseModel: The fetched resource.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/logical_router.py
+++ b/scm/config/network/logical_router.py
@@ -66,11 +66,7 @@ class LogicalRouter(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class LogicalRouter(BaseObject):
         Returns:
             List[LogicalRouterResponseModel]: Filtered list of logical routers
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = routers
 
@@ -285,6 +284,10 @@ class LogicalRouter(BaseObject):
 
         Returns:
             List[LogicalRouterResponseModel]: A list of logical router objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -419,6 +422,10 @@ class LogicalRouter(BaseObject):
 
         Returns:
             LogicalRouterResponseModel: The fetched logical router object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/loopback_interface.py
+++ b/scm/config/network/loopback_interface.py
@@ -62,11 +62,7 @@ class LoopbackInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -209,6 +205,9 @@ class LoopbackInterface(BaseObject):
         Returns:
             List[LoopbackInterfaceResponseModel]: Filtered list of loopback interfaces
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -295,6 +294,10 @@ class LoopbackInterface(BaseObject):
 
         Returns:
             List[LoopbackInterfaceResponseModel]: A list of loopback interface objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -421,6 +424,10 @@ class LoopbackInterface(BaseObject):
 
         Returns:
             LoopbackInterfaceResponseModel: The fetched loopback interface object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/nat_rules.py
+++ b/scm/config/network/nat_rules.py
@@ -66,11 +66,7 @@ class NatRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -220,6 +216,9 @@ class NatRule(BaseObject):
         Returns:
             List[NatRuleResponseModel]: Filtered list of NAT rules
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = rules
 
@@ -365,6 +364,10 @@ class NatRule(BaseObject):
         Returns:
             List[NatRuleResponseModel]: A list of NAT rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -501,6 +504,10 @@ class NatRule(BaseObject):
 
         Returns:
             NatRuleResponseModel: The fetched NAT rule object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/ospf_auth_profile.py
+++ b/scm/config/network/ospf_auth_profile.py
@@ -66,11 +66,7 @@ class OspfAuthProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class OspfAuthProfile(BaseObject):
         Returns:
             List[OspfAuthProfileResponseModel]: A list of OSPF authentication profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class OspfAuthProfile(BaseObject):
 
         Returns:
             OspfAuthProfileResponseModel: The fetched OSPF authentication profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/pbf_rule.py
+++ b/scm/config/network/pbf_rule.py
@@ -66,11 +66,7 @@ class PbfRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class PbfRule(BaseObject):
         Returns:
             List[PbfRuleResponseModel]: A list of PBF rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class PbfRule(BaseObject):
 
         Returns:
             PbfRuleResponseModel: The fetched PBF rule object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/qos_profile.py
+++ b/scm/config/network/qos_profile.py
@@ -66,11 +66,7 @@ class QosProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class QosProfile(BaseObject):
         Returns:
             List[QosProfileResponseModel]: A list of QoS profile objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class QosProfile(BaseObject):
 
         Returns:
             QosProfileResponseModel: The fetched QoS profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/qos_rule.py
+++ b/scm/config/network/qos_rule.py
@@ -68,11 +68,7 @@ class QosRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -271,6 +267,10 @@ class QosRule(BaseObject):
         Returns:
             List[QosRuleResponseModel]: A list of QoS rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -410,6 +410,10 @@ class QosRule(BaseObject):
 
         Returns:
             QosRuleResponseModel: The fetched QoS rule object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/route_access_list.py
+++ b/scm/config/network/route_access_list.py
@@ -66,11 +66,7 @@ class RouteAccessList(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class RouteAccessList(BaseObject):
         Returns:
             List[RouteAccessListResponseModel]: A list of route access list objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class RouteAccessList(BaseObject):
 
         Returns:
             RouteAccessListResponseModel: The fetched route access list object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/route_prefix_list.py
+++ b/scm/config/network/route_prefix_list.py
@@ -66,11 +66,7 @@ class RoutePrefixList(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -269,6 +265,10 @@ class RoutePrefixList(BaseObject):
         Returns:
             List[RoutePrefixListResponseModel]: A list of route prefix list objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -408,6 +408,10 @@ class RoutePrefixList(BaseObject):
 
         Returns:
             RoutePrefixListResponseModel: The fetched route prefix list object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/security_zone.py
+++ b/scm/config/network/security_zone.py
@@ -66,11 +66,7 @@ class SecurityZone(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class SecurityZone(BaseObject):
         Returns:
             List[SecurityZoneResponseModel]: Filtered list of security zones
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = zones
 
@@ -323,6 +322,10 @@ class SecurityZone(BaseObject):
 
         Returns:
             List[SecurityZoneResponseModel]: A list of security zone objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -457,6 +460,10 @@ class SecurityZone(BaseObject):
 
         Returns:
             SecurityZoneResponseModel: The fetched security zone object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/tunnel_interface.py
+++ b/scm/config/network/tunnel_interface.py
@@ -62,11 +62,7 @@ class TunnelInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -209,6 +205,9 @@ class TunnelInterface(BaseObject):
         Returns:
             List[TunnelInterfaceResponseModel]: Filtered list of tunnel interfaces
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -295,6 +294,10 @@ class TunnelInterface(BaseObject):
 
         Returns:
             List[TunnelInterfaceResponseModel]: A list of tunnel interface objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -421,6 +424,10 @@ class TunnelInterface(BaseObject):
 
         Returns:
             TunnelInterfaceResponseModel: The fetched tunnel interface object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/vlan_interface.py
+++ b/scm/config/network/vlan_interface.py
@@ -62,11 +62,7 @@ class VlanInterface(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -174,6 +170,9 @@ class VlanInterface(BaseObject):
         Returns:
             List[VlanInterfaceResponseModel]: The filtered list of resources.
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = interfaces
 
@@ -249,6 +248,10 @@ class VlanInterface(BaseObject):
 
         Returns:
             List[VlanInterfaceResponseModel]: A list of resources.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -348,6 +351,10 @@ class VlanInterface(BaseObject):
 
         Returns:
             VlanInterfaceResponseModel: The fetched resource.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/network/zone_protection_profile.py
+++ b/scm/config/network/zone_protection_profile.py
@@ -66,11 +66,7 @@ class ZoneProtectionProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class ZoneProtectionProfile(BaseObject):
         Returns:
             List[ZoneProtectionProfileResponseModel]: Filtered list of zone protection profiles
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = profiles
 
@@ -285,6 +284,10 @@ class ZoneProtectionProfile(BaseObject):
 
         Returns:
             List[ZoneProtectionProfileResponseModel]: A list of zone protection profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -419,6 +422,10 @@ class ZoneProtectionProfile(BaseObject):
 
         Returns:
             ZoneProtectionProfileResponseModel: The fetched zone protection profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/address.py
+++ b/scm/config/objects/address.py
@@ -73,11 +73,7 @@ class Address(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -132,12 +128,11 @@ class Address(BaseObject):
     ) -> AddressResponseModel:
         """Create a new address object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             AddressResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -161,12 +156,11 @@ class Address(BaseObject):
     ) -> AddressResponseModel:
         """Get an address object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             AddressResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -219,6 +213,9 @@ class Address(BaseObject):
 
         Returns:
             List[AddressResponseModel]: Filtered list of addresses
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = addresses
@@ -335,6 +332,10 @@ class Address(BaseObject):
 
         Returns:
             List[AddressResponseModel]: A list of address objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -469,6 +470,10 @@ class Address(BaseObject):
 
         Returns:
             AddressResponseModel: The fetched address object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/address_group.py
+++ b/scm/config/objects/address_group.py
@@ -66,11 +66,7 @@ class AddressGroup(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class AddressGroup(BaseObject):
     ) -> AddressGroupResponseModel:
         """Create a new address group object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             AddressGroupResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class AddressGroup(BaseObject):
     ) -> AddressGroupResponseModel:
         """Get an address group object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             AddressGroupResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class AddressGroup(BaseObject):
 
         Returns:
             List[AddressGroupResponseModel]: Filtered list of address groups
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = address_groups
@@ -325,6 +322,10 @@ class AddressGroup(BaseObject):
 
         Returns:
             List[AddressGroupResponseModel]: A list of address group objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -459,6 +460,10 @@ class AddressGroup(BaseObject):
 
         Returns:
             AddressGroupResponseModel: The fetched address group object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/application.py
+++ b/scm/config/objects/application.py
@@ -66,11 +66,7 @@ class Application(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class Application(BaseObject):
     ) -> ApplicationResponseModel:
         """Create a new application object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ApplicationResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class Application(BaseObject):
     ) -> ApplicationResponseModel:
         """Get an application object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             ApplicationResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class Application(BaseObject):
 
         Returns:
             List[ApplicationResponseModel]: Filtered list of applications
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = applications
@@ -309,6 +306,10 @@ class Application(BaseObject):
 
         Returns:
             List[ApplicationResponseModel]: A list of application objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -434,6 +435,10 @@ class Application(BaseObject):
 
         Returns:
             ApplicationResponseModel: The fetched application object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/application_filters.py
+++ b/scm/config/objects/application_filters.py
@@ -66,11 +66,7 @@ class ApplicationFilters(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class ApplicationFilters(BaseObject):
     ) -> ApplicationFiltersResponseModel:
         """Create a new application filter object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ApplicationFiltersResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class ApplicationFilters(BaseObject):
     ) -> ApplicationFiltersResponseModel:
         """Get an application filter object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             ApplicationFiltersResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class ApplicationFilters(BaseObject):
 
         Returns:
             List[ApplicationFiltersResponseModel]: Filtered list of application filters
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = application_filters
@@ -327,6 +324,10 @@ class ApplicationFilters(BaseObject):
 
         Returns:
             List[ApplicationFiltersResponseModel]: A list of application filter objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -452,6 +453,10 @@ class ApplicationFilters(BaseObject):
 
         Returns:
             ApplicationFiltersResponseModel: The fetched application filter object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/application_group.py
+++ b/scm/config/objects/application_group.py
@@ -66,11 +66,7 @@ class ApplicationGroup(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class ApplicationGroup(BaseObject):
     ) -> ApplicationGroupResponseModel:
         """Create a new application group object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ApplicationGroupResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class ApplicationGroup(BaseObject):
     ) -> ApplicationGroupResponseModel:
         """Get an application group object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             ApplicationGroupResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class ApplicationGroup(BaseObject):
 
         Returns:
             List[ApplicationGroupResponseModel]: Filtered list of application groups
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = app_groups
@@ -284,6 +281,10 @@ class ApplicationGroup(BaseObject):
 
         Returns:
             List[ApplicationGroupResponseModel]: A list of application group objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -418,6 +419,10 @@ class ApplicationGroup(BaseObject):
 
         Returns:
             ApplicationGroupResponseModel: The fetched application group object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/auto_tag_actions.py
+++ b/scm/config/objects/auto_tag_actions.py
@@ -64,11 +64,7 @@ class AutoTagActions(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -112,12 +108,11 @@ class AutoTagActions(BaseObject):
     ) -> AutoTagActionResponseModel:
         """Create a new auto tag action object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             AutoTagActionResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         auto_tag_action = AutoTagActionCreateModel(**data)
@@ -136,12 +131,11 @@ class AutoTagActions(BaseObject):
     ) -> AutoTagActionResponseModel:
         """Get an auto tag action object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             AutoTagActionResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         endpoint = f"{self.ENDPOINT}/{object_id}"
@@ -239,6 +233,10 @@ class AutoTagActions(BaseObject):
 
         Returns:
             List[AutoTagActionResponseModel]: A list of auto tag action objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -366,6 +364,10 @@ class AutoTagActions(BaseObject):
 
         Returns:
             AutoTagActionResponseModel
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/dynamic_user_group.py
+++ b/scm/config/objects/dynamic_user_group.py
@@ -66,11 +66,7 @@ class DynamicUserGroup(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -211,6 +207,9 @@ class DynamicUserGroup(BaseObject):
         Returns:
             List[DynamicUserGroupResponseModel]: Filtered list of dynamic user groups
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = dynamic_user_groups
 
@@ -299,6 +298,10 @@ class DynamicUserGroup(BaseObject):
 
         Returns:
             List[DynamicUserGroupResponseModel]: A list of dynamic user group objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -433,6 +436,10 @@ class DynamicUserGroup(BaseObject):
 
         Returns:
             DynamicUserGroupResponseModel: The fetched dynamic user group object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/external_dynamic_lists.py
+++ b/scm/config/objects/external_dynamic_lists.py
@@ -75,11 +75,7 @@ class ExternalDynamicLists(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -134,12 +130,11 @@ class ExternalDynamicLists(BaseObject):
     ) -> ExternalDynamicListsResponseModel:
         """Create a new EDL object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ExternalDynamicListsResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -163,12 +158,11 @@ class ExternalDynamicLists(BaseObject):
     ) -> ExternalDynamicListsResponseModel:
         """Get an EDL by ID.
 
+        Args:
+            edl_id: str instance.
+
         Returns:
             ExternalDynamicListsResponseModel
-
-
-        Args:
-                edl_id: str instance.
 
         """
         # Send the request to the remote API
@@ -221,6 +215,9 @@ class ExternalDynamicLists(BaseObject):
 
         Returns:
             List[ExternalDynamicListsResponseModel]: Filtered list of EDLs
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = edls
@@ -318,6 +315,10 @@ class ExternalDynamicLists(BaseObject):
 
         Returns:
             List[ExternalDynamicListsResponseModel]: A list of EDL objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -452,6 +453,10 @@ class ExternalDynamicLists(BaseObject):
 
         Returns:
             ExternalDynamicListsResponseModel: The fetched address object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/hip_object.py
+++ b/scm/config/objects/hip_object.py
@@ -66,11 +66,7 @@ class HIPObject(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class HIPObject(BaseObject):
     ) -> HIPObjectResponseModel:
         """Create a new HIP object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             HIPObjectResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class HIPObject(BaseObject):
     ) -> HIPObjectResponseModel:
         """Get a HIP object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             HIPObjectResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -221,6 +215,9 @@ class HIPObject(BaseObject):
 
         Returns:
             List[HIPObjectResponseModel]: Filtered list of HIP objects
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = hip_objects
@@ -304,6 +301,10 @@ class HIPObject(BaseObject):
 
         Returns:
             List[HIPObjectResponseModel]: A list of HIP objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -438,6 +439,10 @@ class HIPObject(BaseObject):
 
         Returns:
             HIPObjectResponseModel: The fetched HIP object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/hip_profile.py
+++ b/scm/config/objects/hip_profile.py
@@ -66,11 +66,7 @@ class HIPProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -245,6 +241,10 @@ class HIPProfile(BaseObject):
         Returns:
             List[HIPProfileResponseModel]: A list of HIP profiles
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if folder == "":
             raise MissingQueryParameterError(
@@ -375,6 +375,10 @@ class HIPProfile(BaseObject):
 
         Returns:
             HIPProfileResponseModel: The fetched HIP profile as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/http_server_profiles.py
+++ b/scm/config/objects/http_server_profiles.py
@@ -66,11 +66,7 @@ class HTTPServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -216,6 +212,9 @@ class HTTPServerProfile(BaseObject):
         Returns:
             List[HTTPServerProfileResponseModel]: Filtered list of HTTP server profiles
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = http_server_profiles
 
@@ -304,6 +303,10 @@ class HTTPServerProfile(BaseObject):
 
         Returns:
             List[HTTPServerProfileResponseModel]: A list of HTTP server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -438,6 +441,10 @@ class HTTPServerProfile(BaseObject):
 
         Returns:
             HTTPServerProfileResponseModel: The fetched HTTP server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/log_forwarding_profile.py
+++ b/scm/config/objects/log_forwarding_profile.py
@@ -66,11 +66,7 @@ class LogForwardingProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -218,6 +214,9 @@ class LogForwardingProfile(BaseObject):
         Returns:
             List[LogForwardingProfileResponseModel]: Filtered list of profiles
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = profiles
 
@@ -334,6 +333,10 @@ class LogForwardingProfile(BaseObject):
 
         Returns:
             List[LogForwardingProfileResponseModel]: A list of log forwarding profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -468,6 +471,10 @@ class LogForwardingProfile(BaseObject):
 
         Returns:
             LogForwardingProfileResponseModel: The fetched profile object as a Pydantic model.
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+            MissingQueryParameterError: If a required query parameter is missing or empty.
 
         """
         if not name:

--- a/scm/config/objects/region.py
+++ b/scm/config/objects/region.py
@@ -68,11 +68,7 @@ class Region(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -127,12 +123,11 @@ class Region(BaseObject):
     ) -> RegionResponseModel:
         """Create a new region object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             RegionResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -157,12 +152,11 @@ class Region(BaseObject):
     ) -> RegionResponseModel:
         """Get a region object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             RegionResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -216,6 +210,9 @@ class Region(BaseObject):
 
         Returns:
             List[RegionResponseModel]: Filtered list of regions
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = regions
@@ -325,6 +322,10 @@ class Region(BaseObject):
 
         Returns:
             List[RegionResponseModel]: A list of region objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -471,6 +472,10 @@ class Region(BaseObject):
 
         Returns:
             RegionResponseModel: The fetched region object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/schedules.py
+++ b/scm/config/objects/schedules.py
@@ -69,11 +69,7 @@ class Schedule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -214,6 +210,9 @@ class Schedule(BaseObject):
         Returns:
             List[ScheduleResponseModel]: Filtered list of schedules
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filtered_schedules = schedules
 
@@ -310,6 +309,10 @@ class Schedule(BaseObject):
 
         Returns:
             List[ScheduleResponseModel]: A list of schedule objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":

--- a/scm/config/objects/service.py
+++ b/scm/config/objects/service.py
@@ -66,11 +66,7 @@ class Service(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class Service(BaseObject):
     ) -> ServiceResponseModel:
         """Create a new service object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ServiceResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class Service(BaseObject):
     ) -> ServiceResponseModel:
         """Get a service object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             ServiceResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class Service(BaseObject):
 
         Returns:
             List[ServiceResponseModel]: Filtered list of services
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = services
@@ -304,6 +301,10 @@ class Service(BaseObject):
 
         Returns:
             List[ServiceResponseModel]: A list of service objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -438,6 +439,10 @@ class Service(BaseObject):
 
         Returns:
             ServiceResponseModel: The fetched service object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/service_group.py
+++ b/scm/config/objects/service_group.py
@@ -66,11 +66,7 @@ class ServiceGroup(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class ServiceGroup(BaseObject):
     ) -> ServiceGroupResponseModel:
         """Create a new service group object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             ServiceGroupResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class ServiceGroup(BaseObject):
     ) -> ServiceGroupResponseModel:
         """Get a service group object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             ServiceGroupResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class ServiceGroup(BaseObject):
 
         Returns:
             List[ServiceGroupResponseModel]: Filtered list of service groups
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = service_groups
@@ -301,6 +298,10 @@ class ServiceGroup(BaseObject):
 
         Returns:
             List[ServiceGroupResponseModel]: A list of service group objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -435,6 +436,10 @@ class ServiceGroup(BaseObject):
 
         Returns:
             ServiceGroupResponseModel
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/syslog_server_profiles.py
+++ b/scm/config/objects/syslog_server_profiles.py
@@ -66,11 +66,7 @@ class SyslogServerProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -216,6 +212,9 @@ class SyslogServerProfile(BaseObject):
         Returns:
             List[SyslogServerProfileResponseModel]: Filtered list of syslog server profiles
 
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         filter_criteria = syslog_server_profiles
 
@@ -311,6 +310,10 @@ class SyslogServerProfile(BaseObject):
 
         Returns:
             List[SyslogServerProfileResponseModel]: A list of syslog server profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -445,6 +448,10 @@ class SyslogServerProfile(BaseObject):
 
         Returns:
             SyslogServerProfileResponseModel: The fetched syslog server profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/objects/tag.py
+++ b/scm/config/objects/tag.py
@@ -64,11 +64,7 @@ class Tag(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -123,12 +119,11 @@ class Tag(BaseObject):
     ) -> TagResponseModel:
         """Create a new tag object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             TagResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -152,12 +147,11 @@ class Tag(BaseObject):
     ) -> TagResponseModel:
         """Get a tag object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             TagResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -210,6 +204,9 @@ class Tag(BaseObject):
 
         Returns:
             List[TagResponseModel]: Filtered list of tags
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = tags
@@ -296,6 +293,10 @@ class Tag(BaseObject):
 
         Returns:
             List[TagResponseModel]: A list of tag objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -430,6 +431,10 @@ class Tag(BaseObject):
 
         Returns:
             TagResponseModel: The fetched tag object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/anti_spyware_profile.py
+++ b/scm/config/security/anti_spyware_profile.py
@@ -66,11 +66,7 @@ class AntiSpywareProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class AntiSpywareProfile(BaseObject):
     ) -> AntiSpywareProfileResponseModel:
         """Create a new anti-spyware profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             AntiSpywareProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class AntiSpywareProfile(BaseObject):
     ) -> AntiSpywareProfileResponseModel:
         """Get an anti-spyware profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             AntiSpywareProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class AntiSpywareProfile(BaseObject):
 
         Returns:
             List[AntiSpywareProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -284,6 +281,10 @@ class AntiSpywareProfile(BaseObject):
 
         Returns:
             List[AntiSpywareProfileResponseModel]: A list of anti-spyware profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -418,6 +419,10 @@ class AntiSpywareProfile(BaseObject):
 
         Returns:
             AntiSpywareProfileResponseModel: The fetched anti-spyware profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/app_override_rule.py
+++ b/scm/config/security/app_override_rule.py
@@ -69,11 +69,7 @@ class AppOverrideRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -129,13 +125,15 @@ class AppOverrideRule(BaseObject):
     ) -> AppOverrideRuleResponseModel:
         """Create a new app override rule object.
 
+        Args:
+            data: A dictionary containing the resource data.
+            rulebase: (Default: 'pre')
+
         Returns:
             AppOverrideRuleResponseModel
 
-
-        Args:
-                data: A dictionary containing the resource data.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -179,13 +177,15 @@ class AppOverrideRule(BaseObject):
     ) -> AppOverrideRuleResponseModel:
         """Get an app override rule object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+            rulebase: (Default: 'pre')
+
         Returns:
             AppOverrideRuleResponseModel
 
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -220,6 +220,9 @@ class AppOverrideRule(BaseObject):
 
         Returns:
             AppOverrideRuleResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -268,6 +271,9 @@ class AppOverrideRule(BaseObject):
 
         Returns:
             List[AppOverrideRuleResponseModel]: Filtered list of app override rules
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = rules
@@ -444,6 +450,10 @@ class AppOverrideRule(BaseObject):
         Returns:
             List[AppOverrideRuleResponseModel]: A list of app override rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, AppOverrideRuleRulebase):
@@ -593,6 +603,10 @@ class AppOverrideRule(BaseObject):
         Returns:
             AppOverrideRuleResponseModel: The fetched app override rule object as a Pydantic model.
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if not name:
             raise MissingQueryParameterError(
@@ -683,6 +697,9 @@ class AppOverrideRule(BaseObject):
         Args:
             object_id (str): The ID of the object to delete.
             rulebase: Which rulebase to use ('pre' or 'post'), defaults to 'pre'
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`

--- a/scm/config/security/authentication_rule.py
+++ b/scm/config/security/authentication_rule.py
@@ -69,11 +69,7 @@ class AuthenticationRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -129,13 +125,15 @@ class AuthenticationRule(BaseObject):
     ) -> AuthenticationRuleResponseModel:
         """Create a new authentication rule object.
 
+        Args:
+            data: A dictionary containing the resource data.
+            rulebase: (Default: 'pre')
+
         Returns:
             AuthenticationRuleResponseModel
 
-
-        Args:
-                data: A dictionary containing the resource data.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -179,13 +177,15 @@ class AuthenticationRule(BaseObject):
     ) -> AuthenticationRuleResponseModel:
         """Get an authentication rule object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+            rulebase: (Default: 'pre')
+
         Returns:
             AuthenticationRuleResponseModel
 
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -220,6 +220,9 @@ class AuthenticationRule(BaseObject):
 
         Returns:
             AuthenticationRuleResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -268,6 +271,9 @@ class AuthenticationRule(BaseObject):
 
         Returns:
             List[AuthenticationRuleResponseModel]: Filtered list of authentication rules
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = rules
@@ -460,6 +466,10 @@ class AuthenticationRule(BaseObject):
         Returns:
             List[AuthenticationRuleResponseModel]: A list of authentication rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, AuthenticationRuleRulebase):
@@ -609,6 +619,10 @@ class AuthenticationRule(BaseObject):
         Returns:
             AuthenticationRuleResponseModel: The fetched authentication rule object as a Pydantic model.
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if not name:
             raise MissingQueryParameterError(
@@ -699,6 +713,9 @@ class AuthenticationRule(BaseObject):
         Args:
             object_id (str): The ID of the object to delete.
             rulebase: Which rulebase to use ('pre' or 'post'), defaults to 'pre'
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`

--- a/scm/config/security/decryption_profile.py
+++ b/scm/config/security/decryption_profile.py
@@ -66,11 +66,7 @@ class DecryptionProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class DecryptionProfile(BaseObject):
     ) -> DecryptionProfileResponseModel:
         """Create a new decryption profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             DecryptionProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class DecryptionProfile(BaseObject):
     ) -> DecryptionProfileResponseModel:
         """Get a decryption profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             DecryptionProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class DecryptionProfile(BaseObject):
 
         Returns:
             List[DecryptionProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -292,6 +289,10 @@ class DecryptionProfile(BaseObject):
 
         Returns:
             List[DecryptionProfileResponseModel]: A list of decryption profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -426,6 +427,10 @@ class DecryptionProfile(BaseObject):
 
         Returns:
             DecryptionProfileResponseModel: The fetched decryption profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/decryption_rule.py
+++ b/scm/config/security/decryption_rule.py
@@ -69,11 +69,7 @@ class DecryptionRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -129,13 +125,15 @@ class DecryptionRule(BaseObject):
     ) -> DecryptionRuleResponseModel:
         """Create a new decryption rule object.
 
+        Args:
+            data: A dictionary containing the resource data.
+            rulebase: (Default: 'pre')
+
         Returns:
             DecryptionRuleResponseModel
 
-
-        Args:
-                data: A dictionary containing the resource data.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -179,13 +177,15 @@ class DecryptionRule(BaseObject):
     ) -> DecryptionRuleResponseModel:
         """Get a decryption rule object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+            rulebase: (Default: 'pre')
+
         Returns:
             DecryptionRuleResponseModel
 
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -220,6 +220,9 @@ class DecryptionRule(BaseObject):
 
         Returns:
             DecryptionRuleResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -268,6 +271,9 @@ class DecryptionRule(BaseObject):
 
         Returns:
             List[DecryptionRuleResponseModel]: Filtered list of decryption rules
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = rules
@@ -473,6 +479,10 @@ class DecryptionRule(BaseObject):
         Returns:
             List[DecryptionRuleResponseModel]: A list of decryption rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, DecryptionRuleRulebase):
@@ -622,6 +632,10 @@ class DecryptionRule(BaseObject):
         Returns:
             DecryptionRuleResponseModel: The fetched decryption rule object as a Pydantic model.
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if not name:
             raise MissingQueryParameterError(
@@ -712,6 +726,9 @@ class DecryptionRule(BaseObject):
         Args:
             object_id (str): The ID of the object to delete.
             rulebase: Which rulebase to use ('pre' or 'post'), defaults to 'pre'
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`

--- a/scm/config/security/dns_security_profile.py
+++ b/scm/config/security/dns_security_profile.py
@@ -66,11 +66,7 @@ class DNSSecurityProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class DNSSecurityProfile(BaseObject):
     ) -> DNSSecurityProfileResponseModel:
         """Create a new DNS security profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             DNSSecurityProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class DNSSecurityProfile(BaseObject):
     ) -> DNSSecurityProfileResponseModel:
         """Get a DNS security profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             DNSSecurityProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class DNSSecurityProfile(BaseObject):
 
         Returns:
             List[DNSSecurityProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -290,6 +287,10 @@ class DNSSecurityProfile(BaseObject):
 
         Returns:
             List[DNSSecurityProfileResponseModel]: A list of dns security profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -424,6 +425,10 @@ class DNSSecurityProfile(BaseObject):
 
         Returns:
             DNSSecurityProfileResponseModel: The fetched DNS security profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/file_blocking_profile.py
+++ b/scm/config/security/file_blocking_profile.py
@@ -66,11 +66,7 @@ class FileBlockingProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class FileBlockingProfile(BaseObject):
     ) -> FileBlockingProfileResponseModel:
         """Create a new file blocking profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             FileBlockingProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class FileBlockingProfile(BaseObject):
     ) -> FileBlockingProfileResponseModel:
         """Get a file blocking profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             FileBlockingProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class FileBlockingProfile(BaseObject):
 
         Returns:
             List[FileBlockingProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -284,6 +281,10 @@ class FileBlockingProfile(BaseObject):
 
         Returns:
             List[FileBlockingProfileResponseModel]: A list of file blocking profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -418,6 +419,10 @@ class FileBlockingProfile(BaseObject):
 
         Returns:
             FileBlockingProfileResponseModel: The fetched file blocking profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/security_rule.py
+++ b/scm/config/security/security_rule.py
@@ -69,11 +69,7 @@ class SecurityRule(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -129,13 +125,15 @@ class SecurityRule(BaseObject):
     ) -> SecurityRuleResponseModel:
         """Create a new security rule object.
 
+        Args:
+            data: A dictionary containing the resource data.
+            rulebase: (Default: 'pre')
+
         Returns:
             SecurityRuleResponseModel
 
-
-        Args:
-                data: A dictionary containing the resource data.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -179,13 +177,15 @@ class SecurityRule(BaseObject):
     ) -> SecurityRuleResponseModel:
         """Get a security rule object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+            rulebase: (Default: 'pre')
+
         Returns:
             SecurityRuleResponseModel
 
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
-                rulebase: (Default: 'pre')
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -220,6 +220,9 @@ class SecurityRule(BaseObject):
 
         Returns:
             SecurityRuleResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`
@@ -268,6 +271,9 @@ class SecurityRule(BaseObject):
 
         Returns:
             List[SecurityRuleResponseModel]: Filtered list of security rules
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = rules
@@ -509,6 +515,10 @@ class SecurityRule(BaseObject):
         Returns:
             List[SecurityRuleResponseModel]: A list of security rule objects
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         # Validate that the rulebase is of type `pre` or `post`
         if not isinstance(rulebase, SecurityRuleRulebase):
@@ -658,6 +668,10 @@ class SecurityRule(BaseObject):
         Returns:
             SecurityRuleResponseModel: The fetched security rule object as a Pydantic model.
 
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
         """
         if not name:
             raise MissingQueryParameterError(
@@ -748,6 +762,9 @@ class SecurityRule(BaseObject):
         Args:
             object_id (str): The ID of the object to delete.
             rulebase: Which rulebase to use ('pre' or 'post'), defaults to 'pre'
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         # Validate that the rulebase is of type `pre` or `post`

--- a/scm/config/security/url_access_profile.py
+++ b/scm/config/security/url_access_profile.py
@@ -66,11 +66,7 @@ class URLAccessProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class URLAccessProfile(BaseObject):
     ) -> URLAccessProfileResponseModel:
         """Create a new URL access profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             URLAccessProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class URLAccessProfile(BaseObject):
     ) -> URLAccessProfileResponseModel:
         """Get a URL access profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             URLAccessProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -267,6 +261,10 @@ class URLAccessProfile(BaseObject):
 
         Returns:
             List[URLAccessProfileResponseModel]: A list of URL access profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -401,6 +399,10 @@ class URLAccessProfile(BaseObject):
 
         Returns:
             URLAccessProfileResponseModel: The fetched URL access profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/url_categories.py
+++ b/scm/config/security/url_categories.py
@@ -66,11 +66,7 @@ class URLCategories(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class URLCategories(BaseObject):
     ) -> URLCategoriesResponseModel:
         """Create a new URL Category.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             URLCategoriesResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class URLCategories(BaseObject):
     ) -> URLCategoriesResponseModel:
         """Get a URL Category by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             URLCategoriesResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -277,6 +271,10 @@ class URLCategories(BaseObject):
 
         Returns:
             List[URLCategoriesResponseModel]: A list of url category objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -411,6 +409,10 @@ class URLCategories(BaseObject):
 
         Returns:
             URLCategoriesResponseModel: The fetched URL Category object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/vulnerability_protection_profile.py
+++ b/scm/config/security/vulnerability_protection_profile.py
@@ -66,11 +66,7 @@ class VulnerabilityProtectionProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class VulnerabilityProtectionProfile(BaseObject):
     ) -> VulnerabilityProfileResponseModel:
         """Create a new vulnerability protection profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             VulnerabilityProtectionProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class VulnerabilityProtectionProfile(BaseObject):
     ) -> VulnerabilityProfileResponseModel:
         """Get a vulnerability protection profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             VulnerabilityProtectionProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class VulnerabilityProtectionProfile(BaseObject):
 
         Returns:
             List[VulnerabilityProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -300,6 +297,10 @@ class VulnerabilityProtectionProfile(BaseObject):
 
         Returns:
             List[VulnerabilityProfileResponseModel]: A list of vulnerability profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -434,6 +435,10 @@ class VulnerabilityProtectionProfile(BaseObject):
 
         Returns:
             VulnerabilityProfileResponseModel: The fetched vulnerability profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/security/wildfire_antivirus_profile.py
+++ b/scm/config/security/wildfire_antivirus_profile.py
@@ -66,11 +66,7 @@ class WildfireAntivirusProfile(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -125,12 +121,11 @@ class WildfireAntivirusProfile(BaseObject):
     ) -> WildfireAvProfileResponseModel:
         """Create a new wildfire antivirus profile object.
 
+        Args:
+            data: A dictionary containing the resource data.
+
         Returns:
             WildfireAntivirusProfileResponseModel
-
-
-        Args:
-                data: A dictionary containing the resource data.
 
         """
         # Use the dictionary "data" to pass into Pydantic and return a modeled object
@@ -154,12 +149,11 @@ class WildfireAntivirusProfile(BaseObject):
     ) -> WildfireAvProfileResponseModel:
         """Get a wildfire antivirus profile object by ID.
 
+        Args:
+            object_id: The UUID of the resource to retrieve.
+
         Returns:
             WildfireAntivirusProfileResponseModel
-
-
-        Args:
-                object_id: The UUID of the resource to retrieve.
 
         """
         # Send the request to the remote API
@@ -212,6 +206,9 @@ class WildfireAntivirusProfile(BaseObject):
 
         Returns:
             List[WildfireAvProfileResponseModel]: Filtered list of profiles
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filter_criteria = profiles
@@ -284,6 +281,10 @@ class WildfireAntivirusProfile(BaseObject):
 
         Returns:
             List[WildfireAvProfileResponseModel]: A list of wildfire profile objects
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if folder == "":
@@ -418,6 +419,10 @@ class WildfireAntivirusProfile(BaseObject):
 
         Returns:
             WildfireAvProfileResponseModel: The fetched wildfire antivirus profile object as a Pydantic model.
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         if not name:

--- a/scm/config/setup/device.py
+++ b/scm/config/setup/device.py
@@ -60,11 +60,7 @@ class Device(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)

--- a/scm/config/setup/folder.py
+++ b/scm/config/setup/folder.py
@@ -65,11 +65,7 @@ class Folder(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)

--- a/scm/config/setup/label.py
+++ b/scm/config/setup/label.py
@@ -65,11 +65,7 @@ class Label(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)

--- a/scm/config/setup/snippet.py
+++ b/scm/config/setup/snippet.py
@@ -69,11 +69,7 @@ class Snippet(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)
@@ -195,6 +191,9 @@ class Snippet(BaseObject):
 
         Returns:
             List['SnippetResponseModel']: The filtered list of resources.
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
 
         """
         filtered_data = data

--- a/scm/config/setup/variable.py
+++ b/scm/config/setup/variable.py
@@ -65,11 +65,7 @@ class Variable(BaseObject):
         """Set a new maximum limit for API requests.
 
         Args:
-            value: int instance.
-
-
-        Returns:
-            None: The current maximum limit.
+            value: The maximum number of items to return in a single API request.
 
         """
         self._max_limit = self._validate_max_limit(value)


### PR DESCRIPTION
## Summary
- Reorder `Returns:`/`Args:` to Google-style (Args → Returns → Raises) in ~31 files
- Add missing `Raises:` sections to ~73 service class methods documenting explicitly raised exceptions
- Remove incorrect `Returns: None` from 78 `max_limit` setter docstrings

Fixes #322, fixes #323, fixes #324

## Test plan
- [x] `make quality` passes (isort, ruff, flake8, mypy)
- [x] All 6,126 unit tests pass (2 pre-existing API test failures on live endpoints, unrelated)
- [x] No behavioral changes — docstring-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)