### PR TITLE
docs: update README and docs to use primary Scm class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Requires Python 3.10+.
 ## Quick Start
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize with OAuth2 credentials
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -173,10 +173,10 @@ For consistency, use these templates for common documentation patterns:
 ### Code Example Template
 ```markdown
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -200,14 +200,14 @@ print(f"Operation result: {result.id}")
 ### Error Handling Template
 ```markdown
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    ExceptionType1,
    ExceptionType2
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/about/getting-started.md
+++ b/docs/about/getting-started.md
@@ -22,10 +22,10 @@ Before using the SDK, you need to authenticate with Strata Cloud Manager using y
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize the SCM client with your credentials
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",
@@ -47,10 +47,10 @@ The SDK provides two ways to interact with Strata Cloud Manager: the unified cli
 Starting with version 0.3.14, you can access all service objects directly through the client instance. This approach is more intuitive and streamlined:
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize the client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -163,7 +163,7 @@ This page contains the release history of the Strata Cloud Manager SDK, with the
 
 ### Added & Fixed
 - **TLS Certificate Verification Control:**
-  - Added `verify_ssl` parameter to `Scm` and `ScmClient` constructors allowing users to bypass SSL/TLS certificate verification when needed
+  - Added `verify_ssl` parameter to `Scm` and `Scm` constructors allowing users to bypass SSL/TLS certificate verification when needed
   - Enhanced warning messages when TLS verification is disabled to alert users of security implications
   - Extended OAuth2Client to respect the verification setting
   - Proper propagation of verification setting to all HTTP requests
@@ -514,7 +514,7 @@ This page contains the release history of the Strata Cloud Manager SDK, with the
 
 ### Fixed
 
-- **Custom Token URL Support**: Fixed issue where `token_url` parameter defined in `AuthRequestModel` wasn't exposed through the `Scm` and `ScmClient` constructors. Users can now specify custom OAuth token endpoints when initializing the client.
+- **Custom Token URL Support**: Fixed issue where `token_url` parameter defined in `AuthRequestModel` wasn't exposed through the `Scm` and `Scm` constructors. Users can now specify custom OAuth token endpoints when initializing the client.
 - **Documentation Updates**: Added comprehensive documentation for the `token_url` parameter
 
 ## Version 0.3.15
@@ -534,7 +534,7 @@ This page contains the release history of the Strata Cloud Manager SDK, with the
 ### Added
 
 - **Unified Client Interface**: New attribute-based access pattern for services (e.g., `client.address.create()` instead of creating separate service instances)
-- **ScmClient Class**: Added as an alias for the Scm class with identical functionality but more descriptive name
+- **Scm Class**: Added as an alias for the Scm class with identical functionality but more descriptive name
 - **Comprehensive Tests**: Added test suite for the unified client functionality
 - **Enhanced Documentation**: Updated documentation to showcase both traditional and unified client patterns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,9 +46,9 @@ Requires Python 3.10+.
 ## Quick Start
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/client.md
+++ b/docs/sdk/client.md
@@ -426,16 +426,16 @@ status = client.get_job_status(result.job_id)
 print(f"Status: {status.data[0].status_str}")
 ```
 
-## ScmClient Alias
+## Scm Alias
 
-Starting with version 0.3.14, the SDK also provides an `ScmClient` class as an alias for `Scm`. This class offers the exact
+Starting with version 0.3.14, the SDK also provides an `Scm` class as an alias for `Scm`. This class offers the exact
 same functionality but with a more explicit name that better describes its purpose:
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-# Use ScmClient instead of Scm with OAuth2 client credentials (identical functionality)
-client = ScmClient(
+# Use Scm instead of Scm with OAuth2 client credentials (identical functionality)
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",
@@ -443,8 +443,8 @@ client = ScmClient(
     # token_url="https://custom.auth.server.com/oauth2/token"
 )
 
-# OR use ScmClient with bearer token authentication
-bearer_client = ScmClient(
+# OR use Scm with bearer token authentication
+bearer_client = Scm(
     access_token="your_bearer_token"
 )
 ```

--- a/docs/sdk/config/base_object.md
+++ b/docs/sdk/config/base_object.md
@@ -41,9 +41,9 @@ The `BaseObject` class provides standardized CRUD operations (Create, Read, Upda
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/bandwidth_allocations.md
+++ b/docs/sdk/config/deployment/bandwidth_allocations.md
@@ -49,9 +49,9 @@ The `BandwidthAllocations` class inherits from `BaseObject` and provides CRUD op
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/bgp_routing.md
+++ b/docs/sdk/config/deployment/bgp_routing.md
@@ -39,9 +39,9 @@ The `BGPRouting` class inherits from `BaseObject` and provides methods for retri
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/internal_dns_servers.md
+++ b/docs/sdk/config/deployment/internal_dns_servers.md
@@ -42,9 +42,9 @@ The `InternalDnsServers` class inherits from `BaseObject` and provides CRUD oper
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/network_locations.md
+++ b/docs/sdk/config/deployment/network_locations.md
@@ -35,9 +35,9 @@ The `NetworkLocations` class provides access to network location objects represe
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/remote_networks.md
+++ b/docs/sdk/config/deployment/remote_networks.md
@@ -57,9 +57,9 @@ The `RemoteNetworks` class inherits from `BaseObject` and provides CRUD operatio
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/deployment/service_connections.md
+++ b/docs/sdk/config/deployment/service_connections.md
@@ -52,9 +52,9 @@ The `ServiceConnection` class inherits from `BaseObject` and provides CRUD opera
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/authentication_profile.md
+++ b/docs/sdk/config/identity/authentication_profile.md
@@ -4,12 +4,12 @@ The `AuthenticationProfile` service manages authentication profile objects in St
 
 ## Class Overview
 
-The `AuthenticationProfile` class provides CRUD operations for authentication profile objects. It is accessed through the `client.authentication_profile` attribute on an initialized `ScmClient` instance.
+The `AuthenticationProfile` class provides CRUD operations for authentication profile objects. It is accessed through the `client.authentication_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/index.md
+++ b/docs/sdk/config/identity/index.md
@@ -35,10 +35,10 @@ The identity objects also enforce:
 ## Usage Example
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/kerberos_server_profile.md
+++ b/docs/sdk/config/identity/kerberos_server_profile.md
@@ -4,12 +4,12 @@ The `KerberosServerProfile` service manages Kerberos server profile objects in S
 
 ## Class Overview
 
-The `KerberosServerProfile` class provides CRUD operations for Kerberos server profile objects. It is accessed through the `client.kerberos_server_profile` attribute on an initialized `ScmClient` instance.
+The `KerberosServerProfile` class provides CRUD operations for Kerberos server profile objects. It is accessed through the `client.kerberos_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/ldap_server_profile.md
+++ b/docs/sdk/config/identity/ldap_server_profile.md
@@ -4,12 +4,12 @@ The `LdapServerProfile` service manages LDAP server profile objects in Strata Cl
 
 ## Class Overview
 
-The `LdapServerProfile` class provides CRUD operations for LDAP server profile objects. It is accessed through the `client.ldap_server_profile` attribute on an initialized `ScmClient` instance.
+The `LdapServerProfile` class provides CRUD operations for LDAP server profile objects. It is accessed through the `client.ldap_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/radius_server_profile.md
+++ b/docs/sdk/config/identity/radius_server_profile.md
@@ -4,12 +4,12 @@ The `RadiusServerProfile` service manages RADIUS server profile objects in Strat
 
 ## Class Overview
 
-The `RadiusServerProfile` class provides CRUD operations for RADIUS server profile objects. It is accessed through the `client.radius_server_profile` attribute on an initialized `ScmClient` instance.
+The `RadiusServerProfile` class provides CRUD operations for RADIUS server profile objects. It is accessed through the `client.radius_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/saml_server_profile.md
+++ b/docs/sdk/config/identity/saml_server_profile.md
@@ -4,12 +4,12 @@ The `SamlServerProfile` service manages SAML server profile objects in Strata Cl
 
 ## Class Overview
 
-The `SamlServerProfile` class provides CRUD operations for SAML server profile objects. It is accessed through the `client.saml_server_profile` attribute on an initialized `ScmClient` instance.
+The `SamlServerProfile` class provides CRUD operations for SAML server profile objects. It is accessed through the `client.saml_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/identity/tacacs_server_profile.md
+++ b/docs/sdk/config/identity/tacacs_server_profile.md
@@ -4,12 +4,12 @@ The `TacacsServerProfile` service manages TACACS+ server profile objects in Stra
 
 ## Class Overview
 
-The `TacacsServerProfile` class provides CRUD operations for TACACS+ server profile objects. It is accessed through the `client.tacacs_server_profile` attribute on an initialized `ScmClient` instance.
+The `TacacsServerProfile` class provides CRUD operations for TACACS+ server profile objects. It is accessed through the `client.tacacs_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/mobile_agent/agent_versions.md
+++ b/docs/sdk/config/mobile_agent/agent_versions.md
@@ -32,9 +32,9 @@ The `AgentVersions` class inherits from `BaseObject` and offers methods for list
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/mobile_agent/auth_settings.md
+++ b/docs/sdk/config/mobile_agent/auth_settings.md
@@ -44,9 +44,9 @@ The `AuthSettings` class inherits from `BaseObject` and provides CRUD operations
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/aggregate_interface.md
+++ b/docs/sdk/config/network/aggregate_interface.md
@@ -5,10 +5,10 @@ The `AggregateInterface` class manages aggregate ethernet interface (ae) objects
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_address_family_profile.md
+++ b/docs/sdk/config/network/bgp_address_family_profile.md
@@ -5,10 +5,10 @@ The `BgpAddressFamilyProfile` class manages BGP address family profile objects i
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -189,10 +189,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -223,10 +223,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create a BGP Address Family Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -365,7 +365,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -375,7 +375,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_auth_profile.md
+++ b/docs/sdk/config/network/bgp_auth_profile.md
@@ -5,10 +5,10 @@ The `BgpAuthProfile` class manages BGP authentication profile objects in Palo Al
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -111,10 +111,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -145,10 +145,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create a BGP Auth Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -234,7 +234,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -244,7 +244,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_filtering_profile.md
+++ b/docs/sdk/config/network/bgp_filtering_profile.md
@@ -5,10 +5,10 @@ The `BgpFilteringProfile` class manages BGP filtering profile objects in Palo Al
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -183,10 +183,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -221,10 +221,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create a BGP Filtering Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -354,7 +354,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -364,7 +364,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_redistribution_profile.md
+++ b/docs/sdk/config/network/bgp_redistribution_profile.md
@@ -5,10 +5,10 @@ The `BgpRedistributionProfile` class manages BGP redistribution profile objects 
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -148,10 +148,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -190,10 +190,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create a BGP Redistribution Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -324,7 +324,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -334,7 +334,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_route_map.md
+++ b/docs/sdk/config/network/bgp_route_map.md
@@ -8,10 +8,10 @@ The `BgpRouteMap` class manages BGP route map objects in Palo Alto Networks' Str
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -196,10 +196,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -235,10 +235,10 @@ print(f"Retrieved route map: {route_map_by_id.name}")
 ### Create a BGP Route Map
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -400,7 +400,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -410,7 +410,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/bgp_route_map_redistribution.md
+++ b/docs/sdk/config/network/bgp_route_map_redistribution.md
@@ -20,10 +20,10 @@ This produces 7 possible crossover variants, each with variant-specific match an
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -239,10 +239,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -281,10 +281,10 @@ print(f"Retrieved redistribution: {redist_by_id.name}")
 ### Create a BGP Route Map Redistribution
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -454,7 +454,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -464,7 +464,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/dhcp_interface.md
+++ b/docs/sdk/config/network/dhcp_interface.md
@@ -5,10 +5,10 @@ The `DhcpInterface` class manages DHCP server and relay configurations on firewa
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -172,10 +172,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -210,10 +210,10 @@ elif dhcp_by_id.relay:
 ### Create a DHCP Interface
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -336,7 +336,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -346,7 +346,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/dns_proxy.md
+++ b/docs/sdk/config/network/dns_proxy.md
@@ -5,10 +5,10 @@ The `DnsProxy` class manages DNS proxy configuration objects in Palo Alto Networ
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -121,10 +121,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -155,10 +155,10 @@ print(f"Retrieved proxy: {proxy_by_id.name}")
 ### Create a DNS Proxy
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -281,7 +281,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -291,7 +291,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ethernet_interface.md
+++ b/docs/sdk/config/network/ethernet_interface.md
@@ -5,10 +5,10 @@ The `EthernetInterface` class manages ethernet interface objects in Palo Alto Ne
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ike_crypto_profile.md
+++ b/docs/sdk/config/network/ike_crypto_profile.md
@@ -12,10 +12,10 @@ IKE Crypto Profiles define:
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -114,10 +114,10 @@ profiles = client.ike_crypto_profile.list(
 The SDK supports pagination through the `max_limit` parameter, which defines how many objects are retrieved per API call. By default, `max_limit` is set to 2500. The API itself imposes a maximum allowed value of 5000.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -148,10 +148,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create an IKE Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -241,7 +241,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -250,7 +250,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ike_gateway.md
+++ b/docs/sdk/config/network/ike_gateway.md
@@ -5,10 +5,10 @@ The `IKEGateway` class provides functionality to manage Internet Key Exchange (I
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -124,10 +124,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -147,10 +147,10 @@ all_gateways = client.ike_gateway.list(folder='VPN')
 ### Create an IKE Gateway
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -255,7 +255,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -264,7 +264,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/index.md
+++ b/docs/sdk/config/network/index.md
@@ -68,10 +68,10 @@ The network objects also enforce:
 ## Usage Example
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/interface_management_profile.md
+++ b/docs/sdk/config/network/interface_management_profile.md
@@ -5,10 +5,10 @@ The `InterfaceManagementProfile` class manages interface management profile obje
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -136,10 +136,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -170,10 +170,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create an Interface Management Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -279,7 +279,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -289,7 +289,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ipsec_crypto_profile.md
+++ b/docs/sdk/config/network/ipsec_crypto_profile.md
@@ -13,10 +13,10 @@ IPsec Crypto Profiles define:
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -118,10 +118,10 @@ profiles = client.ipsec_crypto_profile.list(
 The SDK supports pagination through the `max_limit` parameter, which defines how many objects are retrieved per API call. By default, `max_limit` is set to 2500. The API itself imposes a maximum allowed value of 5000.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -152,10 +152,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create an IPsec Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -263,7 +263,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -272,7 +272,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ipsec_tunnel.md
+++ b/docs/sdk/config/network/ipsec_tunnel.md
@@ -5,10 +5,10 @@ The `IPsecTunnel` class manages IPsec tunnel objects in Palo Alto Networks' Stra
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -165,10 +165,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -201,10 +201,10 @@ print(f"Retrieved tunnel: {tunnel_by_id.name}")
 ### Create an IPsec Tunnel
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -340,7 +340,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -350,7 +350,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/layer2_subinterface.md
+++ b/docs/sdk/config/network/layer2_subinterface.md
@@ -5,9 +5,9 @@ The `Layer2Subinterface` class manages Layer 2 subinterface objects in Palo Alto
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/layer3_subinterface.md
+++ b/docs/sdk/config/network/layer3_subinterface.md
@@ -5,9 +5,9 @@ The `Layer3Subinterface` class manages Layer 3 subinterface objects in Palo Alto
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/logical_router.md
+++ b/docs/sdk/config/network/logical_router.md
@@ -5,10 +5,10 @@ The `LogicalRouter` class manages logical router objects in Palo Alto Networks' 
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -307,10 +307,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -347,10 +347,10 @@ print(f"Retrieved router: {router_by_id.name}")
 ### Create a Logical Router
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -613,7 +613,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -623,7 +623,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/loopback_interface.md
+++ b/docs/sdk/config/network/loopback_interface.md
@@ -5,9 +5,9 @@ The `LoopbackInterface` class manages loopback interface objects in Palo Alto Ne
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/nat_rules.md
+++ b/docs/sdk/config/network/nat_rules.md
@@ -5,10 +5,10 @@ The `NatRule` class manages NAT rule objects in Palo Alto Networks' Strata Cloud
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -238,10 +238,10 @@ filtered_rules = client.nat_rule.list(
 The SDK supports pagination through the `max_limit` parameter, which defines how many objects are retrieved per API call. By default, `max_limit` is set to 2500. The API itself imposes a maximum allowed value of 5000.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -272,10 +272,10 @@ print(f"NAT Rule ID: {rule_by_id.id}, Name: {rule_by_id.name}")
 ### Create a NAT Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -393,7 +393,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -402,7 +402,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/ospf_auth_profile.md
+++ b/docs/sdk/config/network/ospf_auth_profile.md
@@ -5,10 +5,10 @@ The `OspfAuthProfile` class manages OSPF authentication profile objects in Palo 
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -136,10 +136,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -173,10 +173,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create an OSPF Auth Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -280,7 +280,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -290,7 +290,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/pbf_rule.md
+++ b/docs/sdk/config/network/pbf_rule.md
@@ -5,10 +5,10 @@ The `PbfRule` class manages Policy-Based Forwarding (PBF) rule objects in Palo A
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -126,10 +126,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -164,10 +164,10 @@ if rule.from_:
 ### Create a PBF Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -283,7 +283,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -293,7 +293,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/qos_profile.md
+++ b/docs/sdk/config/network/qos_profile.md
@@ -5,10 +5,10 @@ The `QosProfile` class manages QoS profile objects in Palo Alto Networks' Strata
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -112,10 +112,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -146,10 +146,10 @@ print(f"Retrieved profile: {profile_by_id.name}")
 ### Create a QoS Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -252,7 +252,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -262,7 +262,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/qos_rule.md
+++ b/docs/sdk/config/network/qos_rule.md
@@ -5,10 +5,10 @@ The `QosRule` class manages QoS policy rule objects in Palo Alto Networks' Strat
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -115,10 +115,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -149,10 +149,10 @@ print(f"Retrieved rule: {rule_by_id.name}")
 ### Create a QoS Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -253,7 +253,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -263,7 +263,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/route_access_list.md
+++ b/docs/sdk/config/network/route_access_list.md
@@ -5,10 +5,10 @@ The `RouteAccessList` class manages route access list objects in Palo Alto Netwo
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -153,10 +153,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -190,10 +190,10 @@ print(f"Retrieved access list: {acl_by_id.name}")
 ### Create a Route Access List
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -330,7 +330,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -340,7 +340,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/route_prefix_list.md
+++ b/docs/sdk/config/network/route_prefix_list.md
@@ -5,10 +5,10 @@ The `RoutePrefixList` class manages route prefix list objects in Palo Alto Netwo
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -147,10 +147,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -184,10 +184,10 @@ print(f"Retrieved prefix list: {prefix_list_by_id.name}")
 ### Create a Route Prefix List
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -343,7 +343,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -353,7 +353,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/security_zone.md
+++ b/docs/sdk/config/network/security_zone.md
@@ -5,10 +5,10 @@ The `SecurityZone` class manages security zone objects in Palo Alto Networks' St
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -16,7 +16,7 @@ client = ScmClient(
 
 # Access the Security Zone service directly through the client
 # No need to create a separate SecurityZone instance
-# The ScmClient automatically handles authentication and token refresh
+# The Scm automatically handles authentication and token refresh
 zones = client.security_zone
 ```
 
@@ -264,10 +264,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -300,10 +300,10 @@ print(f"Retrieved security zone: {zone_by_id.name}")
 ### Create a Security Zone
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -413,7 +413,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -423,7 +423,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/tunnel_interface.md
+++ b/docs/sdk/config/network/tunnel_interface.md
@@ -5,9 +5,9 @@ The `TunnelInterface` class manages tunnel interface objects in Palo Alto Networ
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/vlan_interface.md
+++ b/docs/sdk/config/network/vlan_interface.md
@@ -5,9 +5,9 @@ The `VlanInterface` class manages VLAN interface objects in Palo Alto Networks' 
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/network/zone_protection_profile.md
+++ b/docs/sdk/config/network/zone_protection_profile.md
@@ -5,10 +5,10 @@ The `ZoneProtectionProfile` class manages zone protection profile objects in Pal
 ## Class Overview
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -187,10 +187,10 @@ The SDK supports pagination through the `max_limit` parameter, which defines how
 **Example:**
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -222,10 +222,10 @@ print(f"Description: {profile_by_id.description}")
 ### Create a Zone Protection Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -362,7 +362,7 @@ for job in recent_jobs.data:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
    InvalidObjectError,
    MissingQueryParameterError,
@@ -372,7 +372,7 @@ from scm.exceptions import (
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/address.md
+++ b/docs/sdk/config/objects/address.md
@@ -4,12 +4,12 @@ The `Address` service manages address objects in Strata Cloud Manager, supportin
 
 ## Class Overview
 
-The `Address` class provides CRUD operations for address objects. It is accessed through the `client.address` attribute on an initialized `ScmClient` instance.
+The `Address` class provides CRUD operations for address objects. It is accessed through the `client.address` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -126,9 +126,9 @@ client.address.delete("123e4567-e89b-12d3-a456-426655440000")
 Create different types of address objects for various network resources.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -214,7 +214,7 @@ print(f"Commit job ID: {result.job_id}")
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -223,7 +223,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/address_group.md
+++ b/docs/sdk/config/objects/address_group.md
@@ -4,12 +4,12 @@ The `AddressGroup` service manages address group objects in Strata Cloud Manager
 
 ## Class Overview
 
-The `AddressGroup` class provides CRUD operations for address group objects. It is accessed through the `client.address_group` attribute on an initialized `ScmClient` instance.
+The `AddressGroup` class provides CRUD operations for address group objects. It is accessed through the `client.address_group` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -113,9 +113,9 @@ client.address_group.delete("123e4567-e89b-12d3-a456-426655440000")
 Create both types of groups for different use cases.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -164,7 +164,7 @@ for group in combined:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -173,7 +173,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/application.md
+++ b/docs/sdk/config/objects/application.md
@@ -4,12 +4,12 @@ The `Application` service manages custom application definitions in Strata Cloud
 
 ## Class Overview
 
-The `Application` class provides CRUD operations for custom application objects. It is accessed through the `client.application` attribute on an initialized `ScmClient` instance.
+The `Application` class provides CRUD operations for custom application objects. It is accessed through the `client.application` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -117,9 +117,9 @@ client.application.delete("123e4567-e89b-12d3-a456-426655440000")
 Create an application with full security characteristics.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -168,7 +168,7 @@ filtered = client.application.list(
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -177,7 +177,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/application_filters.md
+++ b/docs/sdk/config/objects/application_filters.md
@@ -4,12 +4,12 @@ The `ApplicationFilters` service manages application filter definitions in Strat
 
 ## Class Overview
 
-The `ApplicationFilters` class provides CRUD operations for application filter objects. It is accessed through the `client.application_filter` attribute on an initialized `ScmClient` instance.
+The `ApplicationFilters` class provides CRUD operations for application filter objects. It is accessed through the `client.application_filter` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -119,9 +119,9 @@ client.application_filter.delete("123e4567-e89b-12d3-a456-426655440000")
 Define filters targeting applications with specific security characteristics.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -172,7 +172,7 @@ for f in combined:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -181,7 +181,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/application_group.md
+++ b/docs/sdk/config/objects/application_group.md
@@ -4,12 +4,12 @@ The `ApplicationGroup` service manages application group objects in Strata Cloud
 
 ## Class Overview
 
-The `ApplicationGroup` class provides CRUD operations for application group objects. It is accessed through the `client.application_group` attribute on an initialized `ScmClient` instance.
+The `ApplicationGroup` class provides CRUD operations for application group objects. It is accessed through the `client.application_group` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -95,9 +95,9 @@ client.application_group.delete("123e4567-e89b-12d3-a456-426655440000")
 Group related applications for simplified policy management.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -143,7 +143,7 @@ for group in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -152,7 +152,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/auto_tag_actions.md
+++ b/docs/sdk/config/objects/auto_tag_actions.md
@@ -4,12 +4,12 @@ The `AutoTagActions` service manages automated tag assignment configurations in 
 
 ## Class Overview
 
-The `AutoTagActions` class provides CRUD operations for auto tag action configurations. It is accessed through the `client.auto_tag_actions` attribute on an initialized `ScmClient` instance.
+The `AutoTagActions` class provides CRUD operations for auto tag action configurations. It is accessed through the `client.auto_tag_actions` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -99,9 +99,9 @@ client.auto_tag_actions.delete("123456789")
 Automatically tag hosts that exhibit signs of infection for quarantine.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -180,10 +180,10 @@ client.security_rule.create({
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, ObjectNotPresentError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/dynamic_user_group.md
+++ b/docs/sdk/config/objects/dynamic_user_group.md
@@ -4,12 +4,12 @@ The `DynamicUserGroup` service manages dynamic user group objects in Strata Clou
 
 ## Class Overview
 
-The `DynamicUserGroup` class provides CRUD operations for dynamic user group objects. It is accessed through the `client.dynamic_user_group` attribute on an initialized `ScmClient` instance.
+The `DynamicUserGroup` class provides CRUD operations for dynamic user group objects. It is accessed through the `client.dynamic_user_group` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -106,9 +106,9 @@ client.dynamic_user_group.delete("123e4567-e89b-12d3-a456-426655440000")
 Create dynamic groups for different organizational roles.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -153,7 +153,7 @@ for dug in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -161,7 +161,7 @@ from scm.exceptions import (
     ObjectNotPresentError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/external_dynamic_lists.md
+++ b/docs/sdk/config/objects/external_dynamic_lists.md
@@ -4,12 +4,12 @@ The `ExternalDynamicLists` service manages External Dynamic Lists (EDLs) in Stra
 
 ## Class Overview
 
-The `ExternalDynamicLists` class provides CRUD operations for EDL objects. It is accessed through the `client.external_dynamic_list` attribute on an initialized `ScmClient` instance.
+The `ExternalDynamicLists` class provides CRUD operations for EDL objects. It is accessed through the `client.external_dynamic_list` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -116,9 +116,9 @@ client.external_dynamic_list.delete("123e4567-e89b-12d3-a456-426655440000")
 Set up IP and domain-based EDLs for threat intelligence feeds.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -172,7 +172,7 @@ for edl in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -181,7 +181,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/hip_object.md
+++ b/docs/sdk/config/objects/hip_object.md
@@ -4,12 +4,12 @@ The `HIPObject` service manages Host Information Profile (HIP) objects in Strata
 
 ## Class Overview
 
-The `HIPObject` class provides CRUD operations for HIP objects. It is accessed through the `client.hip_object` attribute on an initialized `ScmClient` instance.
+The `HIPObject` class provides CRUD operations for HIP objects. It is accessed through the `client.hip_object` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -114,9 +114,9 @@ client.hip_object.delete("123e4567-e89b-12d3-a456-426655440000")
 Create HIP objects for different security posture checks.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -175,7 +175,7 @@ for hip in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -184,7 +184,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/hip_profile.md
+++ b/docs/sdk/config/objects/hip_profile.md
@@ -4,12 +4,12 @@ The `HIPProfile` service manages Host Information Profile (HIP) profiles in Stra
 
 ## Class Overview
 
-The `HIPProfile` class provides CRUD operations for HIP profile objects. It is accessed through the `client.hip_profile` attribute on an initialized `ScmClient` instance.
+The `HIPProfile` class provides CRUD operations for HIP profile objects. It is accessed through the `client.hip_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -101,9 +101,9 @@ client.hip_profile.delete("123e4567-e89b-12d3-a456-426655440000")
 Define HIP profiles using boolean match expressions referencing HIP objects.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -155,7 +155,7 @@ for profile in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -164,7 +164,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/http_server_profiles.md
+++ b/docs/sdk/config/objects/http_server_profiles.md
@@ -4,12 +4,12 @@ The `HTTPServerProfile` service manages HTTP server profile configurations in St
 
 ## Class Overview
 
-The `HTTPServerProfile` class provides CRUD operations for HTTP server profile objects. It is accessed through the `client.http_server_profile` attribute on an initialized `ScmClient` instance.
+The `HTTPServerProfile` class provides CRUD operations for HTTP server profile objects. It is accessed through the `client.http_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -133,9 +133,9 @@ client.http_server_profile.delete("123e4567-e89b-12d3-a456-426655440000")
 Create HTTP server profiles for secure log forwarding.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -195,10 +195,10 @@ for profile in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/log_forwarding_profile.md
+++ b/docs/sdk/config/objects/log_forwarding_profile.md
@@ -4,12 +4,12 @@ The `LogForwardingProfile` service manages log forwarding profile configurations
 
 ## Class Overview
 
-The `LogForwardingProfile` class provides CRUD operations for log forwarding profile objects. It is accessed through the `client.log_forwarding_profile` attribute on an initialized `ScmClient` instance.
+The `LogForwardingProfile` class provides CRUD operations for log forwarding profile objects. It is accessed through the `client.log_forwarding_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -139,9 +139,9 @@ client.log_forwarding_profile.delete("123e4567-e89b-12d3-a456-426655440000")
 Forward different log types to appropriate destinations.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -203,10 +203,10 @@ filtered = client.log_forwarding_profile.list(
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/quarantined_devices.md
+++ b/docs/sdk/config/objects/quarantined_devices.md
@@ -4,12 +4,12 @@ The `QuarantinedDevices` service manages quarantined device entries in Strata Cl
 
 ## Class Overview
 
-The `QuarantinedDevices` class provides operations for quarantined device entries. It is accessed through the `client.quarantined_device` attribute on an initialized `ScmClient` instance.
+The `QuarantinedDevices` class provides operations for quarantined device entries. It is accessed through the `client.quarantined_device` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -74,9 +74,9 @@ client.quarantined_device.delete("abc123")
 Quarantine a device, verify the quarantine, then release it.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -120,10 +120,10 @@ print(f"Found {len(pa_devices)} devices with specified serial")
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/region.md
+++ b/docs/sdk/config/objects/region.md
@@ -4,12 +4,12 @@ The `Region` service manages region objects in Strata Cloud Manager, defining ge
 
 ## Class Overview
 
-The `Region` class provides CRUD operations for region objects. It is accessed through the `client.region` attribute on an initialized `ScmClient` instance.
+The `Region` class provides CRUD operations for region objects. It is accessed through the `client.region` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -107,9 +107,9 @@ client.region.delete("123e4567-e89b-12d3-a456-426655440000")
 Define regions with both geographic locations and network addresses.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -165,10 +165,10 @@ combined = client.region.list(
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/schedules.md
+++ b/docs/sdk/config/objects/schedules.md
@@ -4,12 +4,12 @@ The `Schedule` service manages schedule objects in Strata Cloud Manager, definin
 
 ## Class Overview
 
-The `Schedule` class provides CRUD operations for schedule objects. It is accessed through the `client.schedule` attribute on an initialized `ScmClient` instance.
+The `Schedule` class provides CRUD operations for schedule objects. It is accessed through the `client.schedule` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -115,9 +115,9 @@ client.schedule.delete(schedule.id)
 Define weekly and daily recurring schedules for policy enforcement.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -180,7 +180,7 @@ filtered = client.schedule.list(
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -189,7 +189,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/service.md
+++ b/docs/sdk/config/objects/service.md
@@ -4,12 +4,12 @@ The `Service` service manages service objects in Strata Cloud Manager, defining 
 
 ## Class Overview
 
-The `Service` class provides CRUD operations for service objects. It is accessed through the `client.service` attribute on an initialized `ScmClient` instance.
+The `Service` class provides CRUD operations for service objects. It is accessed through the `client.service` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -128,9 +128,9 @@ client.service.delete("123e4567-e89b-12d3-a456-426655440000")
 Define services for different network protocols.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -186,7 +186,7 @@ for svc in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -195,7 +195,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/service_group.md
+++ b/docs/sdk/config/objects/service_group.md
@@ -4,12 +4,12 @@ The `ServiceGroup` service manages service group objects in Strata Cloud Manager
 
 ## Class Overview
 
-The `ServiceGroup` class provides CRUD operations for service group objects. It is accessed through the `client.service_group` attribute on an initialized `ScmClient` instance.
+The `ServiceGroup` class provides CRUD operations for service group objects. It is accessed through the `client.service_group` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -99,9 +99,9 @@ client.service_group.delete("123e4567-e89b-12d3-a456-426655440000")
 Group related services for simplified policy management.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -145,7 +145,7 @@ for group in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -154,7 +154,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/syslog_server_profiles.md
+++ b/docs/sdk/config/objects/syslog_server_profiles.md
@@ -4,12 +4,12 @@ The `SyslogServerProfile` service manages syslog server profile configurations i
 
 ## Class Overview
 
-The `SyslogServerProfile` class provides CRUD operations for syslog server profile objects. It is accessed through the `client.syslog_server_profile` attribute on an initialized `ScmClient` instance.
+The `SyslogServerProfile` class provides CRUD operations for syslog server profile objects. It is accessed through the `client.syslog_server_profile` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -133,9 +133,9 @@ client.syslog_server_profile.delete("123e4567-e89b-12d3-a456-426655440000")
 Create profiles for different transport protocols.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -212,10 +212,10 @@ for profile in filtered:
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/objects/tag.md
+++ b/docs/sdk/config/objects/tag.md
@@ -4,12 +4,12 @@ The `Tag` service manages tag objects in Strata Cloud Manager, providing color-c
 
 ## Class Overview
 
-The `Tag` class provides CRUD operations for tag objects. It is accessed through the `client.tag` attribute on an initialized `ScmClient` instance.
+The `Tag` class provides CRUD operations for tag objects. It is accessed through the `client.tag` attribute on an initialized `Scm` instance.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -98,9 +98,9 @@ client.tag.delete("123e4567-e89b-12d3-a456-426655440000")
 Define tags for different environments with consistent color coding.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -168,7 +168,7 @@ print(f"Commit job ID: {result.job_id}")
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     InvalidObjectError,
     MissingQueryParameterError,
@@ -177,7 +177,7 @@ from scm.exceptions import (
     ReferenceNotZeroError
 )
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/anti_spyware_profile.md
+++ b/docs/sdk/config/security_services/anti_spyware_profile.md
@@ -52,9 +52,9 @@ The `AntiSpywareProfile` class inherits from `BaseObject` and provides CRUD oper
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/app_override_rule.md
+++ b/docs/sdk/config/security_services/app_override_rule.md
@@ -60,9 +60,9 @@ The `AppOverrideRule` class inherits from `BaseObject` and provides CRUD operati
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/authentication_rule.md
+++ b/docs/sdk/config/security_services/authentication_rule.md
@@ -67,9 +67,9 @@ The `AuthenticationRule` class inherits from `BaseObject` and provides CRUD oper
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/decryption_profile.md
+++ b/docs/sdk/config/security_services/decryption_profile.md
@@ -104,9 +104,9 @@ The `DecryptionProfile` class inherits from `BaseObject` and provides CRUD opera
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/decryption_rule.md
+++ b/docs/sdk/config/security_services/decryption_rule.md
@@ -67,9 +67,9 @@ The `DecryptionRule` class inherits from `BaseObject` and provides CRUD operatio
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/dns_security_profile.md
+++ b/docs/sdk/config/security_services/dns_security_profile.md
@@ -65,9 +65,9 @@ The `DNSSecurityProfile` class inherits from `BaseObject` and provides CRUD oper
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/file_blocking_profile.md
+++ b/docs/sdk/config/security_services/file_blocking_profile.md
@@ -47,9 +47,9 @@ The `FileBlockingProfile` class inherits from `BaseObject` and provides CRUD ope
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/index.md
+++ b/docs/sdk/config/security_services/index.md
@@ -71,9 +71,9 @@ All security services configuration objects provide:
 ## Usage Pattern
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/security_rule.md
+++ b/docs/sdk/config/security_services/security_rule.md
@@ -68,9 +68,9 @@ The `SecurityRule` class inherits from `BaseObject` and provides CRUD operations
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/url_access_profile.md
+++ b/docs/sdk/config/security_services/url_access_profile.md
@@ -63,9 +63,9 @@ The `URLAccessProfile` class inherits from `BaseObject` and provides CRUD operat
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/url_categories.md
+++ b/docs/sdk/config/security_services/url_categories.md
@@ -48,9 +48,9 @@ The `URLCategories` class inherits from `BaseObject` and provides CRUD operation
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/vulnerability_protection_profile.md
+++ b/docs/sdk/config/security_services/vulnerability_protection_profile.md
@@ -62,9 +62,9 @@ The `VulnerabilityProtectionProfile` class inherits from `BaseObject` and provid
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/security_services/wildfire_antivirus.md
+++ b/docs/sdk/config/security_services/wildfire_antivirus.md
@@ -60,9 +60,9 @@ The `WildfireAntivirusProfile` class inherits from `BaseObject` and provides CRU
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/setup/device.md
+++ b/docs/sdk/config/setup/device.md
@@ -62,9 +62,9 @@ The `Device` class provides methods for listing, filtering, and retrieving devic
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/setup/folder.md
+++ b/docs/sdk/config/setup/folder.md
@@ -48,9 +48,9 @@ The `Folder` class inherits from `BaseObject` and provides CRUD operations for f
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/setup/label.md
+++ b/docs/sdk/config/setup/label.md
@@ -38,9 +38,9 @@ The `Label` class inherits from `BaseObject` and provides CRUD operations for la
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/setup/snippet.md
+++ b/docs/sdk/config/setup/snippet.md
@@ -51,9 +51,9 @@ The `Snippet` class inherits from `BaseObject` and provides CRUD operations for 
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/config/setup/variable.md
+++ b/docs/sdk/config/setup/variable.md
@@ -71,9 +71,9 @@ The `Variable` class provides CRUD operations for variable resources used to def
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -3,9 +3,9 @@
 Service classes provide CRUD operations for managing Strata Cloud Manager configurations. Each service maps to a resource type and is accessed through the unified client.
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/insights/alerts.md
+++ b/docs/sdk/insights/alerts.md
@@ -48,9 +48,9 @@ The `Alerts` class inherits from `InsightsBaseObject` and provides methods for r
 ### Basic Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/bandwidth_allocation_models.md
+++ b/docs/sdk/models/deployment/bandwidth_allocation_models.md
@@ -48,10 +48,10 @@ The Bandwidth Allocation models enforce data validation through Pydantic:
 ### Creating a Bandwidth Allocation
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/bgp_routing_models.md
+++ b/docs/sdk/models/deployment/bgp_routing_models.md
@@ -157,11 +157,11 @@ except ValueError as e:
 
 ```python
 # Using dictionary approach
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.deployment import BackboneRoutingEnum
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -254,10 +254,10 @@ result = client.bgp_routing.update(partial_update)
 
 ```python
 # Working with response models
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/internal_dns_servers_models.md
+++ b/docs/sdk/models/deployment/internal_dns_servers_models.md
@@ -90,10 +90,10 @@ except ValueError as e:
 ### Creating an Internal DNS Server
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -129,10 +129,10 @@ print(f"Updated DNS server: {updated.name}")
 ### Working with Response Model
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/network_locations.md
+++ b/docs/sdk/models/deployment/network_locations.md
@@ -64,10 +64,10 @@ Here's an example of the data structure for a network location:
 The model is used automatically when retrieving network locations using the SDK:
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize the client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/remote_networks_models.md
+++ b/docs/sdk/models/deployment/remote_networks_models.md
@@ -206,10 +206,10 @@ except ValueError as e:
 ### Creating a Standard Remote Network
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/deployment/service_connections_models.md
+++ b/docs/sdk/models/deployment/service_connections_models.md
@@ -175,11 +175,11 @@ except ValueError as e:
 ### Creating a Basic Service Connection
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.deployment import ServiceConnectionCreateModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/identity/index.md
+++ b/docs/sdk/models/identity/index.md
@@ -39,14 +39,14 @@ Identity models share common patterns:
 ## Usage Examples
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.identity import (
     LdapServerProfileCreateModel,
     RadiusServerProfileCreateModel,
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/insights/alerts_models.md
+++ b/docs/sdk/models/insights/alerts_models.md
@@ -206,9 +206,9 @@ minimal_alert = Alert(
 These models are used throughout the Alerts service:
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/mobile_agent/agent_versions_models.md
+++ b/docs/sdk/models/mobile_agent/agent_versions_models.md
@@ -34,10 +34,10 @@ All models use `extra="forbid"` configuration, which rejects any fields not expl
 ### Listing Agent Versions
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -54,11 +54,11 @@ for version in versions:
 ### Fetching a Specific Version
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -87,11 +87,11 @@ print(f"Found {len(prefix_versions)} versions starting with '5.3'")
 ## Error Handling
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import InvalidObjectError, MissingQueryParameterError
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/mobile_agent/auth_settings_models.md
+++ b/docs/sdk/models/mobile_agent/auth_settings_models.md
@@ -140,10 +140,10 @@ except ValueError as e:
 ### Creating Authentication Settings
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -179,10 +179,10 @@ response = client.auth_setting.create(payload)
 ### Creating Authentication Settings for Multiple Operating Systems
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -214,10 +214,10 @@ response = client.auth_setting.create(default_auth)
 ### Updating Authentication Settings
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -239,10 +239,10 @@ print(f"Updated authentication settings: {response.name}")
 ### Moving Authentication Settings
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/mobile_agent/index.md
+++ b/docs/sdk/models/mobile_agent/index.md
@@ -24,14 +24,14 @@ Key model patterns:
 ## Usage Examples
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.mobile_agent.auth_settings import (
     AuthSettingsCreateModel,
     OperatingSystem
 )
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/bgp_address_family_profile_models.md
+++ b/docs/sdk/models/network/bgp_address_family_profile_models.md
@@ -317,10 +317,10 @@ print(payload)
 ### Updating a BGP Address Family Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/bgp_auth_profile_models.md
+++ b/docs/sdk/models/network/bgp_auth_profile_models.md
@@ -107,10 +107,10 @@ print(payload)
 ### Updating a BGP Auth Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/bgp_filtering_profile_models.md
+++ b/docs/sdk/models/network/bgp_filtering_profile_models.md
@@ -289,10 +289,10 @@ print(payload)
 ### Updating a BGP Filtering Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/bgp_redistribution_profile_models.md
+++ b/docs/sdk/models/network/bgp_redistribution_profile_models.md
@@ -209,10 +209,10 @@ print(payload)
 ### Updating a BGP Redistribution Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/bgp_route_map_models.md
+++ b/docs/sdk/models/network/bgp_route_map_models.md
@@ -294,10 +294,10 @@ print(payload)
 ### Updating a BGP Route Map
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/bgp_route_map_redistribution_models.md
+++ b/docs/sdk/models/network/bgp_route_map_redistribution_models.md
@@ -546,10 +546,10 @@ print(payload)
 ### Updating a Redistribution
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/dhcp_interface_models.md
+++ b/docs/sdk/models/network/dhcp_interface_models.md
@@ -268,10 +268,10 @@ print(payload)
 ### Updating a DHCP Interface Configuration
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/dns_proxy_models.md
+++ b/docs/sdk/models/network/dns_proxy_models.md
@@ -298,10 +298,10 @@ print(payload)
 ### Updating a DNS Proxy
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/ike_crypto_profile_models.md
+++ b/docs/sdk/models/network/ike_crypto_profile_models.md
@@ -190,10 +190,10 @@ except ValueError as e:
 ### Creating an IKE Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -232,10 +232,10 @@ response = client.ike_crypto_profile.create(payload)
 ### Updating an IKE Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/ike_gateway_models.md
+++ b/docs/sdk/models/network/ike_gateway_models.md
@@ -281,10 +281,10 @@ except ValueError as e:
 ### Creating an IKE Gateway with Pre-shared Key
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -324,10 +324,10 @@ print(f"Created gateway: {response.name} (ID: {response.id})")
 ### Creating an IKE Gateway with Certificate Authentication
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -366,10 +366,10 @@ print(f"Created gateway: {response.name}")
 ### Creating an IKE Gateway with Dynamic Peer Address
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -402,10 +402,10 @@ print(f"Created dynamic gateway: {response.name}")
 ### Updating an IKE Gateway
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/index.md
+++ b/docs/sdk/models/network/index.md
@@ -27,11 +27,11 @@ Network models share common patterns:
 ## Usage Examples
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.network import NatRuleCreateModel, NatRuleUpdateModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/interface_management_profile_models.md
+++ b/docs/sdk/models/network/interface_management_profile_models.md
@@ -135,10 +135,10 @@ print(payload)
 ### Updating an Interface Management Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/ipsec_crypto_profile_models.md
+++ b/docs/sdk/models/network/ipsec_crypto_profile_models.md
@@ -269,10 +269,10 @@ except ValueError as e:
 ### Creating an ESP-based IPsec Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -298,10 +298,10 @@ print(f"Created profile: {response.name} (ID: {response.id})")
 ### Creating an AH-based IPsec Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -325,10 +325,10 @@ print(f"Created profile: {response.name} (ID: {response.id})")
 ### Updating an IPsec Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/ipsec_tunnel_models.md
+++ b/docs/sdk/models/network/ipsec_tunnel_models.md
@@ -241,10 +241,10 @@ print(payload)
 ### Updating an IPsec Tunnel
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/logical_router_models.md
+++ b/docs/sdk/models/network/logical_router_models.md
@@ -630,10 +630,10 @@ print(payload)
 ### Updating a Logical Router
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/nat_rule_models.md
+++ b/docs/sdk/models/network/nat_rule_models.md
@@ -367,10 +367,10 @@ except ValueError as e:
 ### Creating a Basic Source NAT Rule (Dynamic IP and Port)
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -399,10 +399,10 @@ print(f"Created NAT rule: {response.name} (ID: {response.id})")
 ### Creating a Destination NAT Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -431,10 +431,10 @@ print(f"Created destination NAT rule: {response.name}")
 ### Creating a Static IP NAT Rule with Bi-directional Support
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -464,10 +464,10 @@ print(f"Created static NAT rule: {response.name}")
 ### Creating a NAT Rule with Interface Address
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -498,10 +498,10 @@ print(f"Created interface NAT rule: {response.name}")
 ### Updating a NAT Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -527,10 +527,10 @@ print(f"Updated NAT rule: {updated.name}")
 ### Moving a NAT Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/nat_rules_models.md
+++ b/docs/sdk/models/network/nat_rules_models.md
@@ -526,10 +526,10 @@ print(payload)
 ### Updating a NAT Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/ospf_auth_profile_models.md
+++ b/docs/sdk/models/network/ospf_auth_profile_models.md
@@ -165,10 +165,10 @@ print(payload)
 ### Updating an OSPF Auth Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/pbf_rule_models.md
+++ b/docs/sdk/models/network/pbf_rule_models.md
@@ -268,10 +268,10 @@ print(payload)
 ### Updating a PBF Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/qos_profile_models.md
+++ b/docs/sdk/models/network/qos_profile_models.md
@@ -122,10 +122,10 @@ print(payload)
 ### Updating a QoS Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/qos_rule_models.md
+++ b/docs/sdk/models/network/qos_rule_models.md
@@ -190,10 +190,10 @@ print(move_before.model_dump(exclude_none=True))
 ### Updating a QoS Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/route_access_list_models.md
+++ b/docs/sdk/models/network/route_access_list_models.md
@@ -221,10 +221,10 @@ print(payload)
 ### Updating a Route Access List
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/route_prefix_list_models.md
+++ b/docs/sdk/models/network/route_prefix_list_models.md
@@ -222,10 +222,10 @@ print(payload)
 ### Updating a Route Prefix List
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id",

--- a/docs/sdk/models/network/security_zone_models.md
+++ b/docs/sdk/models/network/security_zone_models.md
@@ -199,10 +199,10 @@ print(payload)
 ### Updating a Security Zone
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/network/zone_protection_profile_models.md
+++ b/docs/sdk/models/network/zone_protection_profile_models.md
@@ -410,10 +410,10 @@ print(payload)
 ### Updating a Zone Protection Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/address_group_models.md
+++ b/docs/sdk/models/objects/address_group_models.md
@@ -133,10 +133,10 @@ group = AddressGroupCreateModel(
 ### Creating a Static Address Group
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/address_models.md
+++ b/docs/sdk/models/objects/address_models.md
@@ -120,11 +120,11 @@ address = AddressCreateModel(
 ### Creating an Address Object
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.objects import AddressCreateModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/application_filters_models.md
+++ b/docs/sdk/models/objects/application_filters_models.md
@@ -95,10 +95,10 @@ except ValueError as e:
 ### Creating Application Filters
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/application_group_models.md
+++ b/docs/sdk/models/objects/application_group_models.md
@@ -82,10 +82,10 @@ except ValueError as e:
 ### Creating an Application Group
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/application_models.md
+++ b/docs/sdk/models/objects/application_models.md
@@ -105,10 +105,10 @@ except ValueError as e:
 ### Creating a Basic Application
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/dynamic_user_group_models.md
+++ b/docs/sdk/models/objects/dynamic_user_group_models.md
@@ -104,10 +104,10 @@ print(dug.tag)  # ["security"]
 ### Creating a Dynamic User Group
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/external_dynamic_lists_models.md
+++ b/docs/sdk/models/objects/external_dynamic_lists_models.md
@@ -116,10 +116,10 @@ edl = ExternalDynamicListsCreateModel(
 ### Creating an IP List
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/hip_object_models.md
+++ b/docs/sdk/models/objects/hip_object_models.md
@@ -79,10 +79,10 @@ except ValueError as e:
 ### Creating a Windows Host Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/hip_profile_models.md
+++ b/docs/sdk/models/objects/hip_profile_models.md
@@ -69,10 +69,10 @@ except ValueError as e:
 ### Creating a Basic HIP Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/http_server_profiles_models.md
+++ b/docs/sdk/models/objects/http_server_profiles_models.md
@@ -95,10 +95,10 @@ The `HTTPServerProfileResponseModel` extends the base model and includes the ID 
 ### Creating a Basic HTTP Server Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/index.md
+++ b/docs/sdk/models/objects/index.md
@@ -31,11 +31,11 @@ Object models share common patterns:
 ### Creating an Object
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.objects import AddressCreateModel, AddressUpdateModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/log_forwarding_profile_models.md
+++ b/docs/sdk/models/objects/log_forwarding_profile_models.md
@@ -85,10 +85,10 @@ The `LogForwardingProfileResponseModel` extends the base model and includes the 
 ### Creating a Log Forwarding Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/quarantined_devices_models.md
+++ b/docs/sdk/models/objects/quarantined_devices_models.md
@@ -56,10 +56,10 @@ The `QuarantinedDevicesListParamsModel` defines parameters for filtering list op
 ### Creating a Quarantined Device
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/region_models.md
+++ b/docs/sdk/models/objects/region_models.md
@@ -84,10 +84,10 @@ The `RegionResponseModel` extends the base model and includes the ID field retur
 ### Creating a Region
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/schedules_models.md
+++ b/docs/sdk/models/objects/schedules_models.md
@@ -252,10 +252,10 @@ except ValueError as e:
 ### Creating a Weekly Schedule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/service_group_models.md
+++ b/docs/sdk/models/objects/service_group_models.md
@@ -95,10 +95,10 @@ service_group = ServiceGroupCreateModel(
 ### Creating a Service Group
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/service_models.md
+++ b/docs/sdk/models/objects/service_models.md
@@ -133,10 +133,10 @@ except ValueError as e:
 ### Creating a TCP Service
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/syslog_server_profiles_models.md
+++ b/docs/sdk/models/objects/syslog_server_profiles_models.md
@@ -117,10 +117,10 @@ The `SyslogServerProfileResponseModel` extends the base model and includes the I
 ### Creating a Basic Syslog Server Profile with UDP Transport
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/objects/tag_models.md
+++ b/docs/sdk/models/objects/tag_models.md
@@ -152,10 +152,10 @@ except ValueError as e:
 ### Creating a Basic Tag
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/operations/candidate_push.md
+++ b/docs/sdk/models/operations/candidate_push.md
@@ -155,11 +155,11 @@ except ValueError as e:
 ### Creating a Commit Request
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.operations import CandidatePushModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -192,11 +192,11 @@ print(f"Commit job started with ID: {response.job_id}")
 ### Handling the Response
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.operations import CandidatePushResponseModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -226,11 +226,11 @@ else:
 ### Commit with Unified Client
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 import time
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/operations/index.md
+++ b/docs/sdk/models/operations/index.md
@@ -30,11 +30,11 @@ Operations models share common patterns:
 ### Creating a Commit Request
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.operations import CandidatePushModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/operations/jobs.md
+++ b/docs/sdk/models/operations/jobs.md
@@ -255,10 +255,10 @@ print(f"Showing {len(response.data)} of {response.total} jobs")
 ### Using Jobs with Unified Client
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"
@@ -294,11 +294,11 @@ print(f"Found {parent_jobs.total} top-level jobs")
 ### Monitoring Long-Running Jobs
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 import time
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/anti_spyware_profile_models.md
+++ b/docs/sdk/models/security_services/anti_spyware_profile_models.md
@@ -302,10 +302,10 @@ rule = AntiSpywareRuleBaseModel(
 ### Creating a Basic Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -332,10 +332,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Multiple Rules
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -382,10 +382,10 @@ print(f"Created profile with {len(response.rules)} rules")
 ### Creating a Profile with Threat Exceptions
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -430,10 +430,10 @@ print(f"Created profile with {len(response.threat_exception)} exceptions")
 ### Updating a Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/app_override_rule_models.md
+++ b/docs/sdk/models/security_services/app_override_rule_models.md
@@ -223,10 +223,10 @@ except ValueError as e:
 ### Creating a Basic App Override Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -253,10 +253,10 @@ print(f"Created rule: {response.name}")
 ### Creating a Rule with Multiple Ports and Tags
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -285,10 +285,10 @@ print(f"Port: {response.port}")
 ### Creating a UDP Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -315,10 +315,10 @@ print(f"Created UDP rule: {response.name}")
 ### Updating an App Override Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -342,10 +342,10 @@ print(f"Updated rule: {updated.name}")
 ### Moving an App Override Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/authentication_rule_models.md
+++ b/docs/sdk/models/security_services/authentication_rule_models.md
@@ -237,10 +237,10 @@ except ValueError as e:
 ### Creating a Basic Authentication Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -267,10 +267,10 @@ print(f"Created rule: {response.name}")
 ### Creating a Rule with Timeout and HIP Profiles
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -301,10 +301,10 @@ print(f"Created rule with HIP profiles: {response.name}")
 ### Updating an Authentication Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -329,10 +329,10 @@ print(f"Updated rule: {updated.name}")
 ### Moving an Authentication Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/decryption_profile_models.md
+++ b/docs/sdk/models/security_services/decryption_profile_models.md
@@ -201,10 +201,10 @@ except ValueError as e:
 ### Creating a Basic Decryption Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -229,10 +229,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Forward Proxy Settings
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -261,10 +261,10 @@ print(f"Created forward proxy profile: {response.name}")
 ### Updating a Decryption Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/decryption_rule_models.md
+++ b/docs/sdk/models/security_services/decryption_rule_models.md
@@ -266,10 +266,10 @@ except ValueError as e:
 ### Creating a Basic Decryption Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -297,10 +297,10 @@ print(f"Created rule: {response.name}")
 ### Creating a Rule with SSL Forward Proxy
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -331,10 +331,10 @@ print(f"Created rule with SSL forward proxy: {response.name}")
 ### Creating a Rule with SSL Inbound Inspection
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -363,10 +363,10 @@ print(f"Created rule with SSL inbound inspection: {response.name}")
 ### Updating a Decryption Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -394,10 +394,10 @@ print(f"Updated rule: {updated.name}")
 ### Moving a Decryption Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/dns_security_profile_models.md
+++ b/docs/sdk/models/security_services/dns_security_profile_models.md
@@ -218,10 +218,10 @@ action = ListActionRequestModel(root={"block": {}})
 ### Creating a DNS Security Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -264,10 +264,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Multiple Categories
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -315,10 +315,10 @@ print(f"Created profile with {len(response.botnet_domains.dns_security_categorie
 ### Updating a DNS Security Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/file_blocking_profile_models.md
+++ b/docs/sdk/models/security_services/file_blocking_profile_models.md
@@ -151,10 +151,10 @@ except ValueError as e:
 ### Creating a Basic Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -181,10 +181,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Multiple Rules
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -227,10 +227,10 @@ print(f"Created profile with {len(response.rules)} rules")
 ### Updating a Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/index.md
+++ b/docs/sdk/models/security_services/index.md
@@ -31,11 +31,11 @@ Security service models share common patterns:
 ### Creating a Security Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.security import SecurityRuleCreateModel
 
 # Initialize client
-client = ScmClient(
+client = Scm(
    client_id="your_client_id",
    client_secret="your_client_secret",
    tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/security_rule_models.md
+++ b/docs/sdk/models/security_services/security_rule_models.md
@@ -231,10 +231,10 @@ except ValueError as e:
 ### Creating a Basic Security Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -262,10 +262,10 @@ print(f"Created rule: {response.name}")
 ### Creating a Rule with Security Profiles
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -296,10 +296,10 @@ print(f"Created rule with profile: {response.name}")
 ### Updating a Security Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -327,10 +327,10 @@ print(f"Updated rule: {updated.name}")
 ### Moving a Security Rule
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/url_access_profile_models.md
+++ b/docs/sdk/models/security_services/url_access_profile_models.md
@@ -172,10 +172,10 @@ profile = URLAccessProfileCreateModel(
 ### Creating a Basic Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -198,10 +198,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Credential Enforcement
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -233,10 +233,10 @@ print(f"Created profile with credential enforcement: {response.name}")
 ### Creating a Profile with Logging and Inline Categorization
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -268,10 +268,10 @@ print(f"Safe search enforcement: {response.safe_search_enforcement}")
 ### Updating a Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/url_categories_models.md
+++ b/docs/sdk/models/security_services/url_categories_models.md
@@ -110,10 +110,10 @@ except ValueError as e:
 ### Creating a URL List Category
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -135,10 +135,10 @@ print(f"Created category: {response.name}")
 ### Creating a Category Match Category
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -160,10 +160,10 @@ print(f"Created category match: {response.name}")
 ### Updating a URL Category
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/vulnerability_protection_profile_models.md
+++ b/docs/sdk/models/security_services/vulnerability_protection_profile_models.md
@@ -251,10 +251,10 @@ except ValueError as e:
 ### Creating a Basic Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -281,10 +281,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Threat Exceptions
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -325,10 +325,10 @@ print(f"Created profile with {len(response.rules)} rules")
 ### Updating a Vulnerability Protection Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/security_services/wildfire_antivirus_profile_models.md
+++ b/docs/sdk/models/security_services/wildfire_antivirus_profile_models.md
@@ -162,10 +162,10 @@ except ValueError as e:
 ### Creating a Basic Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -193,10 +193,10 @@ print(f"Created profile: {response.name}")
 ### Creating a Profile with Exceptions
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -233,10 +233,10 @@ print(f"Created profile with exceptions: {response.name}")
 ### Updating a Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/setup/device_models.md
+++ b/docs/sdk/models/setup/device_models.md
@@ -127,10 +127,10 @@ The Device models can raise the following exceptions during validation:
 ### Listing Devices
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -149,10 +149,10 @@ for device in devices:
 ### Getting a Device by ID
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -168,10 +168,10 @@ print(f"HA State: {device.ha_state}")
 ### Fetching a Device by Name
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -196,10 +196,10 @@ else:
 ### Filtering Devices
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/setup/folder_models.md
+++ b/docs/sdk/models/setup/folder_models.md
@@ -90,10 +90,10 @@ child_folder = FolderResponseModel(
 ### Creating a Folder
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -114,10 +114,10 @@ print(f"Created folder: {response.name} with ID: {response.id}")
 ### Creating a Child Folder
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -138,10 +138,10 @@ print(f"Created child folder: {response.name}")
 ### Updating a Folder
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -162,10 +162,10 @@ print(f"Updated folder: {updated.name}")
 ### Listing Folders
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -189,10 +189,10 @@ labeled_folders = client.folder.list(labels=["engineering"])
 ### Fetching a Folder by Name
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/setup/label_models.md
+++ b/docs/sdk/models/setup/label_models.md
@@ -65,10 +65,10 @@ The Label models include validators to ensure data integrity:
 ### Creating a Label
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -87,10 +87,10 @@ print(f"Created label: {response.name} with ID: {response.id}")
 ### Updating a Label
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -110,10 +110,10 @@ print(f"Updated label: {updated.name}")
 ### Listing Labels
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -131,10 +131,10 @@ for label in all_labels:
 ### Fetching a Label by Name
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/setup/snippet_models.md
+++ b/docs/sdk/models/setup/snippet_models.md
@@ -94,10 +94,10 @@ except ValueError as e:
 ### Creating a Snippet
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -118,10 +118,10 @@ print(f"Created snippet: {response.name} with ID: {response.id}")
 ### Updating a Snippet
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -142,10 +142,10 @@ print(f"Updated snippet: {updated.name}")
 ### Listing Snippets
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -169,10 +169,10 @@ custom_snippets = client.snippet.list(types=["custom"])
 ### Fetching a Snippet by Name
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/docs/sdk/models/setup/variable_models.md
+++ b/docs/sdk/models/setup/variable_models.md
@@ -149,10 +149,10 @@ except ValueError as e:
 ### Creating a Variable
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -174,10 +174,10 @@ print(f"Created variable: {response.name} with ID: {response.id}")
 ### Updating a Variable
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -198,10 +198,10 @@ print(f"Updated variable: {updated.name}")
 ### Listing Variables
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"
@@ -225,10 +225,10 @@ labeled_variables = client.variable.list(labels=["network"])
 ### Fetching a Variable by Name
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Initialize client
-client = ScmClient(
+client = Scm(
     client_id="your_client_id",
     client_secret="your_client_secret",
     tsg_id="your_tsg_id"

--- a/examples/bandwidth_allocations_example.py
+++ b/examples/bandwidth_allocations_example.py
@@ -12,7 +12,7 @@ import argparse
 
 from dotenv import load_dotenv
 
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.models.deployment import (
     BandwidthAllocationCreateModel,
     BandwidthAllocationUpdateModel,
@@ -33,7 +33,7 @@ def setup_logging(level: str = "INFO") -> None:
     )
 
 
-def setup_client() -> ScmClient:
+def setup_client() -> Scm:
     """Set up the SCM client using environment variables."""
     # Load environment variables from .env file
     load_dotenv()
@@ -49,7 +49,7 @@ def setup_client() -> ScmClient:
         )
 
     # Initialize the client
-    return ScmClient(
+    return Scm(
         client_id=client_id,
         client_secret=client_secret,
         tsg_id=tsg_id,
@@ -57,7 +57,7 @@ def setup_client() -> ScmClient:
     )
 
 
-def create_bandwidth_allocation(client: ScmClient, args: argparse.Namespace) -> None:
+def create_bandwidth_allocation(client: Scm, args: argparse.Namespace) -> None:
     """Create a new bandwidth allocation."""
     # Prepare QoS settings if enabled
     qos = None
@@ -96,7 +96,7 @@ def create_bandwidth_allocation(client: ScmClient, args: argparse.Namespace) -> 
         sys.exit(1)
 
 
-def list_bandwidth_allocations(client: ScmClient, args: argparse.Namespace) -> None:
+def list_bandwidth_allocations(client: Scm, args: argparse.Namespace) -> None:
     """List bandwidth allocations with optional filtering."""
     filters = {}
 
@@ -124,7 +124,7 @@ def list_bandwidth_allocations(client: ScmClient, args: argparse.Namespace) -> N
         sys.exit(1)
 
 
-def update_bandwidth_allocation(client: ScmClient, args: argparse.Namespace) -> None:
+def update_bandwidth_allocation(client: Scm, args: argparse.Namespace) -> None:
     """Update an existing bandwidth allocation."""
     # Get current allocation
     try:
@@ -192,7 +192,7 @@ def update_bandwidth_allocation(client: ScmClient, args: argparse.Namespace) -> 
         sys.exit(1)
 
 
-def delete_bandwidth_allocation(client: ScmClient, args: argparse.Namespace) -> None:
+def delete_bandwidth_allocation(client: Scm, args: argparse.Namespace) -> None:
     """Delete a bandwidth allocation."""
     try:
         # Get current allocation to verify it exists

--- a/examples/scm/config/network/README_IKE_CRYPTO_PROFILES.md
+++ b/examples/scm/config/network/README_IKE_CRYPTO_PROFILES.md
@@ -78,10 +78,10 @@ Specify one of the following:
 ### Creating an IKE Crypto Profile
 
 ```python
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.config.network import IKECryptoProfile
 
-client = ScmClient(
+client = Scm(
     client_id="your-client-id",
     client_secret="your-client-secret",
     tsg_id="your-tsg-id"

--- a/examples/scm/config/network/ike_crypto_profile.py
+++ b/examples/scm/config/network/ike_crypto_profile.py
@@ -54,7 +54,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.config.network import IKECryptoProfile
 from scm.models.network import (
     HashAlgorithm,
@@ -161,7 +161,7 @@ def initialize_client():
     3. Initialize the SCM client with appropriate credentials
 
     Returns:
-        ScmClient: An authenticated SCM client instance ready for API calls
+        Scm: An authenticated SCM client instance ready for API calls
 
     Raises:
         AuthenticationError: If authentication fails due to invalid credentials
@@ -218,7 +218,7 @@ def initialize_client():
     log_operation_start("Creating SCM client")
 
     # Create the client
-    client = ScmClient(
+    client = Scm(
         client_id=client_id,
         client_secret=client_secret,
         tsg_id=tsg_id,

--- a/examples/scm/unified_client_token_url_example.py
+++ b/examples/scm/unified_client_token_url_example.py
@@ -1,9 +1,9 @@
-"""Example showing how to initialize the ScmClient with a custom token URL."""
+"""Example showing how to initialize the Scm with a custom token URL."""
 
-from scm.client import ScmClient
+from scm.client import Scm
 
 # Create client with custom token URL
-client = ScmClient(
+client = Scm(
     client_id="your-client-id",
     client_secret="your-client-secret",
     tsg_id="your-tsg-id",

--- a/examples/test_move_security_rule.py
+++ b/examples/test_move_security_rule.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # SDK imports
-from scm.client import ScmClient
+from scm.client import Scm
 from scm.exceptions import (
     APIError,
     AuthenticationError,
@@ -61,7 +61,7 @@ def initialize_client(client_id, client_secret, tsg_id, log_level):
     """Initialize the SCM client."""
     print("Initializing SCM client...")
     try:
-        client = ScmClient(
+        client = Scm(
             client_id=client_id,
             client_secret=client_secret,
             tsg_id=tsg_id,


### PR DESCRIPTION
## Summary
- Replace all `ScmClient` references with `Scm` across README.md, docs/, and examples/
- `ScmClient` is a deprecated backwards-compat alias (client.py:817); `Scm` is the primary class (client.py:38)
- 173 files updated (167 docs + 4 examples + README + 1 example README)

Closes #343