### PR TITLE
docs: simplify README and docs landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,321 +1,68 @@
 # Strata Cloud Manager SDK
 
 <p align="center">
-  <a href="https://cdot65.github.io/pan-scm-sdk/"><img src="https://raw.githubusercontent.com/cdot65/pan-scm-sdk/main/docs/images/logo.svg" alt="pan-scm-sdk" width="200"></a>
+  <a href="https://cdot65.github.io/pan-scm-sdk/">
+    <img src="https://raw.githubusercontent.com/cdot65/pan-scm-sdk/main/docs/images/logo.svg" alt="pan-scm-sdk" width="200">
+  </a>
 </p>
-[![codecov](https://codecov.io/github/cdot65/pan-scm-sdk/graph/badge.svg?token=BB39SMLYFP)](https://codecov.io/github/cdot65/pan-scm-sdk)
-[![Build Status](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml)
-[![PyPI version](https://img.shields.io/pypi/v/pan-scm-sdk.svg)](https://pypi.org/project/pan-scm-sdk/)
-[![Python versions](https://img.shields.io/pypi/pyversions/pan-scm-sdk.svg)](https://pypi.org/project/pan-scm-sdk/)
-[![License](https://img.shields.io/github/license/cdot65/pan-scm-sdk.svg)](https://github.com/cdot65/pan-scm-sdk/blob/main/LICENSE)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cdot65/pan-scm-sdk)
 
-Python SDK for Palo Alto Networks Strata Cloud Manager.
+<p align="center">
+  <a href="https://codecov.io/github/cdot65/pan-scm-sdk"><img src="https://codecov.io/github/cdot65/pan-scm-sdk/graph/badge.svg?token=BB39SMLYFP" alt="codecov"></a>
+  <a href="https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml"><img src="https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml/badge.svg" alt="Build Status"></a>
+  <a href="https://pypi.org/project/pan-scm-sdk/"><img src="https://img.shields.io/pypi/v/pan-scm-sdk.svg" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/pan-scm-sdk/"><img src="https://img.shields.io/pypi/pyversions/pan-scm-sdk.svg" alt="Python versions"></a>
+  <a href="https://github.com/cdot65/pan-scm-sdk/blob/main/LICENSE"><img src="https://img.shields.io/github/license/cdot65/pan-scm-sdk.svg" alt="License"></a>
+</p>
 
-> **NOTE**: Please refer to the [GitHub Pages documentation site](https://cdot65.github.io/pan-scm-sdk/) for all
-> examples
-
-## Table of Contents
-
-- [Strata Cloud Manager SDK](#strata-cloud-manager-sdk)
-  - [Table of Contents](#table-of-contents)
-  - [Features](#features)
-  - [Development Guidelines](#development-guidelines)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [Authentication](#authentication)
-      - [Method 1: OAuth2 Client Credentials passed into a ScmClient instance](#method-1-oauth2-client-credentials-passed-into-a-scmclient-instance)
-      - [Method 2: Bearer Token Authentication](#method-2-bearer-token-authentication)
-    - [TLS Certificate Verification Control](#tls-certificate-verification-control)
-    - [Available Client Services](#available-client-services)
-  - [Development](#development)
-    - [Setup](#setup)
-    - [Code Quality](#code-quality)
-    - [Pre-commit Hooks](#pre-commit-hooks)
-  - [Contributing](#contributing)
-  - [License](#license)
-  - [Support](#support)
-
-## Features
-
-- **Flexible Authentication**:
-  - OAuth2 client credentials flow for standard authentication
-  - Bearer token support for scenarios with pre-acquired tokens
-- **Resource Management**: Create, read, update, and delete configuration objects such as addresses, address groups,
-  applications, regions, internal DNS servers, and more.
-- **Data Validation**: Utilize Pydantic models for data validation and serialization.
-- **Exception Handling**: Comprehensive error handling with custom exceptions for API errors.
-- **Extensibility**: Designed for easy extension to support additional resources and endpoints.
-
-## Development Guidelines
-
-For developers working on this SDK:
-
-- **Service File Standards**: See `SDK_STYLING_GUIDE.md` for comprehensive service file guidelines
-- **Model Standards**: See `PYDANTIC_MODELS_GUIDE.md` for Pydantic model patterns and conventions
-- **Templates**: Use `SDK_SERVICE_TEMPLATE.py` as a starting point for new services
+Python SDK for Palo Alto Networks Strata Cloud Manager. Provides OAuth2-authenticated CRUD operations on firewall configuration objects — addresses, security rules, NAT rules, and 80+ resource types — via a unified client interface.
 
 ## Installation
-
-**Requirements**:
-
-- Python 3.10 or higher
-
-Install the package via pip:
 
 ```bash
 pip install pan-scm-sdk
 ```
 
-## Usage
+Requires Python 3.10+.
 
-### TLS Certificate Verification Control
-
-By default, the SDK verifies TLS certificates for all HTTPS requests. You can bypass TLS verification (for development or testing) by setting the `verify_ssl` flag to `False` when initializing `Scm` or `ScmClient`:
+## Quick Start
 
 ```python
 from scm.client import ScmClient
 
+# Initialize with OAuth2 credentials
 client = ScmClient(
-    client_id="...",
-    client_secret="...",
-    tsg_id="...",
-    verify_ssl=False,  # WARNING: disables TLS verification!
-)
-```
-
-> **Warning:** Disabling TLS verification is insecure and exposes you to man-in-the-middle attacks. Only use `verify_ssl=False` in trusted development environments.
-
-### Authentication
-
-Before interacting with the SDK, you need to authenticate:
-
-#### Method 1: OAuth2 Client Credentials passed into a ScmClient instance
-
-```python
-from scm.client import ScmClient
-
-# Initialize the API client with OAuth2 client credentials
-api_client = ScmClient(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",
 )
 
-# The SCM client is now ready to use
+# Create an address object
+client.address.create({
+    "name": "web-server",
+    "ip_netmask": "10.0.1.100/32",
+    "description": "Production web server",
+    "folder": "Texas",
+})
+
+# List all addresses in a folder
+addresses = client.address.list(folder="Texas")
+for addr in addresses:
+    print(f"{addr.name}: {addr.ip_netmask or addr.fqdn}")
 ```
 
-#### Method 2: Bearer Token Authentication
+## Documentation
 
-If you already have a valid OAuth token, you can use it directly:
+For comprehensive guides, API reference, and examples for all 80+ supported resources, visit the full documentation site:
 
-```python
-from scm.client import Scm
-
-# Initialize the API client with a pre-acquired bearer token
-api_client = Scm(
-    access_token="your_bearer_token"
-)
-
-# The SCM client is now ready to use
-```
-
-> **NOTE**: When using bearer token authentication, token refresh is your responsibility. For commit operations with bearer token auth, you must explicitly provide the `admin` parameter.
-
-```python
-# Example of commit with bearer token authentication
-api_client.commit(
-    folders=["Texas"],
-    description="Configuration changes",
-    admin=["admin@example.com"],  # Required when using bearer token
-    sync=True
-)
-```
-
-### Available Client Services
-
-The unified client provides access to the following services through attribute-based access:
-
-| Client Property                    | Description                                                   |
-| ---------------------------------- | ------------------------------------------------------------- |
-| **Objects**                        |                                                               |
-| `address`                          | IP addresses, CIDR ranges, and FQDNs for security policies    |
-| `address_group`                    | Static or dynamic collections of address objects              |
-| `application`                      | Custom application definitions and signatures                 |
-| `application_filter`               | Filters for identifying applications by characteristics       |
-| `application_group`                | Logical groups of applications for policy application         |
-| `auto_tag_action`                  | Automated tag assignment based on traffic and security events |
-| `dynamic_user_group`               | User groups with dynamic membership criteria                  |
-| `external_dynamic_list`            | Externally managed lists of IPs, URLs, or domains             |
-| `hip_object`                       | Host information profile match criteria                       |
-| `hip_profile`                      | Endpoint security compliance profiles                         |
-| `http_server_profile`              | HTTP server configurations for logging and monitoring         |
-| `log_forwarding_profile`           | Configurations for forwarding logs to external systems        |
-| `quarantined_device`               | Management of devices blocked from network access             |
-| `region`                           | Geographic regions for policy control                         |
-| `schedule`                         | Time-based policies and access control                        |
-| `service`                          | Protocol and port definitions for network services            |
-| `service_group`                    | Collections of services for simplified policy management      |
-| `syslog_server_profile`            | Syslog server configurations for centralized logging          |
-| `tag`                              | Resource classification and organization labels               |
-| **Mobile Agent**                   |                                                               |
-| `auth_setting`                     | GlobalProtect authentication settings                         |
-| `agent_version`                    | GlobalProtect agent versions (read-only)                      |
-| **Network**                        |                                                               |
-| `aggregate_interface`              | Aggregated ethernet interfaces with LACP support              |
-| `bgp_address_family_profile`       | BGP address family profiles (IPv4/IPv6 unicast/multicast)     |
-| `bgp_auth_profile`                 | BGP authentication profiles (MD5 for BGP sessions)            |
-| `bgp_filtering_profile`           | BGP filtering profiles for inbound/outbound route filtering   |
-| `bgp_redistribution_profile`      | BGP redistribution profiles for protocol route redistribution |
-| `bgp_route_map`                   | BGP route maps for import/export policy control               |
-| `bgp_route_map_redistribution`    | BGP route map redistribution with protocol crossover patterns |
-| `dhcp_interface`                   | DHCP server and relay settings on interfaces                  |
-| `ethernet_interface`               | Physical ethernet interface configurations                    |
-| `ike_crypto_profile`               | IKE crypto profiles for VPN tunnel encryption                 |
-| `ike_gateway`                      | IKE gateways for VPN tunnel endpoints                         |
-| `interface_management_profile`     | Interface management profiles (HTTPS, SSH, ping access)       |
-| `ipsec_crypto_profile`             | IPsec crypto profiles for VPN tunnel encryption               |
-| `ipsec_tunnel`                     | IPsec tunnel objects for encrypted site-to-site connectivity  |
-| `layer2_subinterface`              | Layer 2 VLAN subinterfaces for switching                      |
-| `layer3_subinterface`              | Layer 3 VLAN subinterfaces for routing                        |
-| `logical_router`                   | Logical routers with VRF, BGP, OSPF, ECMP, static routes     |
-| `loopback_interface`               | Loopback interfaces for management and routing                |
-| `nat_rule`                         | Network address translation policies for traffic routing      |
-| `ospf_auth_profile`                | OSPF authentication profiles (MD5/password for adjacencies)   |
-| `route_access_list`                | Route access lists for filtering routes by network/mask       |
-| `route_prefix_list`                | Route prefix lists for prefix-based route filtering           |
-| `security_zone`                    | Security zones for network segmentation                       |
-| `tunnel_interface`                 | Tunnel interfaces for VPN and overlay networks                |
-| `vlan_interface`                   | VLAN interfaces for network segmentation                      |
-| `dns_proxy`                        | DNS proxy configurations for DNS interception and forwarding  |
-| `pbf_rule`                         | Policy-Based Forwarding rules for application-aware routing   |
-| `qos_profile`                      | QoS profiles for traffic shaping and bandwidth allocation     |
-| `qos_rule`                         | QoS policy rules with rule move/reorder support               |
-| `zone_protection_profile`          | Zone protection with flood, scan, and packet-based defense    |
-| **Deployment**                     |                                                               |
-| `bandwidth_allocation`             | Bandwidth allocation management for network capacity planning |
-| `bgp_routing`                      | BGP routing configuration for network connectivity            |
-| `internal_dns_server`              | Internal DNS server configurations for domain resolution      |
-| `network_location`                 | Geographic network locations for service connectivity         |
-| `remote_network`                   | Secure branch and remote site connectivity configurations     |
-| `service_connection`               | Service connections to cloud service providers                |
-| **Security**                       |                                                               |
-| `anti_spyware_profile`             | Protection against spyware, C2 traffic, and data exfiltration |
-| `decryption_profile`               | SSL/TLS traffic inspection configurations                     |
-| `dns_security_profile`             | Protection against DNS-based threats and tunneling            |
-| `security_rule`                    | Core security policies controlling network traffic            |
-| `authentication_rule`              | Authentication policy rules for identity-based access         |
-| `decryption_rule`                  | SSL/TLS decryption policy rules                               |
-| `app_override_rule`                | Application override rules for custom app identification      |
-| `file_blocking_profile`            | File blocking security profiles                               |
-| `url_access_profile`               | URL filtering access profiles                                 |
-| `url_category`                     | Custom URL categorization for web filtering                   |
-| `vulnerability_protection_profile` | Defense against known CVEs and exploit attempts               |
-| `wildfire_antivirus_profile`       | Cloud-based malware analysis and zero-day protection          |
-| **Insights**                       |                                                               |
-| `alerts`                           | Security alerts and threat intelligence notifications         |
-| **Setup**                          |                                                               |
-| `device`                           | Device resources and management                               |
-| `folder`                           | Folder organization and hierarchy                             |
-| `label`                            | Resource classification and simple key-value object labels    |
-| `snippet`                          | Reusable configuration snippets                               |
-| `variable`                         | Typed variables with flexible container scoping               |
-| **Identity**                       |                                                               |
-| `authentication_profile`           | Authentication profiles for identity-based access control     |
-| `kerberos_server_profile`          | Kerberos server configurations for domain authentication      |
-| `ldap_server_profile`              | LDAP server configurations for directory integration          |
-| `radius_server_profile`            | RADIUS server configurations for AAA authentication           |
-| `saml_server_profile`              | SAML identity provider configurations for SSO                 |
-| `tacacs_server_profile`            | TACACS+ server configurations for centralized AAA             |
-
----
-
-## Development
-
-Before starting development, please review:
-
-- `SDK_STYLING_GUIDE.md` - Comprehensive guide for writing consistent SDK code
-- `PYDANTIC_MODELS_GUIDE.md` - Guidelines for creating Pydantic models
-- `SDK_SERVICE_TEMPLATE.py` - Template for new service files
-
-### Setup
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/cdot65/pan-scm-sdk.git
-   cd pan-scm-sdk
-   ```
-
-2. Install dependencies and pre-commit hooks:
-
-   ```bash
-   make setup
-   ```
-
-   Alternatively, you can install manually:
-
-   ```bash
-   poetry install
-   poetry run pre-commit install
-   ```
-
-### Code Quality
-
-This project uses [ruff](https://github.com/astral-sh/ruff) for linting and formatting:
-
-```bash
-# Run linting checks
-make lint
-
-# Format code
-make format
-
-# Auto-fix linting issues when possible
-make fix
-```
-
-### Pre-commit Hooks
-
-We use pre-commit hooks to ensure code quality before committing:
-
-```bash
-# Run pre-commit hooks on all files
-make pre-commit-all
-```
-
-The following checks run automatically before each commit:
-
-- ruff linting and formatting
-- Trailing whitespace removal
-- End-of-file fixer
-- YAML/JSON syntax checking
-- Large file detection
-- Python syntax validation
-- Merge conflict detection
-- Private key detection
+**[https://cdot65.github.io/pan-scm-sdk/](https://cdot65.github.io/pan-scm-sdk/)**
 
 ## Contributing
 
-We welcome contributions! To contribute:
-
-1. Fork the repository.
-2. Create a new feature branch (`git checkout -b feature/your-feature`).
-3. Make your changes, ensuring all linting and tests pass.
-4. Commit your changes (`git commit -m 'Add new feature'`).
-5. Push to your branch (`git push origin feature/your-feature`).
-6. Open a Pull Request.
-
-Ensure your code adheres to the project's coding standards and includes tests where appropriate.
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Run quality checks (`make quality`) and tests (`make test`)
+4. Open a Pull Request
 
 ## License
 
-This project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE) file for details.
-
-## Support
-
-For support and questions, please refer to the [SUPPORT.md](./SUPPORT.md) file in this repository.
-
----
-
-_Detailed documentation is available on our [GitHub Pages documentation site](https://cdot65.github.io/pan-scm-sdk/)._
+Apache 2.0 &mdash; see [LICENSE](./LICENSE) for details.

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -278,6 +278,6 @@ except APIError as e:
 
 ## Next Steps
 
-- Explore the [SDK Reference Documentation](../sdk/index.md) for detailed information on all available services and methods.
+- Explore the [Services Documentation](../sdk/index.md) for detailed information on all available services and methods.
 - Check out the [Client Module](../sdk/client.md) documentation for more information on the unified client interface.
 - Refer to the [examples directory](https://github.com/cdot65/pan-scm-sdk/tree/main/examples) for complete script examples.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,229 +11,91 @@ hide:
     <a href="https://paloaltonetworks.com"><img src="images/logo.svg" alt="PaloAltoNetworks" class="hero-logo"></a>
 </p>
 <p align="center">
-    <em><code>pan-scm-sdk</code>: Python SDK to manage Palo Alto Networks Strata Cloud Manager</em>
+    <em><code>pan-scm-sdk</code>: Python SDK for Palo Alto Networks Strata Cloud Manager</em>
 </p>
-<p align="center">
-<a href="https://github.com/cdot65/pan-scm-sdk/graphs/contributors" target="_blank">
-    <img src="https://img.shields.io/github/contributors/cdot65/pan-scm-sdk.svg?style=for-the-badge" alt="Contributors">
+<p align="center" style="display: flex; justify-content: center; align-items: center; gap: 4px; flex-wrap: wrap;">
+<a href="https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml" target="_blank">
+    <img src="https://github.com/cdot65/pan-scm-sdk/actions/workflows/ci.yml/badge.svg" alt="Build Status" style="height: 20px;">
 </a>
-<a href="https://github.com/cdot65/pan-scm-sdk/network/members" target="_blank">
-    <img src="https://img.shields.io/github/forks/cdot65/pan-scm-sdk.svg?style=for-the-badge" alt="Forks">
+<a href="https://codecov.io/github/cdot65/pan-scm-sdk" target="_blank">
+    <img src="https://codecov.io/github/cdot65/pan-scm-sdk/graph/badge.svg?token=BB39SMLYFP" alt="codecov" style="height: 20px;">
 </a>
-<a href="https://github.com/cdot65/pan-scm-sdk/stargazers" target="_blank">
-    <img src="https://img.shields.io/github/stars/cdot65/pan-scm-sdk.svg?style=for-the-badge" alt="Stars">
+<a href="https://pypi.org/project/pan-scm-sdk/" target="_blank">
+    <img src="https://img.shields.io/pypi/v/pan-scm-sdk.svg?style=flat" alt="PyPI version" style="height: 20px;">
 </a>
-<a href="https://github.com/cdot65/pan-scm-sdk/issues" target="_blank">
-    <img src="https://img.shields.io/github/issues/cdot65/pan-scm-sdk.svg?style=for-the-badge" alt="Issues">
+<a href="https://pypi.org/project/pan-scm-sdk/" target="_blank">
+    <img src="https://img.shields.io/pypi/pyversions/pan-scm-sdk.svg?style=flat" alt="Python versions" style="height: 20px;">
 </a>
 <a href="https://github.com/cdot65/pan-scm-sdk/blob/main/LICENSE" target="_blank">
-    <img src="https://img.shields.io/github/license/cdot65/pan-scm-sdk.svg?style=for-the-badge" alt="License">
+    <img src="https://img.shields.io/github/license/cdot65/pan-scm-sdk.svg?style=flat" alt="License" style="height: 20px;">
 </a>
 </p>
 
 ---
 
-**Documentation
-**: <a href="https://cdot65.github.io/pan-scm-sdk/" target="_blank">https://cdot65.github.io/pan-scm-sdk/</a>
-
-**Source Code
-**: <a href="https://github.com/cdot65/pan-scm-sdk" target="_blank">https://github.com/cdot65/pan-scm-sdk</a>
-
----
-
-`pan-scm-sdk` is a Python SDK for Palo Alto Networks Strata Cloud Manager.
+Manage 80+ Strata Cloud Manager resource types — addresses, security rules, NAT rules, network interfaces, and more — through a simple, unified Python client with full CRUD support, Pydantic validation, and automatic pagination.
 
 ## Installation
 
-**Requirements**:
-
-- Python 3.10 or higher
-
-Install the package via pip:
-
 ```bash
-$ pip install pan-scm-sdk
+pip install pan-scm-sdk
 ```
 
-## Quick Example
+Requires Python 3.10+.
+
+## Quick Start
 
 ```python
-from scm.client import Scm
+from scm.client import ScmClient
 
-# Initialize the unified client (handles all object types through a single interface)
-client = Scm(
+client = ScmClient(
     client_id="your_client_id",
     client_secret="your_client_secret",
-    tsg_id="your_tsg_id"
+    tsg_id="your_tsg_id",
 )
 
-# Work with Address objects
-addresses = client.address.list(folder="Texas")
-print(f"Found {len(addresses)} addresses")
-
-# Fetch a specific address
-my_address = client.address.fetch(name="web-server", folder="Texas")
-print(f"Address details: {my_address.name}, {my_address.ip_netmask}")
-
-# Update the address
-my_address.description = "Updated via unified client"
-updated_address = client.address.update(my_address)
-
-# Work with Internal DNS Servers
-dns_server = client.internal_dns_server.create({
-    "name": "main-dns-server",
-    "domain_name": ["example.com", "internal.example.com"],
-    "primary": "192.168.1.10",
-    "secondary": "192.168.1.11"
+# Create an address object
+client.address.create({
+    "name": "web-server",
+    "ip_netmask": "10.0.1.100/32",
+    "folder": "Texas",
 })
-print(f"Created DNS server: {dns_server.name}")
 
-# List all DNS servers
-dns_servers = client.internal_dns_server.list()
-print(f"Found {len(dns_servers)} DNS servers")
-
-# Work with BGP Routing
-bgp_settings = client.bgp_routing.get()
-print(f"Current BGP routing: {bgp_settings.backbone_routing}")
-
-# Update BGP routing preferences
-client.bgp_routing.update({
-    "routing_preference": {"hot_potato_routing": {}},
-    "backbone_routing": "asymmetric-routing-with-load-share",
-    "accept_route_over_SC": True,
-    "outbound_routes_for_services": ["10.0.0.0/8"]
-})
-print("Updated BGP routing settings")
-
-# Work with Network Locations
-locations = client.network_location.list()
-print(f"Found {len(locations)} network locations")
-
-us_locations = client.network_location.list(continent="North America")
-print(f"Found {len(us_locations)} locations in North America")
-
-west_coast = client.network_location.fetch("us-west-1")
-print(f"Location: {west_coast.display} ({west_coast.value})")
-
-# Work with GlobalProtect Agent Versions (read-only)
-agent_versions = client.agent_version.list()
-print(f"Found {len(agent_versions)} GlobalProtect agent versions")
-
-# Filter for specific versions
-filtered_versions = client.agent_version.list(version="5.3")
-print(f"Found {len(filtered_versions)} versions containing '5.3'")
-
-# Work with Security Rules
-security_rule = client.security_rule.fetch(name="allow-web", folder="Texas")
-print(f"Security rule: {security_rule.name}, Action: {security_rule.action}")
-
-# Work with NAT Rules - list with filtering
-nat_rules = client.nat_rule.list(
-    folder="Texas",
-    source_zone=["trust"]
-)
-print(f"Found {len(nat_rules)} NAT rules with source zone 'trust'")
-
-# Work with Security Zones
-security_zones = client.security_zone.list(folder="Texas")
-print(f"Found {len(security_zones)} security zones")
-
-# Work with Bandwidth Allocations
-bandwidth_allocations = client.bandwidth_allocation.list()
-print(f"Found {len(bandwidth_allocations)} bandwidth allocations")
-
-# Create a new bandwidth allocation
-new_allocation = client.bandwidth_allocation.create({
-    "name": "test-region",
-    "allocated_bandwidth": 100,
-    "spn_name_list": ["spn1", "spn2"],
-    "qos": {
-        "enabled": True,
-        "customized": True,
-        "profile": "test-profile",
-        "guaranteed_ratio": 0.5
-    }
-})
-print(f"Created bandwidth allocation: {new_allocation.name}")
-
-# Delete a NAT rule
-if nat_rules:
-    client.nat_rule.delete(nat_rules[0].id)
-    print(f"Deleted NAT rule: {nat_rules[0].name}")
-
-# Work with Prisma Access Insights - Alerts
-# List recent high-severity alerts
-high_severity_alerts = client.insights.alerts.list(
-    severity=["critical", "high"],
-    status=["Raised"],
-    start_time=7  # Last 7 days
-)
-print(f"Found {len(high_severity_alerts)} high-severity alerts")
-
-# Get alert statistics by severity
-alert_stats = client.insights.alerts.get_statistics(
-    time_range=30,
-    group_by="severity"
-)
-for stat in alert_stats:
-    print(f"{stat.severity}: {stat.count} alerts")
-
-# Generate alert timeline
-timeline = client.insights.alerts.get_timeline(
-    time_range=7,
-    interval="day",
-    status="Raised"
-)
-for point in timeline:
-    print(f"Day {point.state}: {point.count} alerts")
-
-# Make configuration changes
-client.commit(
-    folders=["Texas"],
-    description="Updated address, DNS servers, BGP routing, and removed NAT rule",
-    sync=True
-)
+# List addresses
+for addr in client.address.list(folder="Texas"):
+    print(addr.name)
 ```
 
-For more detailed usage instructions and examples, refer to the [User Guide](about/introduction.md).
+Explore the full API across all resource types in the [Services](sdk/index.md) documentation.
 
 ---
 
 ## Documentation Guide
 
-This documentation is organized into two main developer sections:
+### Services
 
-### SDK Reference
+**[Go to Services →](sdk/index.md)**
 
-**[Go to SDK Reference →](sdk/index.md)**
-
-Service classes for performing CRUD operations on Strata Cloud Manager resources.
-
-Use when you need to:
-
-- Create, read, update, or delete configurations
-- List and filter resources
-- See method signatures and usage examples
+Service classes for performing CRUD operations on Strata Cloud Manager resources. Use when you need method signatures, usage examples, and filtering options.
 
 ### Data Models
 
 **[Go to Data Models →](sdk/models/index.md)**
 
-Pydantic schemas that define validation rules and field constraints.
+Pydantic schemas that define validation rules, required vs optional fields, and allowed values. Use when you need to pre-validate configurations before API calls.
 
-Use when you need to:
+### User Guide
 
-- Understand required vs optional fields
-- Check allowed values and patterns
-- Pre-validate configurations before API calls
+**[Go to User Guide →](about/introduction.md)**
+
+Authentication options, TLS configuration, commit workflows, and detailed walkthroughs for common tasks.
 
 ---
 
 ## Contributing
 
-Contributions are welcome and greatly appreciated. Visit the [Contributing](about/contributing.md) page for guidelines
-on how to contribute.
+Contributions are welcome. Visit the [Contributing](about/contributing.md) page for guidelines.
 
 ## License
 
-This project is licensed under the Apache 2.0 License - see the [License](about/license.md) page for details.
+Apache 2.0 — see the [License](about/license.md) page for details.

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -1,19 +1,23 @@
-# SDK Reference
+# Services
 
-Welcome to the SDK Reference for `pan-scm-sdk`. This section documents the **service classes** that provide CRUD
-operations for managing Strata Cloud Manager configurations.
+Service classes provide CRUD operations for managing Strata Cloud Manager configurations. Each service maps to a resource type and is accessed through the unified client.
 
-## What Is the SDK Reference?
+```python
+from scm.client import ScmClient
 
-The SDK Reference documents **service classes** - Python classes that handle API communication for each resource type.
-Use these classes to create, read, update, delete, and list configuration objects.
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id",
+)
 
-Use this section when you need to:
-
-- **Perform CRUD operations** - Create, read, update, delete resources
-- **List and filter resources** - Query configurations with various filters
-- **Understand method signatures** - Know what parameters each method accepts
-- **See usage examples** - Copy working code patterns
+# Every resource follows the same pattern
+client.address.create({"name": "web-server", "ip_netmask": "10.0.1.100/32", "folder": "Texas"})
+client.address.list(folder="Texas")
+client.address.fetch(name="web-server", folder="Texas")
+client.address.update(address_object)
+client.address.delete(address_id)
+```
 
 !!! note "Looking for field schemas and validation rules?"
     See the **[Data Models](models/index.md)** section to understand what fields are required, allowed values,
@@ -21,269 +25,21 @@ Use this section when you need to:
 
 ---
 
-## Quick Start
-
-The SDK uses a unified client interface to access all service objects:
-
-```python
-from scm.client import Scm
-
-# Initialize the unified client
-client = Scm(
-    client_id="your_client_id",
-    client_secret="your_client_secret",
-    tsg_id="your_tsg_id"
-)
-
-# ===== WORKING WITH ADDRESS OBJECTS =====
-
-# List all addresses in a folder
-addresses = client.address.list(folder="Texas")
-print(f"Found {len(addresses)} addresses in Texas folder")
-
-# Fetch a specific address by name
-web_server = client.address.fetch(name="web-server", folder="Texas")
-print(f"Address details - Name: {web_server.name}, IP: {web_server.ip_netmask or web_server.fqdn}")
-
-# Update the description of the address
-web_server.description = "Primary web server updated via unified client"
-updated_address = client.address.update(web_server)
-print(f"Updated address description: {updated_address.description}")
-
-# ===== WORKING WITH BGP ROUTING =====
-
-# Get current BGP routing settings
-bgp_settings = client.bgp_routing.get()
-print(f"Current BGP backbone routing: {bgp_settings.backbone_routing}")
-
-# Update BGP routing preferences
-client.bgp_routing.update({
-    "routing_preference": {"hot_potato_routing": {}},
-    "backbone_routing": "asymmetric-routing-with-load-share",
-    "accept_route_over_SC": True,
-    "outbound_routes_for_services": ["10.0.0.0/8", "172.16.0.0/12"],
-})
-print("Updated BGP routing settings")
-
-# ===== WORKING WITH INTERNAL DNS SERVERS =====
-
-# Create a new internal DNS server
-dns_server = client.internal_dns_server.create({
-    "name": "main-dns-server",
-    "domain_name": ["example.com", "internal.example.com"],
-    "primary": "192.168.1.10",
-    "secondary": "192.168.1.11"
-})
-print(f"Created DNS server: {dns_server.name} with ID: {dns_server.id}")
-
-# List all DNS servers
-dns_servers = client.internal_dns_server.list()
-print(f"Found {len(dns_servers)} DNS servers")
-
-# ===== WORKING WITH SECURITY RULES =====
-
-# Fetch a specific security rule
-security_rule = client.security_rule.fetch(name="allow-web-traffic", folder="Texas")
-print(f"Security rule: {security_rule.name}")
-print(f"  Source zones: {security_rule.source_zone}")
-print(f"  Destination zones: {security_rule.destination_zone}")
-print(f"  Action: {security_rule.action}")
-
-# ===== WORKING WITH NAT RULES =====
-
-# List NAT rules with filtering (source zone = "trust")
-filtered_nat_rules = client.nat_rule.list(
-    folder="Texas",
-    source_zone=["trust"]
-)
-print(f"Found {len(filtered_nat_rules)} NAT rules with source zone 'trust'")
-
-# Delete a NAT rule if any were found
-if filtered_nat_rules:
-    rule_to_delete = filtered_nat_rules[0].id
-    rule_name = filtered_nat_rules[0].name
-    client.nat_rule.delete(rule_to_delete)
-    print(f"Deleted NAT rule '{rule_name}' (ID: {rule_to_delete})")
-
-# ===== WORKING WITH BANDWIDTH ALLOCATIONS =====
-
-# List all bandwidth allocations
-allocations = client.bandwidth_allocation.list()
-print(f"Found {len(allocations)} bandwidth allocations")
-
-# Create a new bandwidth allocation
-new_allocation = client.bandwidth_allocation.create({
-    "name": "test-region",
-    "allocated_bandwidth": 100,
-    "spn_name_list": ["spn1", "spn2"],
-    "qos": {
-        "enabled": True,
-        "customized": True,
-        "profile": "test-profile",
-        "guaranteed_ratio": 0.5
-    }
-})
-print(f"Created bandwidth allocation: {new_allocation.name}")
-
-# ===== WORKING WITH AUTHENTICATION SETTINGS =====
-
-# List all authentication settings
-auth_settings = client.auth_setting.list()
-print(f"Found {len(auth_settings)} authentication settings")
-
-# Create new authentication settings for Windows
-windows_auth = client.auth_setting.create({
-    "name": "windows_auth",
-    "authentication_profile": "windows-profile",
-    "os": "Windows",
-    "user_credential_or_client_cert_required": True,
-    "folder": "Mobile Users"
-})
-print(f"Created authentication settings: {windows_auth.name}")
-
-# Move authentication settings to the top of evaluation order
-client.auth_setting.move({
-    "name": "windows_auth",
-    "where": "top"
-})
-print("Moved Windows authentication settings to the top")
-
-# ===== WORKING WITH AGENT VERSIONS =====
-
-# List all available GlobalProtect agent versions
-agent_versions = client.agent_version.list()
-print(f"Found {len(agent_versions)} GlobalProtect agent versions")
-
-# Filter for specific versions
-filtered_versions = client.agent_version.list(version="5.3")
-print(f"Found {len(filtered_versions)} versions containing '5.3'")
-
-# Fetch a specific version
-try:
-    version = client.agent_version.fetch("5.3.0")
-    print(f"Found specific version: {version}")
-except Exception as e:
-    print(f"Version not found: {str(e)}")
-
-# ===== WORKING WITH INSIGHTS ALERTS =====
-
-# List recent critical alerts
-critical_alerts = client.insights.alerts.list(
-    severity=["critical"],
-    status=["Raised"],
-    start_time=7  # Last 7 days
-)
-print(f"Found {len(critical_alerts)} critical alerts")
-
-# Get alert statistics
-stats = client.insights.alerts.get_statistics(
-    time_range=30,
-    group_by="severity"
-)
-for stat in stats:
-    print(f"{stat.severity}: {stat.count} alerts")
-
-# Generate alert timeline
-timeline = client.insights.alerts.get_timeline(
-    time_range=7,
-    interval="hour",
-    status="Raised"
-)
-print(f"Generated {len(timeline)} timeline points")
-
-# ===== COMMIT CHANGES =====
-
-# Commit all changes to apply them to the firewall
-commit_result = client.commit(
-    folders=["Texas", "Mobile Users"],
-    description="Updated configurations via unified client",
-    sync=True  # Wait for commit to complete
-)
-
-# Check commit status
-job_status = client.get_job_status(commit_result.job_id)
-print(f"Commit job status: {job_status.data[0].status_str}")
-```
-
-## Available Client Services
-
-The following table shows all services available through the unified client interface:
-
-| Client Property                    | Description                                                   |
-| ---------------------------------- | ------------------------------------------------------------- |
-| **Objects**                        |                                                               |
-| `address`                          | IP addresses, CIDR ranges, and FQDNs for security policies    |
-| `address_group`                    | Static or dynamic collections of address objects              |
-| `application`                      | Custom application definitions and signatures                 |
-| `application_filter`               | Filters for identifying applications by characteristics       |
-| `application_group`                | Logical groups of applications for policy application         |
-| `auto_tag_action`                  | Automated tag assignment based on traffic and security events |
-| `dynamic_user_group`               | User groups with dynamic membership criteria                  |
-| `external_dynamic_list`            | Externally managed lists of IPs, URLs, or domains             |
-| `hip_object`                       | Host information profile match criteria                       |
-| `hip_profile`                      | Endpoint security compliance profiles                         |
-| `http_server_profile`              | HTTP server configurations for logging and monitoring         |
-| `log_forwarding_profile`           | Configurations for forwarding logs to external systems        |
-| `quarantined_device`               | Management of devices blocked from network access             |
-| `region`                           | Geographic regions for policy control                         |
-| `schedule`                         | Time-based policies and access control                        |
-| `service`                          | Protocol and port definitions for network services            |
-| `service_group`                    | Collections of services for simplified policy management      |
-| `syslog_server_profile`            | Syslog server configurations for centralized logging          |
-| `tag`                              | Resource classification and organization labels               |
-| **Mobile Agent**                   |                                                               |
-| `auth_setting`                     | GlobalProtect authentication settings by operating system     |
-| `agent_version`                    | Available GlobalProtect agent versions (read-only)            |
-| **Network**                        |                                                               |
-| `aggregate_interface`              | Aggregated ethernet interfaces with LACP support              |
-| `ethernet_interface`               | Physical ethernet interface configurations                    |
-| `ike_crypto_profile`               | IKE crypto profiles for VPN tunnels                           |
-| `ike_gateway`                      | IKE gateway configurations for VPN tunnel endpoints           |
-| `ipsec_crypto_profile`             | IPsec crypto profiles for VPN tunnel encryption               |
-| `layer2_subinterface`              | Layer 2 VLAN subinterfaces for switching                      |
-| `layer3_subinterface`              | Layer 3 VLAN subinterfaces for routing                        |
-| `loopback_interface`               | Loopback interfaces for management and routing                |
-| `nat_rule`                         | Network address translation policies for traffic routing      |
-| `security_zone`                    | Security zones for network segmentation                       |
-| `tunnel_interface`                 | Tunnel interfaces for VPN and overlay networks                |
-| `vlan_interface`                   | VLAN interfaces for network segmentation                      |
-| **Deployment**                     |                                                               |
-| `bandwidth_allocation`             | Bandwidth allocation settings for regions and service nodes   |
-| `bgp_routing`                      | Global BGP routing preferences and behaviors                  |
-| `internal_dns_server`              | DNS server configurations for domain resolution               |
-| `network_location`                 | Geographic network locations for service connectivity         |
-| `remote_network`                   | Secure branch and remote site connectivity configurations     |
-| `service_connection`               | Service connections to cloud service providers                |
-| **Security**                       |                                                               |
-| `anti_spyware_profile`             | Protection against spyware, C2 traffic, and data exfiltration |
-| `decryption_profile`               | SSL/TLS traffic inspection configurations                     |
-| `dns_security_profile`             | Protection against DNS-based threats and tunneling            |
-| `security_rule`                    | Core security policies controlling network traffic            |
-| `url_category`                     | Custom URL categorization for web filtering                   |
-| `vulnerability_protection_profile` | Defense against known CVEs and exploit attempts               |
-| `wildfire_antivirus_profile`       | Cloud-based malware analysis and zero-day protection          |
-| **Insights**                       |                                                               |
-| `alerts`                           | Security and operational alerts from Prisma Access            |
-| **Setup**                          |                                                               |
-| `device`                           | Device resources and management                               |
-| `folder`                           | Folder organization and hierarchy                             |
-| `label`                            | Resource classification and simple key-value object labels    |
-| `snippet`                          | Reusable configuration snippets                               |
-| `variable`                         | Typed variables with flexible container scoping               |
-
-Check out the [Client Module](client.md) documentation for more information on the unified client interface.
-
 ## Service Categories
 
 - **[Deployment](config/deployment/index.md)** - Prisma Access infrastructure (bandwidth, BGP, DNS, remote networks)
+- **[Identity](config/identity/index.md)** - Authentication and server profiles (LDAP, RADIUS, SAML, TACACS+, Kerberos)
 - **[Mobile Agent](config/mobile_agent/index.md)** - GlobalProtect agent configuration
-- **[Network](config/network/index.md)** - VPN profiles, NAT rules, security zones
-- **[Objects](config/objects/index.md)** - Reusable policy objects (addresses, services, tags)
+- **[Network](config/network/index.md)** - Interfaces, VPN profiles, NAT rules, routing, security zones
+- **[Objects](config/objects/index.md)** - Reusable policy objects (addresses, services, tags, HIP)
 - **[Security Services](config/security_services/index.md)** - Security profiles and rules
 - **[Setup](config/setup/index.md)** - Organizational containers (folders, snippets, devices)
 - **[Insights](insights/index.md)** - Prisma Access Insights alerts
 
 ## Related Documentation
 
+- **[Auth](auth.md)** - OAuth2 authentication flow
+- **[Client](client.md)** - Unified client interface and service registration
+- **[BaseObject](config/base_object.md)** - Base class for all service classes
 - **[Data Models](models/index.md)** - Pydantic schemas for validating configuration data
 - **[Exceptions](exceptions.md)** - Error handling and exception types

--- a/docs/sdk/models/index.md
+++ b/docs/sdk/models/index.md
@@ -118,13 +118,13 @@ Models for Prisma Access Insights:
 
 ---
 
-## Relationship to SDK Reference
+## Relationship to Services
 
-The **Data Models** define *what* data looks like, while the **[SDK Reference](../index.md)** documents *how* to
+The **Data Models** define *what* data looks like, while the **[Services](../index.md)** documentation covers *how* to
 perform operations. For example:
 
 - Use `AddressCreateModel` (Data Models) to understand required fields
-- Use `client.address.create()` (SDK Reference) to actually create the address
+- Use `client.address.create()` (Services) to actually create the address
 
 ```python
 from scm.client import Scm

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,7 @@ nav:
       - Contributing: about/contributing.md
       - Release Notes: about/release-notes.md
       - License: about/license.md
-  - SDK Reference:
+  - Services:
       - Overview: sdk/index.md
       - Auth: sdk/auth.md
       - Client: sdk/client.md


### PR DESCRIPTION
## Summary
- Truncate README from 322 to ~50 lines — install, quick start, link to docs site
- Fix badge rendering on GitHub (blank line after HTML block) and docs site (consistent height)
- Simplify docs landing page quick example from 130 to 15 lines
- Rename "SDK Reference" → "Services" across mkdocs nav and all cross-references

## Test plan
- [x] `mkdocs serve` builds and serves without errors (HTTP 200)
- [x] No behavioral code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)