### PR TITLE
chore: bump version to 0.12.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.12.5"
+version = "0.12.6"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary
- Bump version to 0.12.6 to trigger PyPI release with updated README

## Test plan
- [x] pyproject.toml version updated
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)