### PR TITLE
docs: fix BaseObject docstring to use Raises: section

### DIFF
--- a/scm/config/__init__.py
+++ b/scm/config/__init__.py
@@ -21,10 +21,10 @@ class BaseObject:
         ENDPOINT (str): API endpoint for the object, to be defined in subclasses.
         api_client (Scm): Instance of the API client for making HTTP requests.
 
-    Error:
+    Raises:
         APIError: May be raised for any API-related errors during operations.
 
-    Return:
+    Returns:
         Dict[str, Any] or List[Dict[str, Any]]: API response data for CRUD operations.
 
     """

--- a/tests/scm/config/test_base_object.py
+++ b/tests/scm/config/test_base_object.py
@@ -378,3 +378,18 @@ class TestBaseObject:
             sync=True,
             timeout=600,
         )
+
+    def test_docstring_uses_raises_section(self):
+        """Ensure BaseObject docstring uses 'Raises:' not 'Error:' section heading."""
+        doc = BaseObject.__doc__
+        assert doc is not None, "BaseObject should have a docstring"
+        # Check for "Error:" as a section heading (line starts with it after whitespace)
+        lines = doc.split("\n")
+        for line in lines:
+            stripped = line.strip()
+            assert stripped != "Error:", (
+                "BaseObject docstring should not use 'Error:' section heading"
+            )
+        # Verify "Raises:" section heading exists
+        has_raises = any(line.strip() == "Raises:" for line in lines)
+        assert has_raises, "BaseObject docstring should have 'Raises:' section"


### PR DESCRIPTION
## Summary
- Replace non-standard `Error:` section with `Raises:` in BaseObject docstring
- Replace `Return:` with `Returns:` for Google-style compliance
- Add test asserting correct docstring section headings

Closes #329

## Test plan
- [x] `test_docstring_uses_raises_section` passes
- [x] `ruff check --select D scm/config/__init__.py` passes
- [x] Full test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)