### PR TITLE
fix: correct AddressUpdateModel UUID type hint and ResponseModel docstring

### DIFF
--- a/scm/models/objects/address.py
+++ b/scm/models/objects/address.py
@@ -224,15 +224,15 @@ class AddressUpdateModel(AddressBaseModel):
     This class defines the structure and validation rules for an AddressUpdateModel object.
     """
 
-    id: Optional[UUID] = Field(
-        ...,  # This makes it optional
+    id: UUID = Field(
+        ...,
         description="The UUID of the address object",
         examples=["123e4567-e89b-12d3-a456-426655440000"],
     )
 
 
 class AddressResponseModel(AddressBaseModel):
-    """Represents the creation of a new Address object for Palo Alto Networks' Strata Cloud Manager.
+    """Represents the response representation of an Address object for Palo Alto Networks' Strata Cloud Manager.
 
     This class defines the structure and validation rules for an AddressResponseModel object,
     it inherits all fields from the AddressBaseModel class, adds its own attribute for the

--- a/tests/scm/models/objects/test_address_models.py
+++ b/tests/scm/models/objects/test_address_models.py
@@ -168,6 +168,22 @@ class TestAddressUpdateModel:
         error_msg = str(exc_info.value)
         assert "1 validation error for AddressUpdateModel\nid\n  Field required" in error_msg
 
+    def test_address_update_model_rejects_none_id(self):
+        """Test that AddressUpdateModel rejects id=None."""
+        data = AddressUpdateModelFactory.build_valid()
+        data["id"] = None
+        with pytest.raises(ValidationError) as exc_info:
+            AddressUpdateModel(**data)
+        assert "id" in str(exc_info.value)
+
+    def test_address_update_model_requires_id(self):
+        """Test that AddressUpdateModel requires id field (not optional)."""
+        data = AddressUpdateModelFactory.build_valid()
+        del data["id"]
+        with pytest.raises(ValidationError) as exc_info:
+            AddressUpdateModel(**data)
+        assert "id\n  Field required" in str(exc_info.value)
+
     def test_address_update_model_valid(self):
         """Test validation with valid data in update model."""
         data = AddressUpdateModelFactory.build_valid()


### PR DESCRIPTION
## Summary
- Remove `Optional` wrapper from `AddressUpdateModel.id` field — `UUID` is required, not optional. The `...` sentinel already makes it required but `Optional[UUID]` allowed `None` values through
- Remove misleading `# This makes it optional` comment
- Fix `AddressResponseModel` docstring: "creation of a new" -> "response representation of an"
- Add two new tests: reject `id=None` and require `id` field

Closes #344