### PR TITLE
fix: correct isort violations in two test files

### DIFF
--- a/tests/scm/models/insights/test_common_models.py
+++ b/tests/scm/models/insights/test_common_models.py
@@ -2,8 +2,8 @@
 
 """Tests for Insights common models."""
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from scm.models.insights.common import InsightsResponse, InsightsResponseHeader
 

--- a/tests/scm/models/network/test_interface_common_models.py
+++ b/tests/scm/models/network/test_interface_common_models.py
@@ -2,8 +2,8 @@
 
 """Tests for shared network interface common models."""
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from scm.models.network._interface_common import (
     AdjustTcpMss,


### PR DESCRIPTION
## Summary
- Fix import ordering in `test_common_models.py` and `test_interface_common_models.py`

Closes #338

## Test plan
- [x] `poetry run isort --check-only scm tests` passes
- [x] No code changes, only import order

🤖 Generated with [Claude Code](https://claude.com/claude-code)