### PR TITLE
fix: bump pyjwt to ^2.12.0 for CVE-2026-32597

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ oauthlib = "^3.3.0"
 requests-oauthlib = "^2.0.0"
 setuptools = "^78.1.1"
 pydantic = "^2.12.0"
-pyjwt = "^2.9.0"
+pyjwt = "^2.12.0"
 cryptography = "^46.0.0"
 
 


### PR DESCRIPTION
## Summary
- Bump `pyjwt` minimum from `^2.9.0` to `^2.12.0` to exclude versions affected by CVE-2026-32597

Closes #339

## Test plan
- [x] `poetry run pip-audit` reports zero vulnerabilities
- [x] All 6075 tests pass
- [x] `pip-audit` CI step will enforce going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)