### PR TITLE
ci: add TruffleHog secret scanning to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ on:
     branches: [main]
 
 jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Secret Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add `secrets` job to CI workflow running `trufflesecurity/trufflehog@main` with `--only-verified` to prevent false positives
- Runs in parallel with `build` job on push/PR to main

Closes #345