### PR TITLE
chore: bump version to 0.12.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.12.6"
+version = "0.12.7"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary
- Patch bump 0.12.6 → 0.12.7

Changes since 0.12.6:
- fix: redact Authorization headers from debug logs (#332)
- fix: bump pyjwt to ^2.12.0 for CVE-2026-32597 (#341)
- feat: add pip-audit to CI (#334)
- docs: add architecture page (#336)
- test: add utility model tests (#335)

🤖 Generated with [Claude Code](https://claude.com/claude-code)