### PR TITLE
feat: add Operations and Incidents API support

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,25 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.13.0
+
+**Released:** April 2026
+
+### Added
+
+- **Operations API Support**: New `ServiceBase` class for non-CRUD services, enabling device operations and configuration management
+    - **LocalConfig Service** (`client.local_config`): List device configuration versions and download configuration files as XML
+    - **DeviceOperations Service** (`client.device_operations`): Dispatch and monitor asynchronous device jobs for route tables, FIB tables, DNS proxy, network interfaces, device rules, BGP policy export, and logging service status. Supports both async (fire-and-forget) and sync (poll-to-completion) modes
+- **Incidents API Support**: Unified Incident Framework integration for security incident management
+    - **Incidents Service** (`client.incidents`): Search incidents with filtering by status, severity, and product. Retrieve detailed incident information including alerts and remediation steps
+- **Client Enhancements**:
+    - `region` parameter on `Scm` client for APIs requiring `X-PANW-Region` header (default: `"americas"`)
+    - `raw_response` support in `Scm.request()` for binary file downloads
+- **JobTimeoutError Exception**: Raised when synchronous job polling exceeds timeout, includes `job_id` and `last_state` for manual recovery
+- Pydantic models for all new services (local config versions, device job dispatch/status, incident search/detail/alerts)
+- 63 new tests across 7 test files
+- Comprehensive MkDocs documentation for all new services and models
+
 ## Version 0.6.0
 
 **Released:** February 17, 2026

--- a/docs/sdk/client.md
+++ b/docs/sdk/client.md
@@ -39,7 +39,7 @@ class Scm:
 | `session`      | requests.Session | HTTP session for making requests                        |
 | `logger`       | Logger           | Logger instance for SDK logging                         |
 | `verify_ssl`   | bool             | Whether TLS certificate verification is enabled (default: True) |
-| `region`       | str              | Default region for APIs requiring X-PANW-Region header (default: "americas") |
+| `default_region` | str            | Default region for APIs requiring X-PANW-Region header (default: "americas") |
 
 ## Authentication Methods
 

--- a/docs/sdk/client.md
+++ b/docs/sdk/client.md
@@ -24,7 +24,8 @@ class Scm:
             token_url: str = "https://auth.apps.paloaltonetworks.com/am/oauth2/access_token",
             log_level: str = "ERROR",
             access_token: Optional[str] = None,
-            verify_ssl: bool = True
+            verify_ssl: bool = True,
+            region: str = "americas"
     )
 ```
 
@@ -38,6 +39,7 @@ class Scm:
 | `session`      | requests.Session | HTTP session for making requests                        |
 | `logger`       | Logger           | Logger instance for SDK logging                         |
 | `verify_ssl`   | bool             | Whether TLS certificate verification is enabled (default: True) |
+| `region`       | str              | Default region for APIs requiring X-PANW-Region header (default: "americas") |
 
 ## Authentication Methods
 
@@ -226,6 +228,15 @@ The unified client provides access to all service objects in the SDK through att
 
 - `client.agent_version` - GlobalProtect agent version information
 - `client.auth_setting` - Authentication settings for mobile agents
+
+**Operations**
+
+- `client.local_config` - Device configuration version history and file downloads
+- `client.device_operations` - Asynchronous device operation job dispatch and monitoring
+
+**Incidents**
+
+- `client.incidents` - Unified incident search and detail retrieval
 
 **Setup**
 

--- a/docs/sdk/exceptions.md
+++ b/docs/sdk/exceptions.md
@@ -132,6 +132,31 @@ All inherit from `GatewayTimeoutError`:
 
 - `SessionTimeoutError`: Session timeout (Code '4')
 
+#### JobTimeoutError
+
+Raised when a device operations job does not complete within the timeout period during synchronous polling.
+
+**Attributes:**
+
+- `job_id`: The ID of the timed-out job
+- `last_state`: The last known state of the job
+- `timeout`: The timeout value in seconds that was exceeded
+
+```python
+from scm.exceptions import JobTimeoutError
+
+try:
+    result = client.device_operations.route_table(
+        devices=["007951000123456"],
+        sync=True,
+        timeout=60
+    )
+except JobTimeoutError as e:
+    print(f"Job {e.job_id} timed out after {e.timeout}s (state: {e.last_state})")
+    # Resume polling manually
+    status = client.device_operations.get_job_status(e.job_id)
+```
+
 ## Error Handler
 
 The `ErrorHandler` class provides centralized error handling functionality for the API.

--- a/docs/sdk/incidents/incidents.md
+++ b/docs/sdk/incidents/incidents.md
@@ -1,0 +1,197 @@
+# Incidents
+
+Search and retrieve security incident details from the Unified Incident Framework in Strata Cloud Manager.
+
+## Class Overview
+
+The `Incidents` class inherits from `ServiceBase` and provides methods for searching incidents with filtering and pagination, and retrieving detailed incident information including alerts and remediation steps.
+
+!!! note
+    The Incidents API requires the `X-PANW-Region` header. The SDK sets this automatically from the `region` parameter passed to the `Scm` client (default: `"americas"`).
+
+### Methods
+
+| Method | Description | Parameters | Return Type |
+| --- | --- | --- | --- |
+| `search()` | Search incidents with filters | `status`, `severity`, `product`, `filter_rules`, `page_size`, `page_number`, `order_by` | `IncidentSearchResponseModel` |
+| `get_details()` | Get full incident details | `incident_id` | `IncidentDetailModel` |
+
+### Exceptions
+
+| Exception | HTTP Code | Description |
+| --- | --- | --- |
+| `AuthenticationError` | 401 | Authentication failed |
+| `ObjectNotPresentError` | 404 | Incident not found |
+| `ServerError` | 500 | Internal server error |
+
+### Basic Configuration
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id",
+    region="americas"  # Sets X-PANW-Region header
+)
+```
+
+## Methods
+
+### Search Incidents
+
+Search for incidents using convenience filters or raw filter rules.
+
+```python
+# Search all incidents (default pagination: 50 per page)
+result = client.incidents.search()
+print(f"Found {len(result.data)} incidents")
+
+# Filter by status
+result = client.incidents.search(status=["Raised"])
+
+# Filter by severity and product
+result = client.incidents.search(
+    severity=["Critical", "High"],
+    product=["Prisma Access", "NGFW"]
+)
+
+# Custom pagination
+result = client.incidents.search(
+    page_size=25,
+    page_number=2,
+    order_by=[{"property": "updated_time", "order": "desc"}]
+)
+```
+
+**Using raw filter rules for full control:**
+
+```python
+# Raw filter rules bypass convenience kwargs
+result = client.incidents.search(
+    filter_rules=[
+        {"property": "release_state", "operator": "in", "values": ["Released"]},
+        {"property": "status", "operator": "in", "values": ["Raised"]},
+        {"property": "product", "operator": "in", "values": ["NGFW"]},
+    ]
+)
+```
+
+### Get Incident Details
+
+Retrieve comprehensive information about a specific incident, including alerts and remediation steps.
+
+```python
+# Get detailed incident information
+detail = client.incidents.get_details("21818c4a-8353-4d9c-ae3e-ae90004d4662")
+
+print(f"Title: {detail.title}")
+print(f"Severity: {detail.severity}")
+print(f"Status: {detail.status}")
+print(f"Description: {detail.description}")
+
+# Access associated alerts
+if detail.alerts:
+    for alert in detail.alerts:
+        print(f"  Alert: {alert.title} ({alert.severity})")
+```
+
+## Use Cases
+
+### Monitor Critical Incidents
+
+```python
+# Find all critical raised incidents
+result = client.incidents.search(
+    status=["Raised"],
+    severity=["Critical"],
+    order_by=[{"property": "updated_time", "order": "desc"}]
+)
+
+for incident in result.data:
+    print(f"[{incident.severity}] {incident.title}")
+    print(f"  Product: {incident.product}")
+    print(f"  ID: {incident.incident_id}")
+    print()
+```
+
+### Paginate Through All Incidents
+
+```python
+page = 1
+all_incidents = []
+
+while True:
+    result = client.incidents.search(
+        status=["Raised"],
+        page_size=50,
+        page_number=page
+    )
+    all_incidents.extend(result.data)
+
+    if len(result.data) < 50:
+        break
+    page += 1
+
+print(f"Total incidents: {len(all_incidents)}")
+```
+
+### Incident Detail Drill-Down
+
+```python
+# Search for incidents, then get details on each
+result = client.incidents.search(
+    severity=["Critical"],
+    page_size=5
+)
+
+for incident in result.data:
+    detail = client.incidents.get_details(incident.incident_id)
+    print(f"\n{'='*60}")
+    print(f"Title: {detail.title}")
+    print(f"Product: {detail.product}")
+    print(f"Category: {detail.category}")
+
+    if detail.description:
+        print(f"Description: {detail.description}")
+
+    if detail.remediations:
+        print(f"Remediations: {detail.remediations}")
+
+    if detail.alerts:
+        print(f"Alerts ({len(detail.alerts)}):")
+        for alert in detail.alerts:
+            print(f"  - {alert.title} [{alert.severity}]")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import (
+    AuthenticationError,
+    ObjectNotPresentError,
+    ServerError,
+)
+
+try:
+    result = client.incidents.search(
+        severity=["Critical"],
+        status=["Raised"]
+    )
+except AuthenticationError:
+    print("Authentication failed. Check your credentials.")
+except ServerError as e:
+    print(f"Server error: {e.message}")
+
+try:
+    detail = client.incidents.get_details("nonexistent-id")
+except ObjectNotPresentError:
+    print("Incident not found.")
+```
+
+## Related Topics
+
+- [Incidents Models](../../models/incidents/index.md)
+- [Client Module](../../client.md)
+- [Exceptions](../../exceptions.md)

--- a/docs/sdk/incidents/index.md
+++ b/docs/sdk/incidents/index.md
@@ -1,0 +1,19 @@
+# Incidents
+
+Access the Unified Incident Framework API for searching and analyzing security incidents across Strata Cloud Manager.
+
+## Overview
+
+The Incidents section provides programmatic access to security and operational incidents consolidated from multiple Palo Alto Networks products. These read-only APIs allow you to search, filter, and analyze incident data across the Strata Cloud Manager ecosystem.
+
+## Available Modules
+
+| Module | Description |
+| --- | --- |
+| [Incidents](incidents.md) | Search incidents and retrieve detailed incident information |
+
+## Related Documentation
+
+- [Incidents Models](../models/incidents/index.md)
+- [API Client](../client.md)
+- [Exceptions](../exceptions.md)

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -35,6 +35,8 @@ client.address.delete(address_id)
 - **[Security Services](config/security_services/index.md)** - Security profiles and rules
 - **[Setup](config/setup/index.md)** - Organizational containers (folders, snippets, devices)
 - **[Insights](insights/index.md)** - Prisma Access Insights alerts
+- **[Operations](operations/index.md)** - Device operations, configuration versions, and async job dispatch
+- **[Incidents](incidents/index.md)** - Unified incident search and analysis
 
 ## Related Documentation
 

--- a/docs/sdk/models/incidents/incidents_models.md
+++ b/docs/sdk/models/incidents/incidents_models.md
@@ -1,0 +1,162 @@
+# Incidents Models
+
+Pydantic models for incident search, filtering, pagination, and detail retrieval in Strata Cloud Manager.
+
+## Overview
+
+The Incidents models provide data validation for:
+
+- Building search queries with filter rules and pagination
+- Parsing incident search responses with metadata
+- Representing individual incidents with severity, status, and impacted objects
+- Detailed incident information with alerts and remediation steps
+
+## Request Models
+
+### FilterRuleModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `property` | `str` | Yes | The property to filter on |
+| `operator` | `str` | Yes | The filter operator (e.g., `in`, `equals`) |
+| `values` | `List[Any]` | Yes | The values to filter by |
+
+### PaginationModel
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `page_size` | `int` | No | `50` | Number of results per page |
+| `page_number` | `int` | No | `1` | Page number to retrieve |
+| `order_by` | `Optional[List[Dict]]` | No | `None` | Ordering specification |
+
+### IncidentSearchRequestModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filter` | `Optional[FilterObjectModel]` | No | Filter rules container |
+| `pagination` | `Optional[PaginationModel]` | No | Pagination parameters |
+
+## Response Models
+
+### IncidentSearchResponseModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `header` | `IncidentSearchResponseHeaderModel` | Yes | Response metadata (pagination, counts) |
+| `data` | `List[IncidentModel]` | No | List of matching incidents |
+
+### IncidentModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `incident_id` | `str` | Yes | Unique incident identifier |
+| `title` | `str` | Yes | Incident title |
+| `severity` | `str` | Yes | Severity level (Critical, High, etc.) |
+| `severity_id` | `Optional[int]` | No | Numeric severity identifier |
+| `status` | `str` | Yes | Incident status (Raised, Cleared) |
+| `priority` | `Optional[str]` | No | Priority level |
+| `product` | `str` | Yes | Product (NGFW, Prisma Access, etc.) |
+| `category` | `Optional[str]` | No | Incident category |
+| `sub_category` | `Optional[str]` | No | Incident sub-category |
+| `code` | `Optional[str]` | No | Incident code identifier |
+| `raised_time` | `Optional[int]` | No | Epoch timestamp when raised |
+| `updated_time` | `Optional[int]` | No | Epoch timestamp of last update |
+| `cleared_time` | `Optional[int]` | No | Epoch timestamp when cleared |
+| `incident_type` | `Optional[str]` | No | Type classification |
+| `acknowledged` | `Optional[bool]` | No | Whether incident is acknowledged |
+| `primary_impacted_objects` | `Optional[ImpactedObjectsModel]` | No | Primary impacted resources |
+| `related_impacted_objects` | `Optional[ImpactedObjectsModel]` | No | Related impacted resources |
+| `snow_ticket_id` | `Optional[str]` | No | ServiceNow ticket ID |
+
+### IncidentDetailModel
+
+Extends `IncidentModel` with additional fields:
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `description` | `Optional[str]` | No | Detailed incident description |
+| `remediations` | `Optional[str]` | No | JSON string with remediation steps |
+| `detail` | `Optional[str]` | No | JSON string with detailed alert info |
+| `alerts` | `Optional[List[AlertModel]]` | No | Associated alerts |
+| `resource_keys` | `Optional[str]` | No | JSON string with resource identifiers |
+| `resource_context` | `Optional[str]` | No | JSON string with contextual info |
+| `incident_code` | `Optional[str]` | No | Incident code |
+| `incident_settings_id` | `Optional[str]` | No | Incident settings identifier |
+
+## Component Models
+
+### AlertModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `alert_id` | `str` | Yes | Unique alert identifier |
+| `severity` | `Optional[str]` | No | Alert severity |
+| `state` | `Optional[str]` | No | Alert state |
+| `title` | `Optional[str]` | No | Alert title |
+| `updated_time` | `Optional[int]` | No | Last update timestamp |
+| `domain` | `Optional[str]` | No | Alert domain |
+| `code` | `Optional[str]` | No | Alert code |
+
+### ImpactedObjectsModel
+
+All fields are `Optional[List[str]]` and default to `None`. Key fields include:
+
+| Field | Description |
+| --- | --- |
+| `device_ids` | Impacted device identifiers |
+| `host_names` | Impacted host names |
+| `interfaces` | Impacted network interfaces |
+| `locations` | Impacted locations |
+| `zones` | Impacted security zones |
+| `site_names` | Impacted site names |
+| `tunnel_names` | Impacted tunnel names |
+| `certificate_names` | Impacted certificates |
+| `cves` | Related CVE identifiers |
+
+## Usage Examples
+
+### Creating a Search Request
+
+```python
+from scm.models.incidents.incidents import (
+    FilterRuleModel,
+    PaginationModel,
+    IncidentSearchRequestModel,
+)
+
+# Build a search request
+request = IncidentSearchRequestModel(
+    filter={"rules": [
+        {"property": "status", "operator": "in", "values": ["Raised"]},
+        {"property": "severity", "operator": "in", "values": ["Critical"]},
+    ]},
+    pagination={"page_size": 25, "page_number": 1}
+)
+```
+
+### Parsing a Search Response
+
+```python
+from scm.models.incidents.incidents import IncidentSearchResponseModel
+
+response = IncidentSearchResponseModel(**api_response)
+for incident in response.data:
+    print(f"{incident.severity}: {incident.title} ({incident.status})")
+```
+
+### Working with Incident Details
+
+```python
+from scm.models.incidents.incidents import IncidentDetailModel
+
+detail = IncidentDetailModel(**api_response)
+print(f"Title: {detail.title}")
+if detail.alerts:
+    for alert in detail.alerts:
+        print(f"  Alert: {alert.title}")
+```
+
+## Related Documentation
+
+- [Incidents Service](../../incidents/incidents.md)
+- [API Client](../../client.md)

--- a/docs/sdk/models/incidents/index.md
+++ b/docs/sdk/models/incidents/index.md
@@ -1,0 +1,24 @@
+# Incidents Data Models
+
+Pydantic models for validating and serializing incident-related data in the Strata Cloud Manager SDK.
+
+## Overview
+
+The Incidents models define the data structures for the Unified Incident Framework API. These models handle incident search requests, responses with pagination metadata, and detailed incident information including associated alerts and impacted objects.
+
+## Model Types
+
+- **Request Models**: Used when building search queries with filters and pagination
+- **Response Models**: Used when parsing search results and incident details from the API
+- **Component Models**: Supporting models for filters, alerts, and impacted objects
+
+## Models by Category
+
+### Search
+
+- [Incidents Models](incidents_models.md) - Search, filter, pagination, incident, and alert models
+
+## Related Documentation
+
+- [Incidents Service](../../incidents/incidents.md)
+- [API Client](../../client.md)

--- a/docs/sdk/models/operations/device_operations_models.md
+++ b/docs/sdk/models/operations/device_operations_models.md
@@ -1,0 +1,108 @@
+# Device Operations Models
+
+Pydantic models for device operation job dispatch and status tracking in Strata Cloud Manager.
+
+## Overview
+
+The Device Operations models handle validation and serialization for asynchronous device jobs. These models cover:
+
+- Device serial number validation for job dispatch
+- Job creation responses with job identifiers
+- Job status tracking with progress and state information
+- Per-device results with command execution details
+
+## Request Models
+
+### DeviceOperationsRequestModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `devices` | `List[str]` | Yes | 1-5 device serial numbers (14-15 digits each) |
+
+**Validation Rules:**
+
+- Minimum 1 device, maximum 5 devices
+- Each serial number must match pattern `^\d{14,15}$`
+
+## Response Models
+
+### JobCreatedModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `job_id` | `str` | Yes | Unique identifier for the created job |
+
+### DeviceJobStatusModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `jobId` | `str` | Yes | Unique identifier for the job |
+| `progress` | `int` | Yes | Job completion percentage (0-100) |
+| `state` | `str` | Yes | Current state: `pending`, `in_progress`, `complete`, `failed` |
+| `request` | `DeviceJobRequestModel` | Yes | Original request details |
+| `results` | `List[DeviceJobResultModel]` | No | Results from each device |
+
+### DeviceJobResultModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `device` | `str` | Yes | Device serial number |
+| `state` | `str` | Yes | Job state for this device |
+| `created_ts` | `str` | Yes | Job creation timestamp |
+| `updated_ts` | `str` | Yes | Last update timestamp |
+| `details` | `DeviceJobDetailsModel` | Yes | Command execution results |
+
+### DeviceJobDetailsModel
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `msg` | `str` | Yes | - | Status message from command execution |
+| `result` | `Dict[str, Any]` | No | `{}` | Result data (structure varies by command type) |
+
+### DeviceJobRequestModel
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `command` | `str` | Yes | The command that was executed |
+| `devices` | `List[str]` | Yes | Device serial numbers |
+
+## Usage Examples
+
+### Validating Device Input
+
+```python
+from scm.models.operations.device_operations import DeviceOperationsRequestModel
+from pydantic import ValidationError
+
+# Valid request
+request = DeviceOperationsRequestModel(
+    devices=["007951000123456", "007951000123457"]
+)
+
+# Invalid - too many devices
+try:
+    request = DeviceOperationsRequestModel(
+        devices=["00795100012345" + str(i) for i in range(6)]
+    )
+except ValidationError as e:
+    print(f"Validation error: {e}")
+```
+
+### Parsing Job Status
+
+```python
+from scm.models.operations.device_operations import DeviceJobStatusModel
+
+status = DeviceJobStatusModel(**api_response)
+print(f"Job: {status.jobId}")
+print(f"Progress: {status.progress}%")
+print(f"State: {status.state}")
+
+for result in status.results:
+    print(f"  Device {result.device}: {result.details.msg}")
+```
+
+## Related Documentation
+
+- [Device Operations Service](../../operations/device_operations.md)
+- [Operations Models Overview](index.md)

--- a/docs/sdk/models/operations/index.md
+++ b/docs/sdk/models/operations/index.md
@@ -77,3 +77,11 @@ for job in job_list.data:
 ### Candidate Push
 
 - [Candidate Push Models](candidate_push.md) - Configuration commit models
+
+### Local Config
+
+- [Local Config Models](local_config_models.md) - Device configuration version models
+
+### Device Operations
+
+- [Device Operations Models](device_operations_models.md) - Device job dispatch and status models

--- a/docs/sdk/models/operations/local_config_models.md
+++ b/docs/sdk/models/operations/local_config_models.md
@@ -1,0 +1,50 @@
+# Local Config Models
+
+Pydantic models for local device configuration version data in Strata Cloud Manager.
+
+## Overview
+
+The Local Config models represent configuration version entries retrieved from devices. These models handle:
+
+- Configuration version metadata (version identifiers, timestamps)
+- Device serial number associations
+- Transformation tracking between original and processed configurations
+
+## Models
+
+### LocalConfigVersionModel
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `id` | `int` | Yes | - | Unique identifier for the configuration version entry |
+| `serial` | `str` | Yes | - | Device serial number (14-15 digits) |
+| `local_version` | `str` | Yes | - | Local configuration version identifier |
+| `timestamp` | `datetime` | Yes | - | When the configuration version was created |
+| `xfmed_version` | `str` | Yes | - | Transformed configuration version identifier |
+| `md5` | `Optional[str]` | No | `None` | MD5 hash of the configuration |
+
+## Usage Examples
+
+### Parsing Version Data
+
+```python
+from scm.models.operations.local_config import LocalConfigVersionModel
+
+# Parse a version entry from API response
+version = LocalConfigVersionModel(
+    id=1,
+    serial="007951000123456",
+    local_version="1.0.0",
+    timestamp="2025-01-15T10:30:00Z",
+    xfmed_version="1.0.0-transformed"
+)
+
+print(f"Version: {version.local_version}")
+print(f"Device: {version.serial}")
+print(f"Timestamp: {version.timestamp}")
+```
+
+## Related Documentation
+
+- [Local Config Service](../../operations/local_config.md)
+- [Operations Models Overview](index.md)

--- a/docs/sdk/operations/device_operations.md
+++ b/docs/sdk/operations/device_operations.md
@@ -1,0 +1,236 @@
+# Device Operations
+
+Dispatch and monitor asynchronous device operation jobs in Strata Cloud Manager.
+
+## Class Overview
+
+The `DeviceOperations` class inherits from `ServiceBase` and provides methods for dispatching asynchronous jobs to retrieve operational data from devices. Each method supports both async (fire-and-forget) and sync (poll-to-completion) modes.
+
+### Methods
+
+| Method | Description | Parameters | Return Type |
+| --- | --- | --- | --- |
+| `route_table()` | Retrieve route table | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `fib_table()` | Retrieve FIB table | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `dns_proxy()` | Retrieve DNS proxy table | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `device_interfaces()` | Retrieve network interfaces | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `device_rules()` | Retrieve rules | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `bgp_policy_export()` | BGP policy export | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `logging_service_status()` | Logging service status | `devices`, `sync`, `poll_interval`, `timeout` | `JobCreatedModel` or `DeviceJobStatusModel` |
+| `get_job_status()` | Poll job status | `job_id` | `DeviceJobStatusModel` |
+
+### Common Parameters
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `devices` | `List[str]` | Yes | - | 1-5 device serial numbers (14-15 digits each) |
+| `sync` | `bool` | No | `False` | If `True`, poll until job completes or times out |
+| `poll_interval` | `int` | No | `10` | Seconds between polls when `sync=True` |
+| `timeout` | `int` | No | `300` | Max seconds to wait when `sync=True` |
+
+### Exceptions
+
+| Exception | HTTP Code | Description |
+| --- | --- | --- |
+| `ValidationError` | - | Invalid device list (empty, >5, or bad serial format) |
+| `JobTimeoutError` | - | Job did not complete within timeout (sync mode) |
+| `AuthenticationError` | 401 | Authentication failed |
+| `ServerError` | 500 | Internal server error |
+
+### Basic Configuration
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+```
+
+## Methods
+
+### Async Mode (Default)
+
+Dispatch a job and receive a job ID immediately for manual polling.
+
+```python
+# Dispatch a route table retrieval job
+job = client.device_operations.route_table(
+    devices=["007951000123456"]
+)
+print(f"Job dispatched: {job.job_id}")
+
+# Poll for results manually
+status = client.device_operations.get_job_status(job.job_id)
+print(f"State: {status.state}, Progress: {status.progress}%")
+```
+
+### Sync Mode
+
+Dispatch a job and wait for it to complete before returning.
+
+```python
+# Dispatch and wait for completion
+result = client.device_operations.route_table(
+    devices=["007951000123456"],
+    sync=True,
+    poll_interval=5,
+    timeout=120
+)
+
+print(f"Job state: {result.state}")
+for device_result in result.results:
+    print(f"Device {device_result.device}: {device_result.details.msg}")
+```
+
+### Retrieve Route Table
+
+```python
+result = client.device_operations.route_table(
+    devices=["007951000123456", "007951000123457"],
+    sync=True
+)
+
+for device_result in result.results:
+    routes = device_result.details.result
+    print(f"Routes for {device_result.device}: {routes}")
+```
+
+### Retrieve FIB Table
+
+```python
+result = client.device_operations.fib_table(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+### Retrieve Network Interfaces
+
+```python
+result = client.device_operations.device_interfaces(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+### Retrieve Device Rules
+
+```python
+result = client.device_operations.device_rules(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+### BGP Policy Export
+
+```python
+result = client.device_operations.bgp_policy_export(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+### Logging Service Status
+
+```python
+result = client.device_operations.logging_service_status(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+### DNS Proxy
+
+```python
+result = client.device_operations.dns_proxy(
+    devices=["007951000123456"],
+    sync=True
+)
+```
+
+## Use Cases
+
+### Multi-Device Route Audit
+
+```python
+devices = [
+    "007951000123456",
+    "007951000123457",
+    "007951000123458",
+]
+
+result = client.device_operations.route_table(
+    devices=devices,
+    sync=True,
+    timeout=120
+)
+
+for device_result in result.results:
+    if device_result.state == "complete":
+        print(f"\nRoutes for {device_result.device}:")
+        for vrf, routes in device_result.details.result.items():
+            print(f"  VRF {vrf}: {len(routes)} routes")
+    else:
+        print(f"Device {device_result.device}: {device_result.state}")
+```
+
+### Async Job Monitoring
+
+```python
+import time
+
+# Dispatch multiple jobs
+jobs = []
+for device in ["007951000123456", "007951000123457"]:
+    job = client.device_operations.route_table(devices=[device])
+    jobs.append(job)
+    print(f"Dispatched job {job.job_id} for {device}")
+
+# Poll all jobs
+for job in jobs:
+    while True:
+        status = client.device_operations.get_job_status(job.job_id)
+        if status.state in ("complete", "failed"):
+            print(f"Job {job.job_id}: {status.state}")
+            break
+        time.sleep(5)
+```
+
+## Error Handling
+
+```python
+from pydantic import ValidationError
+from scm.exceptions import (
+    AuthenticationError,
+    JobTimeoutError,
+    ServerError,
+)
+
+try:
+    result = client.device_operations.route_table(
+        devices=["007951000123456"],
+        sync=True,
+        timeout=60
+    )
+except ValidationError as e:
+    print(f"Invalid device list: {e}")
+except JobTimeoutError as e:
+    print(f"Job {e.job_id} timed out (last state: {e.last_state})")
+    # Can resume polling manually
+    status = client.device_operations.get_job_status(e.job_id)
+except AuthenticationError:
+    print("Authentication failed. Check your credentials.")
+except ServerError as e:
+    print(f"Server error: {e.message}")
+```
+
+## Related Topics
+
+- [Operations Models](../../models/operations/index.md)
+- [Local Config](local_config.md)
+- [Client Module](../../client.md)
+- [Exceptions](../../exceptions.md)

--- a/docs/sdk/operations/index.md
+++ b/docs/sdk/operations/index.md
@@ -1,0 +1,20 @@
+# Operations
+
+Access the Strata Cloud Manager Operations API for device management, configuration retrieval, and troubleshooting.
+
+## Overview
+
+The Operations section provides programmatic access to device operational data through the Palo Alto Networks Strata Cloud Manager SDK. These services support configuration version tracking, binary config downloads, and asynchronous device job dispatch for retrieving routing tables, interfaces, rules, and more.
+
+## Available Modules
+
+| Module | Description |
+| --- | --- |
+| [Local Config](local_config.md) | Retrieve device configuration versions and download config files |
+| [Device Operations](device_operations.md) | Dispatch and monitor asynchronous device operation jobs |
+
+## Related Documentation
+
+- [Operations Models](../models/operations/index.md)
+- [API Client](../client.md)
+- [Exceptions](../exceptions.md)

--- a/docs/sdk/operations/local_config.md
+++ b/docs/sdk/operations/local_config.md
@@ -1,0 +1,137 @@
+# Local Config
+
+Provides access to local device configuration versions and file downloads in Strata Cloud Manager.
+
+## Class Overview
+
+The `LocalConfig` class inherits from `ServiceBase` and provides methods for listing configuration versions and downloading configuration files from devices.
+
+### Methods
+
+| Method | Description | Parameters | Return Type |
+| --- | --- | --- | --- |
+| `list_versions()` | List config versions for a device | `device` | `List[LocalConfigVersionModel]` |
+| `download()` | Download a config file | `device`, `version` | `bytes` |
+
+### Model Attributes
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | `int` | Unique identifier for the configuration version entry |
+| `serial` | `str` | Device serial number (14-15 digits) |
+| `local_version` | `str` | Local configuration version identifier |
+| `timestamp` | `datetime` | When the configuration version was created |
+| `xfmed_version` | `str` | Transformed configuration version identifier |
+| `md5` | `Optional[str]` | MD5 hash of the configuration |
+
+### Exceptions
+
+| Exception | HTTP Code | Description |
+| --- | --- | --- |
+| `InvalidQueryParameterError` | 400 | Invalid query parameters |
+| `MissingQueryParameterError` | 400 | Missing required parameters |
+| `AuthenticationError` | 401 | Authentication failed |
+| `ObjectNotPresentError` | 404 | Configuration not found |
+| `ServerError` | 500 | Internal server error |
+
+### Basic Configuration
+
+```python
+from scm.client import ScmClient
+
+client = ScmClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+```
+
+## Methods
+
+### List Configuration Versions
+
+Retrieve the version history of local configurations for a specified device.
+
+```python
+# List all configuration versions for a device
+versions = client.local_config.list_versions(device="007951000123456")
+
+for version in versions:
+    print(f"Version {version.local_version} at {version.timestamp}")
+```
+
+### Download a Configuration File
+
+Download a specific local configuration file as raw XML bytes.
+
+```python
+# Download a specific configuration version
+config_bytes = client.local_config.download(
+    device="007951000123456",
+    version="1"
+)
+
+# Save to a file
+with open("device-config.xml", "wb") as f:
+    f.write(config_bytes)
+
+print(f"Downloaded {len(config_bytes)} bytes")
+```
+
+## Use Cases
+
+### Back Up Device Configuration
+
+```python
+# Get all versions, then download the latest
+versions = client.local_config.list_versions(device="007951000123456")
+
+if versions:
+    latest = versions[0]
+    config = client.local_config.download(
+        device="007951000123456",
+        version=str(latest.id)
+    )
+    filename = f"backup-{latest.serial}-{latest.local_version}.xml"
+    with open(filename, "wb") as f:
+        f.write(config)
+    print(f"Backed up to {filename}")
+else:
+    print("No configuration versions found")
+```
+
+### Track Configuration Changes
+
+```python
+# Monitor configuration version history
+versions = client.local_config.list_versions(device="007951000123456")
+
+for v in versions:
+    print(f"ID: {v.id} | Version: {v.local_version} | "
+          f"Transformed: {v.xfmed_version} | Time: {v.timestamp}")
+```
+
+## Error Handling
+
+```python
+from scm.exceptions import (
+    AuthenticationError,
+    ObjectNotPresentError,
+    ServerError,
+)
+
+try:
+    versions = client.local_config.list_versions(device="007951000123456")
+except AuthenticationError:
+    print("Authentication failed. Check your credentials.")
+except ObjectNotPresentError:
+    print("Device not found.")
+except ServerError as e:
+    print(f"Server error: {e.message}")
+```
+
+## Related Topics
+
+- [Operations Models](../../models/operations/index.md)
+- [Device Operations](device_operations.md)
+- [Client Module](../../client.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,6 +211,13 @@ nav:
       - Insights:
           - Overview: sdk/insights/index.md
           - Alerts: sdk/insights/alerts.md
+      - Operations:
+          - Overview: sdk/operations/index.md
+          - Local Config: sdk/operations/local_config.md
+          - Device Operations: sdk/operations/device_operations.md
+      - Incidents:
+          - Overview: sdk/incidents/index.md
+          - Incidents: sdk/incidents/incidents.md
       - Exceptions: sdk/exceptions.md
   - Data Models:
       - Overview: sdk/models/index.md
@@ -284,6 +291,11 @@ nav:
           - Overview: sdk/models/operations/index.md
           - Candidate Push: sdk/models/operations/candidate_push.md
           - Jobs: sdk/models/operations/jobs.md
+          - Local Config: sdk/models/operations/local_config_models.md
+          - Device Operations: sdk/models/operations/device_operations_models.md
+      - Incidents:
+          - Overview: sdk/models/incidents/index.md
+          - Incidents: sdk/models/incidents/incidents_models.md
       - Security Services:
           - Overview: sdk/models/security_services/index.md
           - Anti-Spyware Profiles: sdk/models/security_services/anti_spyware_profile_models.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.12.7"
+version = "0.13.0"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/client.py
+++ b/scm/client.py
@@ -53,6 +53,7 @@ class Scm:
             When provided, client_id, client_secret, and tsg_id are not required.
             Token refresh is the caller's responsibility when using this mode.
         verify_ssl: Whether to verify TLS certificates for all requests (default: True). Set to False to bypass TLS verification (insecure!).
+        region: Default region for APIs requiring X-PANW-Region header (default: "americas")
 
     """
 
@@ -67,10 +68,12 @@ class Scm:
         log_level: str = "ERROR",
         access_token: Optional[str] = None,
         verify_ssl: bool = True,
+        region: str = "americas",
     ):
         """Initialize the ScmClient with the provided client_id, client_secret, tsg_id, API URLs, log level, access token, and TLS verification flag."""
         self.api_base_url = api_base_url
         self.verify_ssl = verify_ssl
+        self.region = region
         self.oauth_client = None
 
         # Map string log level to numeric level
@@ -163,8 +166,10 @@ class Scm:
             method: HTTP method to be used for the request (e.g., 'GET', 'POST').
             endpoint: The API endpoint to which the request is made.
             **kwargs: Additional arguments to be passed to the request (e.g., headers, params, data).
+                Pass raw_response=True to receive the raw requests.Response object instead of parsed JSON.
 
         """
+        raw_response = kwargs.pop("raw_response", False)
         url = f"{self.api_base_url}{endpoint}"
         self.logger.debug(f"Making {method} request to {url} with params {kwargs}")
 
@@ -178,6 +183,9 @@ class Scm:
                 **kwargs,
             )
             response.raise_for_status()
+
+            if raw_response:
+                return response
 
             if response.content and response.content.strip():
                 return response.json()
@@ -790,6 +798,20 @@ class Scm:
             "pbf_rule": (
                 "scm.config.network.pbf_rule",
                 "PbfRule",
+            ),
+            # Operations Services (v0.13.0)
+            "local_config": (
+                "scm.operations.local_config",
+                "LocalConfig",
+            ),
+            "device_operations": (
+                "scm.operations.device_operations",
+                "DeviceOperations",
+            ),
+            # Incidents Services (v0.13.0)
+            "incidents": (
+                "scm.incidents.incidents",
+                "Incidents",
             ),
         }
 

--- a/scm/client.py
+++ b/scm/client.py
@@ -73,7 +73,7 @@ class Scm:
         """Initialize the ScmClient with the provided client_id, client_secret, tsg_id, API URLs, log level, access token, and TLS verification flag."""
         self.api_base_url = api_base_url
         self.verify_ssl = verify_ssl
-        self.region = region
+        self.default_region = region
         self.oauth_client = None
 
         # Map string log level to numeric level

--- a/scm/exceptions/__init__.py
+++ b/scm/exceptions/__init__.py
@@ -229,6 +229,7 @@ class JobTimeoutError(APIError):
     """Raised when a device operations job does not complete within the timeout period."""
 
     def __init__(self, job_id: str, last_state: str, timeout: int, **kwargs):
+        """Initialize JobTimeoutError with job details."""
         self.job_id = job_id
         self.last_state = last_state
         self.timeout = timeout

--- a/scm/exceptions/__init__.py
+++ b/scm/exceptions/__init__.py
@@ -225,6 +225,19 @@ class SessionTimeoutError(GatewayTimeoutError):
     """Raised when the session times out (Code '4': Session Timeout)."""
 
 
+class JobTimeoutError(APIError):
+    """Raised when a device operations job does not complete within the timeout period."""
+
+    def __init__(self, job_id: str, last_state: str, timeout: int, **kwargs):
+        self.job_id = job_id
+        self.last_state = last_state
+        self.timeout = timeout
+        super().__init__(
+            message=f"Job {job_id} did not complete within {timeout} seconds (last state: {last_state})",
+            **kwargs,
+        )
+
+
 class ErrorHandler:
     """Handles mapping of API error responses to appropriate exceptions."""
 

--- a/scm/incidents/__init__.py
+++ b/scm/incidents/__init__.py
@@ -1,0 +1,1 @@
+"""scm.incidents: Incident management services."""

--- a/scm/incidents/incidents.py
+++ b/scm/incidents/incidents.py
@@ -15,7 +15,7 @@ class Incidents(ServiceBase):
     BASE_ENDPOINT = "/incidents/v1"
 
     def _get_headers(self) -> Dict[str, str]:
-        headers = {"X-PANW-Region": self.api_client.region}
+        headers = {"X-PANW-Region": self.api_client.default_region}
         if self.api_client.oauth_client:
             tsg_id = self.api_client.oauth_client.auth_request.tsg_id
             if tsg_id:

--- a/scm/incidents/incidents.py
+++ b/scm/incidents/incidents.py
@@ -1,0 +1,96 @@
+"""Incidents service for the Unified Incident Framework API."""
+
+from typing import Any, Dict, List, Optional
+
+from scm.models.incidents.incidents import (
+    IncidentDetailModel,
+    IncidentSearchResponseModel,
+)
+from scm.services import ServiceBase
+
+
+class Incidents(ServiceBase):
+    """Service for searching and retrieving incident details."""
+
+    BASE_ENDPOINT = "/incidents/v1"
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {"X-PANW-Region": self.api_client.region}
+        if self.api_client.oauth_client:
+            tsg_id = self.api_client.oauth_client.auth_request.tsg_id
+            if tsg_id:
+                headers["prisma-tenant"] = tsg_id
+        return headers
+
+    def search(
+        self,
+        *,
+        status: Optional[List[str]] = None,
+        severity: Optional[List[str]] = None,
+        product: Optional[List[str]] = None,
+        filter_rules: Optional[List[Dict[str, Any]]] = None,
+        page_size: int = 50,
+        page_number: int = 1,
+        order_by: Optional[List[Dict[str, str]]] = None,
+    ) -> IncidentSearchResponseModel:
+        """Search incidents with filtering and pagination.
+
+        Args:
+            status: Filter by incident status (e.g., ["Raised", "Cleared"]).
+            severity: Filter by severity (e.g., ["Critical", "High"]).
+            product: Filter by product (e.g., ["NGFW", "Prisma Access"]).
+            filter_rules: Raw filter rules for full control. Overrides convenience kwargs.
+            page_size: Number of results per page (default 50).
+            page_number: Page number (default 1).
+            order_by: Ordering specification.
+
+        Returns:
+            IncidentSearchResponseModel with header metadata and incident list.
+
+        """
+        if filter_rules is not None:
+            rules = filter_rules
+        else:
+            rules = []
+            if status:
+                rules.append({"property": "status", "operator": "in", "values": status})
+            if severity:
+                rules.append({"property": "severity", "operator": "in", "values": severity})
+            if product:
+                rules.append({"property": "product", "operator": "in", "values": product})
+
+        payload: Dict[str, Any] = {
+            "pagination": {
+                "page_size": page_size,
+                "page_number": page_number,
+            },
+        }
+
+        if order_by:
+            payload["pagination"]["order_by"] = order_by
+
+        if rules:
+            payload["filter"] = {"rules": rules}
+
+        response = self.api_client.post(
+            f"{self.BASE_ENDPOINT}/search",
+            json=payload,
+            headers=self._get_headers(),
+        )
+        return IncidentSearchResponseModel(**response)
+
+    def get_details(self, incident_id: str) -> IncidentDetailModel:
+        """Get detailed information about a specific incident.
+
+        Args:
+            incident_id: The unique identifier of the incident.
+
+        Returns:
+            IncidentDetailModel with full incident details including alerts.
+
+        """
+        response = self.api_client.get(
+            f"{self.BASE_ENDPOINT}/details/{incident_id}",
+            headers=self._get_headers(),
+        )
+        return IncidentDetailModel(**response)

--- a/scm/models/incidents/__init__.py
+++ b/scm/models/incidents/__init__.py
@@ -1,0 +1,1 @@
+"""scm.models.incidents: Incident-related models."""

--- a/scm/models/incidents/incidents.py
+++ b/scm/models/incidents/incidents.py
@@ -1,0 +1,178 @@
+"""Incident models for the Unified Incident Framework API."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FilterRuleModel(BaseModel):
+    """A single filter rule for incident search."""
+
+    property: str = Field(..., description="The property to filter on.")
+    operator: str = Field(..., description="The filter operator (e.g., 'in', 'equals').")
+    values: List[Any] = Field(..., description="The values to filter by.")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class FilterObjectModel(BaseModel):
+    """Container for filter rules."""
+
+    rules: List[FilterRuleModel] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PaginationModel(BaseModel):
+    """Pagination parameters for incident search."""
+
+    page_size: int = Field(default=50, description="Number of results per page.")
+    page_number: int = Field(default=1, description="Page number to retrieve.")
+    order_by: Optional[List[Dict[str, str]]] = Field(default=None, description="Ordering specification.")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IncidentSearchRequestModel(BaseModel):
+    """Request body for incident search."""
+
+    filter: Optional[FilterObjectModel] = Field(default=None)
+    pagination: Optional[PaginationModel] = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ImpactedObjectsModel(BaseModel):
+    """Impacted objects associated with an incident."""
+
+    agent_ids: Optional[List[str]] = None
+    aggr_locations: Optional[List[str]] = None
+    app_names: Optional[List[str]] = None
+    asn_org_names: Optional[List[str]] = None
+    auth_server_profiles: Optional[List[str]] = None
+    auth_servers: Optional[List[str]] = None
+    bgp_peer_names: Optional[List[str]] = None
+    certificate_names: Optional[List[str]] = None
+    cluster_names: Optional[List[str]] = None
+    cves: Optional[List[str]] = None
+    device_ids: Optional[List[str]] = None
+    directory_ids: Optional[List[str]] = None
+    dns_servers: Optional[List[str]] = None
+    gp_versions: Optional[List[str]] = None
+    gre_tunnel_names: Optional[List[str]] = None
+    host_names: Optional[List[str]] = None
+    ike_gateway_names: Optional[List[str]] = None
+    interfaces: Optional[List[str]] = None
+    licenses: Optional[List[str]] = None
+    link_names: Optional[List[str]] = None
+    locations: Optional[List[str]] = None
+    log_receivers: Optional[List[str]] = None
+    nat_policies: Optional[List[str]] = None
+    packages: Optional[List[str]] = None
+    roles: Optional[List[str]] = None
+    security_checks: Optional[List[str]] = None
+    security_objects: Optional[List[str]] = None
+    security_types: Optional[List[str]] = None
+    sha256s: Optional[List[str]] = None
+    site_names: Optional[List[str]] = None
+    slots: Optional[List[str]] = None
+    spn_names: Optional[List[str]] = None
+    theaters: Optional[List[str]] = None
+    tunnel_names: Optional[List[str]] = None
+    user_locations: Optional[List[str]] = None
+    zones: Optional[List[str]] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IncidentModel(BaseModel):
+    """Represents an incident from search results."""
+
+    incident_id: str = Field(..., description="Unique incident identifier.")
+    title: str = Field(..., description="Incident title.")
+    severity: str = Field(..., description="Severity level.")
+    severity_id: Optional[int] = Field(default=None)
+    status: str = Field(..., description="Incident status.")
+    priority: Optional[str] = Field(default=None)
+    priority_id: Optional[int] = Field(default=None)
+    product: str = Field(..., description="Product that generated the incident.")
+    category: Optional[str] = Field(default=None)
+    sub_category: Optional[str] = Field(default=None)
+    code: Optional[str] = Field(default=None)
+    raised_time: Optional[int] = Field(default=None)
+    updated_time: Optional[int] = Field(default=None)
+    cleared_time: Optional[int] = Field(default=None)
+    release_state: Optional[str] = Field(default=None)
+    incident_type: Optional[str] = Field(default=None)
+    designation: Optional[str] = Field(default=None)
+    acknowledged: Optional[bool] = Field(default=None)
+    acknowledged_by: Optional[str] = Field(default=None)
+    primary_impacted_objects: Optional[ImpactedObjectsModel] = Field(default=None)
+    related_impacted_objects: Optional[ImpactedObjectsModel] = Field(default=None)
+    snow_assignee: Optional[str] = Field(default=None)
+    snow_priority: Optional[str] = Field(default=None)
+    snow_status: Optional[str] = Field(default=None)
+    snow_ticket_id: Optional[str] = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AlertModel(BaseModel):
+    """Represents an alert within an incident detail."""
+
+    alert_id: str = Field(..., description="Unique alert identifier.")
+    processed_alert_id: Optional[str] = Field(default=None)
+    severity: Optional[str] = Field(default=None)
+    state: Optional[str] = Field(default=None)
+    title: Optional[str] = Field(default=None)
+    updated_time: Optional[int] = Field(default=None)
+    domain: Optional[str] = Field(default=None)
+    inc_prop: Optional[int] = Field(default=None)
+    ctx_only_alert: Optional[bool] = Field(default=None)
+    code: Optional[str] = Field(default=None)
+    resource_keys: Optional[str] = Field(default=None)
+    release_state: Optional[str] = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IncidentDetailModel(IncidentModel):
+    """Extended incident information from the details endpoint."""
+
+    description: Optional[str] = Field(default=None)
+    description_locale_key: Optional[str] = Field(default=None)
+    remediations: Optional[str] = Field(default=None)
+    detail: Optional[str] = Field(default=None)
+    alerts: Optional[List[AlertModel]] = Field(default=None)
+    resource_keys: Optional[str] = Field(default=None)
+    resource_context: Optional[str] = Field(default=None)
+    incident_code: Optional[str] = Field(default=None)
+    incident_settings_id: Optional[str] = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IncidentSearchResponseHeaderModel(BaseModel):
+    """Response header metadata from incident search."""
+
+    createdAt: Optional[str] = Field(default=None)
+    dataCount: Optional[int] = Field(default=None)
+    requestId: Optional[str] = Field(default=None)
+    queryInput: Optional[Dict[str, Any]] = Field(default=None)
+    isResourceDataOverridden: Optional[bool] = Field(default=None)
+    fieldList: Optional[List[Dict[str, Any]]] = Field(default=None)
+    status: Optional[Dict[str, Any]] = Field(default=None)
+    pagination: Optional[Dict[str, Any]] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    cache_operation: Optional[str] = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IncidentSearchResponseModel(BaseModel):
+    """Full response from incident search."""
+
+    header: IncidentSearchResponseHeaderModel = Field(..., description="Response metadata.")
+    data: List[IncidentModel] = Field(default_factory=list, description="List of incidents.")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/scm/models/operations/__init__.py
+++ b/scm/models/operations/__init__.py
@@ -9,6 +9,7 @@ from .jobs import (
     JobStatusData,
     JobStatusResponse,
 )
+from .local_config import LocalConfigVersionModel
 
 __all__ = [
     "CandidatePushRequestModel",
@@ -18,4 +19,5 @@ __all__ = [
     "JobStatusResponse",
     "JobListItem",
     "JobListResponse",
+    "LocalConfigVersionModel",
 ]

--- a/scm/models/operations/__init__.py
+++ b/scm/models/operations/__init__.py
@@ -2,6 +2,14 @@
 # scm/models/operations/__init__.py
 
 from .candidate_push import CandidatePushRequestModel, CandidatePushResponseModel
+from .device_operations import (
+    DeviceJobDetailsModel,
+    DeviceJobRequestModel,
+    DeviceJobResultModel,
+    DeviceJobStatusModel,
+    DeviceOperationsRequestModel,
+    JobCreatedModel,
+)
 from .jobs import (
     JobDetails,
     JobListItem,
@@ -14,6 +22,12 @@ from .local_config import LocalConfigVersionModel
 __all__ = [
     "CandidatePushRequestModel",
     "CandidatePushResponseModel",
+    "DeviceJobDetailsModel",
+    "DeviceJobRequestModel",
+    "DeviceJobResultModel",
+    "DeviceJobStatusModel",
+    "DeviceOperationsRequestModel",
+    "JobCreatedModel",
     "JobDetails",
     "JobStatusData",
     "JobStatusResponse",

--- a/scm/models/operations/device_operations.py
+++ b/scm/models/operations/device_operations.py
@@ -1,0 +1,83 @@
+"""Device operations models for Operations API."""
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DeviceOperationsRequestModel(BaseModel):
+    """Validates device serial numbers for job dispatch."""
+
+    devices: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=5,
+        description="List of 1-5 device serial numbers.",
+    )
+
+    @field_validator("devices")
+    @classmethod
+    def validate_serial_numbers(cls, v: List[str]) -> List[str]:
+        import re
+        pattern = re.compile(r"^\d{14,15}$")
+        for serial in v:
+            if not pattern.match(serial):
+                raise ValueError(f"Invalid device serial number format: {serial}")
+        return v
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class JobCreatedModel(BaseModel):
+    """Response from job dispatch — contains the job ID for polling."""
+
+    job_id: str = Field(..., description="Unique identifier for the created job.")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DeviceJobDetailsModel(BaseModel):
+    """Detailed results from a device command execution."""
+
+    msg: str = Field(..., description="Status message from the command execution.")
+    result: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Result data. Structure varies by command type.",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DeviceJobResultModel(BaseModel):
+    """Result from a single device within a job."""
+
+    device: str = Field(..., description="Device serial number.")
+    state: str = Field(..., description="Job state for this device.")
+    created_ts: str = Field(..., description="Timestamp when the job was created.")
+    updated_ts: str = Field(..., description="Timestamp when the job was last updated.")
+    details: DeviceJobDetailsModel = Field(..., description="Detailed command results.")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DeviceJobRequestModel(BaseModel):
+    """The original request that initiated the job."""
+
+    command: str = Field(..., description="The command that was executed.")
+    devices: List[str] = Field(..., description="Device serial numbers.")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class DeviceJobStatusModel(BaseModel):
+    """Full job status response from the device jobs endpoint."""
+
+    jobId: str = Field(..., description="Unique identifier for the job.")
+    progress: int = Field(..., ge=0, le=100, description="Job completion percentage.")
+    state: str = Field(..., description="Current state of the job.")
+    request: DeviceJobRequestModel = Field(..., description="Original request.")
+    results: List[DeviceJobResultModel] = Field(
+        default_factory=list, description="Results from each device.",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/scm/models/operations/device_operations.py
+++ b/scm/models/operations/device_operations.py
@@ -18,6 +18,7 @@ class DeviceOperationsRequestModel(BaseModel):
     @field_validator("devices")
     @classmethod
     def validate_serial_numbers(cls, v: List[str]) -> List[str]:
+        """Validate that each serial number matches the expected 14-15 digit format."""
         import re
         pattern = re.compile(r"^\d{14,15}$")
         for serial in v:

--- a/scm/models/operations/local_config.py
+++ b/scm/models/operations/local_config.py
@@ -1,0 +1,19 @@
+"""Local configuration version models for Operations API."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LocalConfigVersionModel(BaseModel):
+    """Represents a local configuration version entry for a device."""
+
+    id: int = Field(..., description="Unique identifier for this configuration version entry.")
+    serial: str = Field(..., description="Device serial number (14-15 digits).")
+    local_version: str = Field(..., description="Local configuration version identifier.")
+    timestamp: datetime = Field(..., description="When this configuration version was created.")
+    xfmed_version: str = Field(..., description="Transformed configuration version identifier.")
+    md5: Optional[str] = Field(default=None, description="MD5 hash of the configuration.")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/scm/operations/__init__.py
+++ b/scm/operations/__init__.py
@@ -1,0 +1,1 @@
+"""Operations services for SCM API."""

--- a/scm/operations/__init__.py
+++ b/scm/operations/__init__.py
@@ -1,0 +1,1 @@
+"""scm.operations: Device operations and local config services."""

--- a/scm/operations/__init__.py
+++ b/scm/operations/__init__.py
@@ -1,1 +1,0 @@
-"""Operations services for SCM API."""

--- a/scm/operations/device_operations.py
+++ b/scm/operations/device_operations.py
@@ -1,0 +1,125 @@
+"""DeviceOperations service for Operations API."""
+
+import time
+from typing import List, Union
+
+from scm.exceptions import JobTimeoutError
+from scm.models.operations.device_operations import (
+    DeviceJobStatusModel,
+    DeviceOperationsRequestModel,
+    JobCreatedModel,
+)
+from scm.services import ServiceBase
+
+
+class DeviceOperations(ServiceBase):
+    """Service for dispatching device operation jobs and polling for results."""
+
+    BASE_ENDPOINT = "/operations/v1"
+
+    def _dispatch_job(
+        self,
+        endpoint: str,
+        devices: List[str],
+        sync: bool = False,
+        poll_interval: int = 10,
+        timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Dispatch a device operation job.
+
+        Args:
+            endpoint: Job endpoint path (e.g., "jobs/route-table").
+            devices: List of 1-5 device serial numbers.
+            sync: If True, poll until job completes or times out.
+            poll_interval: Seconds between polls when sync=True.
+            timeout: Max seconds to wait when sync=True.
+
+        Returns:
+            JobCreatedModel if sync=False, DeviceJobStatusModel if sync=True.
+
+        Raises:
+            ValidationError: If devices list is invalid.
+            JobTimeoutError: If sync=True and job doesn't complete within timeout.
+
+        """
+        request_model = DeviceOperationsRequestModel(devices=devices)
+        response = self.api_client.post(
+            f"{self.BASE_ENDPOINT}/{endpoint}",
+            json=request_model.model_dump(),
+        )
+        job = JobCreatedModel(**response)
+
+        if not sync:
+            return job
+
+        start_time = time.time()
+        while True:
+            status = self.get_job_status(job.job_id)
+            if status.state in ("complete", "failed"):
+                return status
+
+            if time.time() - start_time > timeout:
+                raise JobTimeoutError(
+                    job_id=job.job_id,
+                    last_state=status.state,
+                    timeout=timeout,
+                )
+
+            time.sleep(poll_interval)
+
+    def get_job_status(self, job_id: str) -> DeviceJobStatusModel:
+        """Get the status of a device operations job.
+
+        Args:
+            job_id: The job ID returned from a dispatch method.
+
+        Returns:
+            DeviceJobStatusModel with current job state and results.
+
+        """
+        response = self.api_client.get(f"{self.BASE_ENDPOINT}/device/jobs/{job_id}")
+        return DeviceJobStatusModel(**response)
+
+    def route_table(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/route-table", devices, sync, poll_interval, timeout)
+
+    def fib_table(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/fib-table", devices, sync, poll_interval, timeout)
+
+    def dns_proxy(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/dns-proxy", devices, sync, poll_interval, timeout)
+
+    def device_interfaces(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/device-interfaces", devices, sync, poll_interval, timeout)
+
+    def device_rules(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/device-rules", devices, sync, poll_interval, timeout)
+
+    def bgp_policy_export(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job("jobs/bgp-policy-export", devices, sync, poll_interval, timeout)
+
+    def logging_service_status(
+        self, devices: List[str], sync: bool = False,
+        poll_interval: int = 10, timeout: int = 300,
+    ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        return self._dispatch_job(
+            "jobs/logging-service-forwarding-status", devices, sync, poll_interval, timeout
+        )

--- a/scm/operations/device_operations.py
+++ b/scm/operations/device_operations.py
@@ -84,42 +84,49 @@ class DeviceOperations(ServiceBase):
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve route table from device(s)."""
         return self._dispatch_job("jobs/route-table", devices, sync, poll_interval, timeout)
 
     def fib_table(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve FIB table from device(s)."""
         return self._dispatch_job("jobs/fib-table", devices, sync, poll_interval, timeout)
 
     def dns_proxy(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve DNS proxy configuration from device(s)."""
         return self._dispatch_job("jobs/dns-proxy", devices, sync, poll_interval, timeout)
 
     def device_interfaces(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve network interfaces from device(s)."""
         return self._dispatch_job("jobs/device-interfaces", devices, sync, poll_interval, timeout)
 
     def device_rules(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve security rules from device(s)."""
         return self._dispatch_job("jobs/device-rules", devices, sync, poll_interval, timeout)
 
     def bgp_policy_export(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve BGP policy export from device(s)."""
         return self._dispatch_job("jobs/bgp-policy-export", devices, sync, poll_interval, timeout)
 
     def logging_service_status(
         self, devices: List[str], sync: bool = False,
         poll_interval: int = 10, timeout: int = 300,
     ) -> Union[JobCreatedModel, DeviceJobStatusModel]:
+        """Retrieve logging service forwarding status from device(s)."""
         return self._dispatch_job(
             "jobs/logging-service-forwarding-status", devices, sync, poll_interval, timeout
         )

--- a/scm/operations/local_config.py
+++ b/scm/operations/local_config.py
@@ -1,0 +1,48 @@
+"""LocalConfig service for Operations API."""
+
+from typing import List
+
+from scm.models.operations.local_config import LocalConfigVersionModel
+from scm.services import ServiceBase
+
+
+class LocalConfig(ServiceBase):
+    """Service for retrieving local device configuration versions and downloads."""
+
+    ENDPOINT = "/operations/v1/local-config"
+
+    def list_versions(self, device: str) -> List[LocalConfigVersionModel]:
+        """List local configuration versions for a device.
+
+        Args:
+            device: Device serial number (14-15 digits).
+
+        Returns:
+            List of configuration version entries.
+
+        """
+        response = self.api_client.get(
+            f"{self.ENDPOINT}/versions",
+            params={"device": device},
+        )
+        if not response:
+            return []
+        return [LocalConfigVersionModel(**item) for item in response]
+
+    def download(self, device: str, version: str) -> bytes:
+        """Download a local configuration file for a device.
+
+        Args:
+            device: Device serial number (14-15 digits).
+            version: Configuration version ID.
+
+        Returns:
+            Raw bytes of the XML configuration file.
+
+        """
+        response = self.api_client.get(
+            f"{self.ENDPOINT}/download",
+            params={"device": device, "version": version},
+            raw_response=True,
+        )
+        return response.content

--- a/scm/services/__init__.py
+++ b/scm/services/__init__.py
@@ -1,0 +1,17 @@
+"""scm.services: Base class for non-CRUD service implementations."""
+
+from typing import Any, Dict
+
+
+class ServiceBase:
+    """Thin base class for non-CRUD services.
+
+    Provides api_client access and optional header injection.
+    Subclasses override _get_headers() to inject custom headers.
+    """
+
+    def __init__(self, api_client: Any):
+        self.api_client = api_client
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {}

--- a/scm/services/__init__.py
+++ b/scm/services/__init__.py
@@ -11,7 +11,9 @@ class ServiceBase:
     """
 
     def __init__(self, api_client: Any):
+        """Initialize ServiceBase with an API client instance."""
         self.api_client = api_client
 
     def _get_headers(self) -> Dict[str, str]:
+        """Return extra headers to inject into requests."""
         return {}

--- a/tests/scm/incidents/__init__.py
+++ b/tests/scm/incidents/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scm.incidents."""

--- a/tests/scm/incidents/test_incidents.py
+++ b/tests/scm/incidents/test_incidents.py
@@ -20,7 +20,7 @@ class TestIncidents:
         client = MagicMock()
         client.get = MagicMock()
         client.post = MagicMock()
-        client.region = "americas"
+        client.default_region = "americas"
         client.oauth_client = MagicMock()
         client.oauth_client.auth_request.tsg_id = "test-tsg-123"
         return client
@@ -45,7 +45,7 @@ class TestIncidents:
 
     def test_get_headers_custom_region(self, incidents_service):
         """Test that _get_headers uses the configured region."""
-        incidents_service.api_client.region = "europe"
+        incidents_service.api_client.default_region = "europe"
         headers = incidents_service._get_headers()
         assert headers["X-PANW-Region"] == "europe"
 

--- a/tests/scm/incidents/test_incidents.py
+++ b/tests/scm/incidents/test_incidents.py
@@ -1,0 +1,156 @@
+"""Tests for Incidents service."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scm.incidents.incidents import Incidents
+from scm.models.incidents.incidents import (
+    IncidentDetailModel,
+    IncidentSearchResponseModel,
+)
+
+
+class TestIncidents:
+    """Tests for the Incidents service."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get = MagicMock()
+        client.post = MagicMock()
+        client.region = "americas"
+        client.oauth_client = MagicMock()
+        client.oauth_client.auth_request.tsg_id = "test-tsg-123"
+        return client
+
+    @pytest.fixture
+    def incidents_service(self, mock_client):
+        return Incidents(mock_client)
+
+    def test_get_headers(self, incidents_service):
+        headers = incidents_service._get_headers()
+        assert headers["X-PANW-Region"] == "americas"
+        assert headers["prisma-tenant"] == "test-tsg-123"
+
+    def test_get_headers_no_oauth(self, incidents_service):
+        incidents_service.api_client.oauth_client = None
+        headers = incidents_service._get_headers()
+        assert headers["X-PANW-Region"] == "americas"
+        assert "prisma-tenant" not in headers
+
+    def test_get_headers_custom_region(self, incidents_service):
+        incidents_service.api_client.region = "europe"
+        headers = incidents_service._get_headers()
+        assert headers["X-PANW-Region"] == "europe"
+
+    def test_search_basic(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {
+                "createdAt": "2026-03-12T19:38:43Z",
+                "dataCount": 1,
+                "requestId": "test-req-1",
+            },
+            "data": [{
+                "incident_id": "inc-123",
+                "title": "Test incident",
+                "severity": "High",
+                "status": "Raised",
+                "product": "NGFW",
+            }],
+        }
+        result = incidents_service.search()
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/incidents/v1/search"
+        assert call_args[1]["headers"]["X-PANW-Region"] == "americas"
+        assert isinstance(result, IncidentSearchResponseModel)
+        assert len(result.data) == 1
+        assert result.data[0].incident_id == "inc-123"
+
+    def test_search_with_filters(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r2"},
+            "data": [],
+        }
+        incidents_service.search(
+            status=["Raised"], severity=["Critical", "High"],
+            product=["Prisma Access", "NGFW"],
+        )
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        rules = payload["filter"]["rules"]
+        status_rule = next(r for r in rules if r["property"] == "status")
+        assert status_rule["operator"] == "in"
+        assert status_rule["values"] == ["Raised"]
+        severity_rule = next(r for r in rules if r["property"] == "severity")
+        assert severity_rule["values"] == ["Critical", "High"]
+        product_rule = next(r for r in rules if r["property"] == "product")
+        assert product_rule["values"] == ["Prisma Access", "NGFW"]
+
+    def test_search_with_raw_filter_rules(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r3"},
+            "data": [],
+        }
+        custom_rules = [{"property": "release_state", "operator": "in", "values": ["Released"]}]
+        incidents_service.search(filter_rules=custom_rules)
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        rules = payload["filter"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["property"] == "release_state"
+
+    def test_search_pagination(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r4"},
+            "data": [],
+        }
+        incidents_service.search(page_size=25, page_number=3)
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["pagination"]["page_size"] == 25
+        assert payload["pagination"]["page_number"] == 3
+
+    def test_search_order_by(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r5"},
+            "data": [],
+        }
+        incidents_service.search(order_by=[{"property": "updated_time", "order": "desc"}])
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["pagination"]["order_by"] == [{"property": "updated_time", "order": "desc"}]
+
+    def test_get_details(self, incidents_service, mock_client):
+        mock_client.get.return_value = {
+            "incident_id": "inc-456",
+            "title": "Detailed incident",
+            "severity": "Critical",
+            "status": "Raised",
+            "product": "NGFW",
+            "description": "This is a test description.",
+            "alerts": [{
+                "alert_id": "alert-1", "severity": "Critical",
+                "state": "Raised", "title": "Alert 1", "updated_time": 1765468859684,
+            }],
+        }
+        result = incidents_service.get_details("inc-456")
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "/incidents/v1/details/inc-456"
+        assert call_args[1]["headers"]["X-PANW-Region"] == "americas"
+        assert isinstance(result, IncidentDetailModel)
+        assert result.description == "This is a test description."
+        assert len(result.alerts) == 1
+
+    def test_search_defaults(self, incidents_service, mock_client):
+        mock_client.post.return_value = {
+            "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r6"},
+            "data": [],
+        }
+        incidents_service.search()
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["pagination"]["page_size"] == 50
+        assert payload["pagination"]["page_number"] == 1

--- a/tests/scm/incidents/test_incidents.py
+++ b/tests/scm/incidents/test_incidents.py
@@ -16,6 +16,7 @@ class TestIncidents:
 
     @pytest.fixture
     def mock_client(self):
+        """Create a mock API client."""
         client = MagicMock()
         client.get = MagicMock()
         client.post = MagicMock()
@@ -26,25 +27,30 @@ class TestIncidents:
 
     @pytest.fixture
     def incidents_service(self, mock_client):
+        """Create an Incidents service instance with mock client."""
         return Incidents(mock_client)
 
     def test_get_headers(self, incidents_service):
+        """Test that _get_headers returns region and tenant headers."""
         headers = incidents_service._get_headers()
         assert headers["X-PANW-Region"] == "americas"
         assert headers["prisma-tenant"] == "test-tsg-123"
 
     def test_get_headers_no_oauth(self, incidents_service):
+        """Test that _get_headers omits tenant header when oauth_client is None."""
         incidents_service.api_client.oauth_client = None
         headers = incidents_service._get_headers()
         assert headers["X-PANW-Region"] == "americas"
         assert "prisma-tenant" not in headers
 
     def test_get_headers_custom_region(self, incidents_service):
+        """Test that _get_headers uses the configured region."""
         incidents_service.api_client.region = "europe"
         headers = incidents_service._get_headers()
         assert headers["X-PANW-Region"] == "europe"
 
     def test_search_basic(self, incidents_service, mock_client):
+        """Test that search returns a parsed IncidentSearchResponseModel."""
         mock_client.post.return_value = {
             "header": {
                 "createdAt": "2026-03-12T19:38:43Z",
@@ -69,6 +75,7 @@ class TestIncidents:
         assert result.data[0].incident_id == "inc-123"
 
     def test_search_with_filters(self, incidents_service, mock_client):
+        """Test that search builds correct filter rules from keyword args."""
         mock_client.post.return_value = {
             "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r2"},
             "data": [],
@@ -89,6 +96,7 @@ class TestIncidents:
         assert product_rule["values"] == ["Prisma Access", "NGFW"]
 
     def test_search_with_raw_filter_rules(self, incidents_service, mock_client):
+        """Test that search passes raw filter_rules directly."""
         mock_client.post.return_value = {
             "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r3"},
             "data": [],
@@ -102,6 +110,7 @@ class TestIncidents:
         assert rules[0]["property"] == "release_state"
 
     def test_search_pagination(self, incidents_service, mock_client):
+        """Test that search sends pagination parameters correctly."""
         mock_client.post.return_value = {
             "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r4"},
             "data": [],
@@ -113,6 +122,7 @@ class TestIncidents:
         assert payload["pagination"]["page_number"] == 3
 
     def test_search_order_by(self, incidents_service, mock_client):
+        """Test that search includes order_by in pagination."""
         mock_client.post.return_value = {
             "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r5"},
             "data": [],
@@ -123,6 +133,7 @@ class TestIncidents:
         assert payload["pagination"]["order_by"] == [{"property": "updated_time", "order": "desc"}]
 
     def test_get_details(self, incidents_service, mock_client):
+        """Test that get_details returns a parsed IncidentDetailModel."""
         mock_client.get.return_value = {
             "incident_id": "inc-456",
             "title": "Detailed incident",
@@ -145,6 +156,7 @@ class TestIncidents:
         assert len(result.alerts) == 1
 
     def test_search_defaults(self, incidents_service, mock_client):
+        """Test that search uses default pagination when no params given."""
         mock_client.post.return_value = {
             "header": {"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "r6"},
             "data": [],

--- a/tests/scm/models/incidents/__init__.py
+++ b/tests/scm/models/incidents/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for scm.models.incidents."""

--- a/tests/scm/models/incidents/test_incidents_models.py
+++ b/tests/scm/models/incidents/test_incidents_models.py
@@ -1,0 +1,155 @@
+"""Tests for incidents models."""
+
+import pytest
+from pydantic import ValidationError
+
+from scm.models.incidents.incidents import (
+    AlertModel,
+    FilterRuleModel,
+    ImpactedObjectsModel,
+    IncidentDetailModel,
+    IncidentModel,
+    IncidentSearchRequestModel,
+    IncidentSearchResponseModel,
+    PaginationModel,
+)
+
+
+class TestFilterRuleModel:
+    def test_valid_rule(self):
+        model = FilterRuleModel(property="status", operator="in", values=["Raised"])
+        assert model.property == "status"
+        assert model.operator == "in"
+        assert model.values == ["Raised"]
+
+
+class TestPaginationModel:
+    def test_defaults(self):
+        model = PaginationModel()
+        assert model.page_size == 50
+        assert model.page_number == 1
+        assert model.order_by is None
+
+    def test_custom_values(self):
+        model = PaginationModel(
+            page_size=25, page_number=3,
+            order_by=[{"property": "updated_time", "order": "desc"}],
+        )
+        assert model.page_size == 25
+        assert model.page_number == 3
+        assert len(model.order_by) == 1
+
+
+class TestIncidentSearchRequestModel:
+    def test_empty_request(self):
+        model = IncidentSearchRequestModel()
+        assert model.filter is None
+        assert model.pagination is None
+
+    def test_with_filter_and_pagination(self):
+        model = IncidentSearchRequestModel(
+            filter={"rules": [{"property": "status", "operator": "in", "values": ["Raised"]}]},
+            pagination={"page_size": 25, "page_number": 1},
+        )
+        assert model.filter is not None
+        assert model.pagination is not None
+
+
+class TestImpactedObjectsModel:
+    def test_all_defaults_empty(self):
+        model = ImpactedObjectsModel()
+        assert model.device_ids is None
+        assert model.host_names is None
+        assert model.interfaces is None
+
+    def test_with_values(self):
+        model = ImpactedObjectsModel(
+            device_ids=["dev-1", "dev-2"], host_names=["host-1"], zones=["zone-a"],
+        )
+        assert model.device_ids == ["dev-1", "dev-2"]
+        assert model.host_names == ["host-1"]
+        assert model.zones == ["zone-a"]
+
+
+class TestIncidentModel:
+    def test_valid_incident(self):
+        model = IncidentModel(
+            incident_id="21818c4a-8353-4d9c-ae3e-ae90004d4662",
+            title="Tenant has 14 raised alerts", severity="Informational",
+            severity_id=200, status="Raised", priority="Not Set",
+            priority_id=0, product="Prisma Access", category="Network",
+        )
+        assert model.incident_id == "21818c4a-8353-4d9c-ae3e-ae90004d4662"
+        assert model.severity == "Informational"
+        assert model.status == "Raised"
+
+    def test_with_impacted_objects(self):
+        model = IncidentModel(
+            incident_id="test-id", title="Test", severity="High",
+            status="Raised", product="NGFW",
+            primary_impacted_objects={"device_ids": ["dev-1"]},
+        )
+        assert model.primary_impacted_objects.device_ids == ["dev-1"]
+
+    def test_optional_fields_default_none(self):
+        model = IncidentModel(
+            incident_id="test-id", title="Test", severity="High",
+            status="Raised", product="NGFW",
+        )
+        assert model.sub_category is None
+        assert model.cleared_time is None
+        assert model.snow_ticket_id is None
+        assert model.acknowledged is None
+
+
+class TestAlertModel:
+    def test_valid_alert(self):
+        model = AlertModel(
+            alert_id="0a887db4-d760-4dc2-bb14-04c5e120b811",
+            severity="Critical", state="Raised",
+            title="Alert title", updated_time=1765468859684,
+        )
+        assert model.alert_id == "0a887db4-d760-4dc2-bb14-04c5e120b811"
+        assert model.severity == "Critical"
+
+
+class TestIncidentDetailModel:
+    def test_extends_incident_model(self):
+        model = IncidentDetailModel(
+            incident_id="test-id", title="Test incident", severity="Critical",
+            status="Raised", product="NGFW", description="Test description",
+            alerts=[{
+                "alert_id": "alert-1", "severity": "Critical",
+                "state": "Raised", "title": "Alert 1", "updated_time": 1765468859684,
+            }],
+        )
+        assert model.description == "Test description"
+        assert len(model.alerts) == 1
+        assert model.alerts[0].alert_id == "alert-1"
+
+    def test_optional_detail_fields(self):
+        model = IncidentDetailModel(
+            incident_id="test-id", title="Test", severity="High",
+            status="Raised", product="NGFW",
+        )
+        assert model.description is None
+        assert model.remediations is None
+        assert model.alerts is None
+        assert model.resource_context is None
+
+
+class TestIncidentSearchResponseModel:
+    def test_valid_response(self):
+        model = IncidentSearchResponseModel(
+            header={"createdAt": "2026-03-12T19:38:43Z", "dataCount": 1, "requestId": "test-123"},
+            data=[{"incident_id": "test-id", "title": "Test", "severity": "High", "status": "Raised", "product": "NGFW"}],
+        )
+        assert len(model.data) == 1
+        assert model.data[0].incident_id == "test-id"
+
+    def test_empty_data(self):
+        model = IncidentSearchResponseModel(
+            header={"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "test-123"},
+            data=[],
+        )
+        assert len(model.data) == 0

--- a/tests/scm/models/incidents/test_incidents_models.py
+++ b/tests/scm/models/incidents/test_incidents_models.py
@@ -1,7 +1,5 @@
 """Tests for incidents models."""
 
-import pytest
-from pydantic import ValidationError
 
 from scm.models.incidents.incidents import (
     AlertModel,
@@ -16,7 +14,10 @@ from scm.models.incidents.incidents import (
 
 
 class TestFilterRuleModel:
+    """Tests for FilterRuleModel."""
+
     def test_valid_rule(self):
+        """Test that a valid filter rule is accepted."""
         model = FilterRuleModel(property="status", operator="in", values=["Raised"])
         assert model.property == "status"
         assert model.operator == "in"
@@ -24,13 +25,17 @@ class TestFilterRuleModel:
 
 
 class TestPaginationModel:
+    """Tests for PaginationModel."""
+
     def test_defaults(self):
+        """Test that defaults are page_size=50 and page_number=1."""
         model = PaginationModel()
         assert model.page_size == 50
         assert model.page_number == 1
         assert model.order_by is None
 
     def test_custom_values(self):
+        """Test that custom pagination values are accepted."""
         model = PaginationModel(
             page_size=25, page_number=3,
             order_by=[{"property": "updated_time", "order": "desc"}],
@@ -41,12 +46,16 @@ class TestPaginationModel:
 
 
 class TestIncidentSearchRequestModel:
+    """Tests for IncidentSearchRequestModel."""
+
     def test_empty_request(self):
+        """Test that an empty request defaults filter and pagination to None."""
         model = IncidentSearchRequestModel()
         assert model.filter is None
         assert model.pagination is None
 
     def test_with_filter_and_pagination(self):
+        """Test that filter and pagination are set when provided."""
         model = IncidentSearchRequestModel(
             filter={"rules": [{"property": "status", "operator": "in", "values": ["Raised"]}]},
             pagination={"page_size": 25, "page_number": 1},
@@ -56,13 +65,17 @@ class TestIncidentSearchRequestModel:
 
 
 class TestImpactedObjectsModel:
+    """Tests for ImpactedObjectsModel."""
+
     def test_all_defaults_empty(self):
+        """Test that all fields default to None."""
         model = ImpactedObjectsModel()
         assert model.device_ids is None
         assert model.host_names is None
         assert model.interfaces is None
 
     def test_with_values(self):
+        """Test that provided values are stored correctly."""
         model = ImpactedObjectsModel(
             device_ids=["dev-1", "dev-2"], host_names=["host-1"], zones=["zone-a"],
         )
@@ -72,7 +85,10 @@ class TestImpactedObjectsModel:
 
 
 class TestIncidentModel:
+    """Tests for IncidentModel."""
+
     def test_valid_incident(self):
+        """Test that a valid incident is accepted."""
         model = IncidentModel(
             incident_id="21818c4a-8353-4d9c-ae3e-ae90004d4662",
             title="Tenant has 14 raised alerts", severity="Informational",
@@ -84,6 +100,7 @@ class TestIncidentModel:
         assert model.status == "Raised"
 
     def test_with_impacted_objects(self):
+        """Test that primary_impacted_objects is parsed correctly."""
         model = IncidentModel(
             incident_id="test-id", title="Test", severity="High",
             status="Raised", product="NGFW",
@@ -92,6 +109,7 @@ class TestIncidentModel:
         assert model.primary_impacted_objects.device_ids == ["dev-1"]
 
     def test_optional_fields_default_none(self):
+        """Test that optional fields default to None."""
         model = IncidentModel(
             incident_id="test-id", title="Test", severity="High",
             status="Raised", product="NGFW",
@@ -103,7 +121,10 @@ class TestIncidentModel:
 
 
 class TestAlertModel:
+    """Tests for AlertModel."""
+
     def test_valid_alert(self):
+        """Test that a valid alert is accepted."""
         model = AlertModel(
             alert_id="0a887db4-d760-4dc2-bb14-04c5e120b811",
             severity="Critical", state="Raised",
@@ -114,7 +135,10 @@ class TestAlertModel:
 
 
 class TestIncidentDetailModel:
+    """Tests for IncidentDetailModel."""
+
     def test_extends_incident_model(self):
+        """Test that detail model includes description and alerts."""
         model = IncidentDetailModel(
             incident_id="test-id", title="Test incident", severity="Critical",
             status="Raised", product="NGFW", description="Test description",
@@ -128,6 +152,7 @@ class TestIncidentDetailModel:
         assert model.alerts[0].alert_id == "alert-1"
 
     def test_optional_detail_fields(self):
+        """Test that optional detail fields default to None."""
         model = IncidentDetailModel(
             incident_id="test-id", title="Test", severity="High",
             status="Raised", product="NGFW",
@@ -139,7 +164,10 @@ class TestIncidentDetailModel:
 
 
 class TestIncidentSearchResponseModel:
+    """Tests for IncidentSearchResponseModel."""
+
     def test_valid_response(self):
+        """Test that a valid response with data is parsed correctly."""
         model = IncidentSearchResponseModel(
             header={"createdAt": "2026-03-12T19:38:43Z", "dataCount": 1, "requestId": "test-123"},
             data=[{"incident_id": "test-id", "title": "Test", "severity": "High", "status": "Raised", "product": "NGFW"}],
@@ -148,6 +176,7 @@ class TestIncidentSearchResponseModel:
         assert model.data[0].incident_id == "test-id"
 
     def test_empty_data(self):
+        """Test that an empty data list is accepted."""
         model = IncidentSearchResponseModel(
             header={"createdAt": "2026-03-12T19:38:43Z", "dataCount": 0, "requestId": "test-123"},
             data=[],

--- a/tests/scm/models/operations/__init__.py
+++ b/tests/scm/models/operations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for operations models."""

--- a/tests/scm/models/operations/test_device_operations_models.py
+++ b/tests/scm/models/operations/test_device_operations_models.py
@@ -1,7 +1,7 @@
 """Tests for device operations models."""
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from scm.models.operations.device_operations import (
     DeviceJobDetailsModel,
@@ -13,45 +13,60 @@ from scm.models.operations.device_operations import (
 
 
 class TestDeviceOperationsRequestModel:
+    """Tests for DeviceOperationsRequestModel."""
+
     def test_valid_single_device(self):
+        """Test that a single valid device serial is accepted."""
         model = DeviceOperationsRequestModel(devices=["007951000123456"])
         assert len(model.devices) == 1
 
     def test_valid_five_devices(self):
+        """Test that five valid device serials are accepted."""
         devices = [f"00795100012345{i}" for i in range(5)]
         model = DeviceOperationsRequestModel(devices=devices)
         assert len(model.devices) == 5
 
     def test_empty_devices_rejected(self):
+        """Test that an empty devices list is rejected."""
         with pytest.raises(ValidationError):
             DeviceOperationsRequestModel(devices=[])
 
     def test_too_many_devices_rejected(self):
+        """Test that more than five devices are rejected."""
         devices = [f"00795100012345{i}" for i in range(6)]
         with pytest.raises(ValidationError):
             DeviceOperationsRequestModel(devices=devices)
 
     def test_invalid_serial_format_rejected(self):
+        """Test that a non-numeric serial is rejected."""
         with pytest.raises(ValidationError):
             DeviceOperationsRequestModel(devices=["abc"])
 
     def test_valid_14_digit_serial(self):
+        """Test that a 14-digit serial is accepted."""
         model = DeviceOperationsRequestModel(devices=["00795100012345"])
         assert model.devices[0] == "00795100012345"
 
     def test_valid_15_digit_serial(self):
+        """Test that a 15-digit serial is accepted."""
         model = DeviceOperationsRequestModel(devices=["007951000123456"])
         assert model.devices[0] == "007951000123456"
 
 
 class TestJobCreatedModel:
+    """Tests for JobCreatedModel."""
+
     def test_valid_job_id(self):
+        """Test that a valid job_id is accepted."""
         model = JobCreatedModel(job_id="550e8400-e29b-41d4-a716-446655440000")
         assert model.job_id == "550e8400-e29b-41d4-a716-446655440000"
 
 
 class TestDeviceJobDetailsModel:
+    """Tests for DeviceJobDetailsModel."""
+
     def test_valid_details(self):
+        """Test that valid details with result data are accepted."""
         model = DeviceJobDetailsModel(
             msg="Command completed successfully.",
             result={"router_global": {"3.3.3.3/32": [{"prefix": "3.3.3.3/32"}]}},
@@ -60,12 +75,16 @@ class TestDeviceJobDetailsModel:
         assert "router_global" in model.result
 
     def test_empty_result(self):
+        """Test that an empty result dict is accepted."""
         model = DeviceJobDetailsModel(msg="Pending.", result={})
         assert model.result == {}
 
 
 class TestDeviceJobResultModel:
+    """Tests for DeviceJobResultModel."""
+
     def test_valid_result(self):
+        """Test that a valid device job result is accepted."""
         model = DeviceJobResultModel(
             device="007951000123456",
             state="complete",
@@ -78,6 +97,7 @@ class TestDeviceJobResultModel:
         assert model.details.msg == "Command completed successfully."
 
     def test_valid_states(self):
+        """Test that all expected state values are accepted."""
         for state in ["pending", "in_progress", "complete", "failed"]:
             model = DeviceJobResultModel(
                 device="007951000123456",
@@ -90,7 +110,10 @@ class TestDeviceJobResultModel:
 
 
 class TestDeviceJobStatusModel:
+    """Tests for DeviceJobStatusModel."""
+
     def test_valid_complete_job(self):
+        """Test that a complete job status is parsed correctly."""
         model = DeviceJobStatusModel(
             jobId="ab123c4d-e56f-7g8h-901i-23jk4l5mn678",
             progress=100,
@@ -112,6 +135,7 @@ class TestDeviceJobStatusModel:
         assert len(model.results) == 1
 
     def test_in_progress_job(self):
+        """Test that an in-progress job with empty results is accepted."""
         model = DeviceJobStatusModel(
             jobId="test-job-id",
             progress=50,
@@ -124,6 +148,7 @@ class TestDeviceJobStatusModel:
         assert len(model.results) == 0
 
     def test_progress_bounds(self):
+        """Test that progress values outside 0-100 are rejected."""
         with pytest.raises(ValidationError):
             DeviceJobStatusModel(
                 jobId="test", progress=-1, state="pending",

--- a/tests/scm/models/operations/test_device_operations_models.py
+++ b/tests/scm/models/operations/test_device_operations_models.py
@@ -1,0 +1,136 @@
+"""Tests for device operations models."""
+
+import pytest
+from pydantic import ValidationError
+
+from scm.models.operations.device_operations import (
+    DeviceJobDetailsModel,
+    DeviceJobResultModel,
+    DeviceJobStatusModel,
+    DeviceOperationsRequestModel,
+    JobCreatedModel,
+)
+
+
+class TestDeviceOperationsRequestModel:
+    def test_valid_single_device(self):
+        model = DeviceOperationsRequestModel(devices=["007951000123456"])
+        assert len(model.devices) == 1
+
+    def test_valid_five_devices(self):
+        devices = [f"00795100012345{i}" for i in range(5)]
+        model = DeviceOperationsRequestModel(devices=devices)
+        assert len(model.devices) == 5
+
+    def test_empty_devices_rejected(self):
+        with pytest.raises(ValidationError):
+            DeviceOperationsRequestModel(devices=[])
+
+    def test_too_many_devices_rejected(self):
+        devices = [f"00795100012345{i}" for i in range(6)]
+        with pytest.raises(ValidationError):
+            DeviceOperationsRequestModel(devices=devices)
+
+    def test_invalid_serial_format_rejected(self):
+        with pytest.raises(ValidationError):
+            DeviceOperationsRequestModel(devices=["abc"])
+
+    def test_valid_14_digit_serial(self):
+        model = DeviceOperationsRequestModel(devices=["00795100012345"])
+        assert model.devices[0] == "00795100012345"
+
+    def test_valid_15_digit_serial(self):
+        model = DeviceOperationsRequestModel(devices=["007951000123456"])
+        assert model.devices[0] == "007951000123456"
+
+
+class TestJobCreatedModel:
+    def test_valid_job_id(self):
+        model = JobCreatedModel(job_id="550e8400-e29b-41d4-a716-446655440000")
+        assert model.job_id == "550e8400-e29b-41d4-a716-446655440000"
+
+
+class TestDeviceJobDetailsModel:
+    def test_valid_details(self):
+        model = DeviceJobDetailsModel(
+            msg="Command completed successfully.",
+            result={"router_global": {"3.3.3.3/32": [{"prefix": "3.3.3.3/32"}]}},
+        )
+        assert model.msg == "Command completed successfully."
+        assert "router_global" in model.result
+
+    def test_empty_result(self):
+        model = DeviceJobDetailsModel(msg="Pending.", result={})
+        assert model.result == {}
+
+
+class TestDeviceJobResultModel:
+    def test_valid_result(self):
+        model = DeviceJobResultModel(
+            device="007951000123456",
+            state="complete",
+            created_ts="2026-03-02 19:00:04",
+            updated_ts="2026-03-02 19:00:04",
+            details={"msg": "Command completed successfully.", "result": {}},
+        )
+        assert model.device == "007951000123456"
+        assert model.state == "complete"
+        assert model.details.msg == "Command completed successfully."
+
+    def test_valid_states(self):
+        for state in ["pending", "in_progress", "complete", "failed"]:
+            model = DeviceJobResultModel(
+                device="007951000123456",
+                state=state,
+                created_ts="2026-03-02 19:00:04",
+                updated_ts="2026-03-02 19:00:04",
+                details={"msg": "test", "result": {}},
+            )
+            assert model.state == state
+
+
+class TestDeviceJobStatusModel:
+    def test_valid_complete_job(self):
+        model = DeviceJobStatusModel(
+            jobId="ab123c4d-e56f-7g8h-901i-23jk4l5mn678",
+            progress=100,
+            state="complete",
+            request={"command": "show-advanced-routing-route", "devices": ["007951000123456"]},
+            results=[
+                {
+                    "device": "007951000123456",
+                    "state": "complete",
+                    "created_ts": "2026-03-02 19:00:04",
+                    "updated_ts": "2026-03-02 19:00:04",
+                    "details": {"msg": "Command completed successfully.", "result": {}},
+                }
+            ],
+        )
+        assert model.jobId == "ab123c4d-e56f-7g8h-901i-23jk4l5mn678"
+        assert model.progress == 100
+        assert model.state == "complete"
+        assert len(model.results) == 1
+
+    def test_in_progress_job(self):
+        model = DeviceJobStatusModel(
+            jobId="test-job-id",
+            progress=50,
+            state="in_progress",
+            request={"command": "show-advanced-routing-route", "devices": ["007951000123456"]},
+            results=[],
+        )
+        assert model.progress == 50
+        assert model.state == "in_progress"
+        assert len(model.results) == 0
+
+    def test_progress_bounds(self):
+        with pytest.raises(ValidationError):
+            DeviceJobStatusModel(
+                jobId="test", progress=-1, state="pending",
+                request={"command": "test", "devices": ["007951000123456"]}, results=[],
+            )
+        with pytest.raises(ValidationError):
+            DeviceJobStatusModel(
+                jobId="test", progress=101, state="pending",
+                request={"command": "test", "devices": ["007951000123456"]}, results=[],
+            )

--- a/tests/scm/models/operations/test_local_config_models.py
+++ b/tests/scm/models/operations/test_local_config_models.py
@@ -1,7 +1,7 @@
 """Tests for local config version models."""
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from scm.models.operations.local_config import LocalConfigVersionModel
 
@@ -10,6 +10,7 @@ class TestLocalConfigVersionModel:
     """Tests for LocalConfigVersionModel."""
 
     def test_valid_model(self):
+        """Test that a valid model with all required fields is accepted."""
         data = {
             "id": 1,
             "serial": "007951000123456",
@@ -24,6 +25,7 @@ class TestLocalConfigVersionModel:
         assert model.xfmed_version == "1.0.0-transformed"
 
     def test_optional_md5(self):
+        """Test that optional md5 field is accepted when provided."""
         data = {
             "id": 2,
             "serial": "007951000123456",
@@ -36,6 +38,7 @@ class TestLocalConfigVersionModel:
         assert model.md5 == "abc123def456"
 
     def test_md5_defaults_none(self):
+        """Test that md5 defaults to None when not provided."""
         data = {
             "id": 1,
             "serial": "007951000123456",
@@ -47,6 +50,7 @@ class TestLocalConfigVersionModel:
         assert model.md5 is None
 
     def test_missing_required_field(self):
+        """Test that missing required fields raise ValidationError."""
         data = {
             "id": 1,
             "serial": "007951000123456",
@@ -55,6 +59,7 @@ class TestLocalConfigVersionModel:
             LocalConfigVersionModel(**data)
 
     def test_timestamp_parsing(self):
+        """Test that timestamp string is stored correctly."""
         data = {
             "id": 1,
             "serial": "007951000123456",

--- a/tests/scm/models/operations/test_local_config_models.py
+++ b/tests/scm/models/operations/test_local_config_models.py
@@ -1,0 +1,66 @@
+"""Tests for local config version models."""
+
+import pytest
+from pydantic import ValidationError
+
+from scm.models.operations.local_config import LocalConfigVersionModel
+
+
+class TestLocalConfigVersionModel:
+    """Tests for LocalConfigVersionModel."""
+
+    def test_valid_model(self):
+        data = {
+            "id": 1,
+            "serial": "007951000123456",
+            "local_version": "1.0.0",
+            "timestamp": "2025-01-15T10:30:00Z",
+            "xfmed_version": "1.0.0-transformed",
+        }
+        model = LocalConfigVersionModel(**data)
+        assert model.id == 1
+        assert model.serial == "007951000123456"
+        assert model.local_version == "1.0.0"
+        assert model.xfmed_version == "1.0.0-transformed"
+
+    def test_optional_md5(self):
+        data = {
+            "id": 2,
+            "serial": "007951000123456",
+            "local_version": "1.0.0",
+            "timestamp": "2025-01-15T10:30:00Z",
+            "xfmed_version": "1.0.0-transformed",
+            "md5": "abc123def456",
+        }
+        model = LocalConfigVersionModel(**data)
+        assert model.md5 == "abc123def456"
+
+    def test_md5_defaults_none(self):
+        data = {
+            "id": 1,
+            "serial": "007951000123456",
+            "local_version": "1.0.0",
+            "timestamp": "2025-01-15T10:30:00Z",
+            "xfmed_version": "1.0.0-transformed",
+        }
+        model = LocalConfigVersionModel(**data)
+        assert model.md5 is None
+
+    def test_missing_required_field(self):
+        data = {
+            "id": 1,
+            "serial": "007951000123456",
+        }
+        with pytest.raises(ValidationError):
+            LocalConfigVersionModel(**data)
+
+    def test_timestamp_parsing(self):
+        data = {
+            "id": 1,
+            "serial": "007951000123456",
+            "local_version": "1.0.0",
+            "timestamp": "2025-01-15T10:30:00Z",
+            "xfmed_version": "1.0.0-transformed",
+        }
+        model = LocalConfigVersionModel(**data)
+        assert model.timestamp is not None

--- a/tests/scm/operations/__init__.py
+++ b/tests/scm/operations/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for operations services."""
+"""Tests for scm.operations."""

--- a/tests/scm/operations/__init__.py
+++ b/tests/scm/operations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for operations services."""

--- a/tests/scm/operations/test_device_operations.py
+++ b/tests/scm/operations/test_device_operations.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from scm.exceptions import JobTimeoutError
 from scm.models.operations.device_operations import (
@@ -18,6 +18,7 @@ class TestDeviceOperations:
 
     @pytest.fixture
     def mock_client(self):
+        """Create a mock API client."""
         client = MagicMock()
         client.get = MagicMock()
         client.post = MagicMock()
@@ -25,9 +26,11 @@ class TestDeviceOperations:
 
     @pytest.fixture
     def device_ops(self, mock_client):
+        """Create a DeviceOperations service instance with mock client."""
         return DeviceOperations(mock_client)
 
     def test_route_table_async(self, device_ops, mock_client):
+        """Test that route_table dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-123"}
         result = device_ops.route_table(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -38,6 +41,7 @@ class TestDeviceOperations:
         assert result.job_id == "test-job-123"
 
     def test_fib_table_async(self, device_ops, mock_client):
+        """Test that fib_table dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-456"}
         result = device_ops.fib_table(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -47,6 +51,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_dns_proxy_async(self, device_ops, mock_client):
+        """Test that dns_proxy dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-789"}
         result = device_ops.dns_proxy(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -56,6 +61,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_device_interfaces_async(self, device_ops, mock_client):
+        """Test that device_interfaces dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-abc"}
         result = device_ops.device_interfaces(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -65,6 +71,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_device_rules_async(self, device_ops, mock_client):
+        """Test that device_rules dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-def"}
         result = device_ops.device_rules(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -74,6 +81,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_bgp_policy_export_async(self, device_ops, mock_client):
+        """Test that bgp_policy_export dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-ghi"}
         result = device_ops.bgp_policy_export(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -83,6 +91,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_logging_service_status_async(self, device_ops, mock_client):
+        """Test that logging_service_status dispatches async job correctly."""
         mock_client.post.return_value = {"job_id": "test-job-jkl"}
         result = device_ops.logging_service_status(devices=["007951000123456"])
         mock_client.post.assert_called_once_with(
@@ -92,6 +101,7 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_multiple_devices(self, device_ops, mock_client):
+        """Test that multiple devices are sent in the request payload."""
         mock_client.post.return_value = {"job_id": "test-job-multi"}
         devices = ["007951000123456", "007951000123457", "007951000123458"]
         result = device_ops.route_table(devices=devices)
@@ -100,19 +110,23 @@ class TestDeviceOperations:
         assert isinstance(result, JobCreatedModel)
 
     def test_invalid_devices_rejected(self, device_ops):
+        """Test that an empty devices list raises ValidationError."""
         with pytest.raises(ValidationError):
             device_ops.route_table(devices=[])
 
     def test_too_many_devices_rejected(self, device_ops):
+        """Test that more than five devices raises ValidationError."""
         devices = [f"00795100012345{i}" for i in range(6)]
         with pytest.raises(ValidationError):
             device_ops.route_table(devices=devices)
 
     def test_invalid_serial_rejected(self, device_ops):
+        """Test that an invalid serial format raises ValidationError."""
         with pytest.raises(ValidationError):
             device_ops.route_table(devices=["invalid"])
 
     def test_get_job_status(self, device_ops, mock_client):
+        """Test that get_job_status returns parsed DeviceJobStatusModel."""
         mock_client.get.return_value = {
             "jobId": "test-job-123",
             "progress": 100,
@@ -134,6 +148,7 @@ class TestDeviceOperations:
 
     @patch("scm.operations.device_operations.time.sleep")
     def test_sync_mode_polls_until_complete(self, mock_sleep, device_ops, mock_client):
+        """Test that sync mode polls until job state is complete."""
         mock_client.post.return_value = {"job_id": "test-job-sync"}
         mock_client.get.side_effect = [
             {
@@ -160,6 +175,7 @@ class TestDeviceOperations:
     @patch("scm.operations.device_operations.time.sleep")
     @patch("scm.operations.device_operations.time.time")
     def test_sync_mode_timeout(self, mock_time, mock_sleep, device_ops, mock_client):
+        """Test that sync mode raises JobTimeoutError on timeout."""
         mock_client.post.return_value = {"job_id": "test-job-timeout"}
         mock_time.side_effect = [0, 0, 301]
         mock_client.get.return_value = {
@@ -174,6 +190,7 @@ class TestDeviceOperations:
 
     @patch("scm.operations.device_operations.time.sleep")
     def test_sync_mode_failed_job(self, mock_sleep, device_ops, mock_client):
+        """Test that sync mode returns failed status without raising."""
         mock_client.post.return_value = {"job_id": "test-job-fail"}
         mock_client.get.return_value = {
             "jobId": "test-job-fail", "progress": 100, "state": "failed",

--- a/tests/scm/operations/test_device_operations.py
+++ b/tests/scm/operations/test_device_operations.py
@@ -1,0 +1,185 @@
+"""Tests for DeviceOperations service."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from scm.exceptions import JobTimeoutError
+from scm.models.operations.device_operations import (
+    DeviceJobStatusModel,
+    JobCreatedModel,
+)
+from scm.operations.device_operations import DeviceOperations
+
+
+class TestDeviceOperations:
+    """Tests for the DeviceOperations service."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get = MagicMock()
+        client.post = MagicMock()
+        return client
+
+    @pytest.fixture
+    def device_ops(self, mock_client):
+        return DeviceOperations(mock_client)
+
+    def test_route_table_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-123"}
+        result = device_ops.route_table(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/route-table",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+        assert result.job_id == "test-job-123"
+
+    def test_fib_table_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-456"}
+        result = device_ops.fib_table(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/fib-table",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_dns_proxy_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-789"}
+        result = device_ops.dns_proxy(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/dns-proxy",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_device_interfaces_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-abc"}
+        result = device_ops.device_interfaces(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/device-interfaces",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_device_rules_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-def"}
+        result = device_ops.device_rules(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/device-rules",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_bgp_policy_export_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-ghi"}
+        result = device_ops.bgp_policy_export(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/bgp-policy-export",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_logging_service_status_async(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-jkl"}
+        result = device_ops.logging_service_status(devices=["007951000123456"])
+        mock_client.post.assert_called_once_with(
+            "/operations/v1/jobs/logging-service-forwarding-status",
+            json={"devices": ["007951000123456"]},
+        )
+        assert isinstance(result, JobCreatedModel)
+
+    def test_multiple_devices(self, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-multi"}
+        devices = ["007951000123456", "007951000123457", "007951000123458"]
+        result = device_ops.route_table(devices=devices)
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["devices"] == devices
+        assert isinstance(result, JobCreatedModel)
+
+    def test_invalid_devices_rejected(self, device_ops):
+        with pytest.raises(ValidationError):
+            device_ops.route_table(devices=[])
+
+    def test_too_many_devices_rejected(self, device_ops):
+        devices = [f"00795100012345{i}" for i in range(6)]
+        with pytest.raises(ValidationError):
+            device_ops.route_table(devices=devices)
+
+    def test_invalid_serial_rejected(self, device_ops):
+        with pytest.raises(ValidationError):
+            device_ops.route_table(devices=["invalid"])
+
+    def test_get_job_status(self, device_ops, mock_client):
+        mock_client.get.return_value = {
+            "jobId": "test-job-123",
+            "progress": 100,
+            "state": "complete",
+            "request": {"command": "show-advanced-routing-route", "devices": ["007951000123456"]},
+            "results": [{
+                "device": "007951000123456",
+                "state": "complete",
+                "created_ts": "2026-03-02 19:00:04",
+                "updated_ts": "2026-03-02 19:00:04",
+                "details": {"msg": "Command completed successfully.", "result": {}},
+            }],
+        }
+        result = device_ops.get_job_status("test-job-123")
+        mock_client.get.assert_called_once_with("/operations/v1/device/jobs/test-job-123")
+        assert isinstance(result, DeviceJobStatusModel)
+        assert result.state == "complete"
+        assert result.progress == 100
+
+    @patch("scm.operations.device_operations.time.sleep")
+    def test_sync_mode_polls_until_complete(self, mock_sleep, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-sync"}
+        mock_client.get.side_effect = [
+            {
+                "jobId": "test-job-sync", "progress": 50, "state": "in_progress",
+                "request": {"command": "test", "devices": ["007951000123456"]},
+                "results": [],
+            },
+            {
+                "jobId": "test-job-sync", "progress": 100, "state": "complete",
+                "request": {"command": "test", "devices": ["007951000123456"]},
+                "results": [{
+                    "device": "007951000123456", "state": "complete",
+                    "created_ts": "2026-03-02 19:00:04", "updated_ts": "2026-03-02 19:00:04",
+                    "details": {"msg": "Done.", "result": {}},
+                }],
+            },
+        ]
+        result = device_ops.route_table(devices=["007951000123456"], sync=True, poll_interval=1)
+        assert isinstance(result, DeviceJobStatusModel)
+        assert result.state == "complete"
+        assert mock_client.get.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("scm.operations.device_operations.time.sleep")
+    @patch("scm.operations.device_operations.time.time")
+    def test_sync_mode_timeout(self, mock_time, mock_sleep, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-timeout"}
+        mock_time.side_effect = [0, 0, 301]
+        mock_client.get.return_value = {
+            "jobId": "test-job-timeout", "progress": 50, "state": "in_progress",
+            "request": {"command": "test", "devices": ["007951000123456"]},
+            "results": [],
+        }
+        with pytest.raises(JobTimeoutError) as exc_info:
+            device_ops.route_table(devices=["007951000123456"], sync=True, timeout=300)
+        assert exc_info.value.job_id == "test-job-timeout"
+        assert exc_info.value.last_state == "in_progress"
+
+    @patch("scm.operations.device_operations.time.sleep")
+    def test_sync_mode_failed_job(self, mock_sleep, device_ops, mock_client):
+        mock_client.post.return_value = {"job_id": "test-job-fail"}
+        mock_client.get.return_value = {
+            "jobId": "test-job-fail", "progress": 100, "state": "failed",
+            "request": {"command": "test", "devices": ["007951000123456"]},
+            "results": [],
+        }
+        result = device_ops.route_table(devices=["007951000123456"], sync=True)
+        assert isinstance(result, DeviceJobStatusModel)
+        assert result.state == "failed"

--- a/tests/scm/operations/test_local_config.py
+++ b/tests/scm/operations/test_local_config.py
@@ -13,6 +13,7 @@ class TestLocalConfig:
 
     @pytest.fixture
     def mock_client(self):
+        """Create a mock API client."""
         client = MagicMock()
         client.get = MagicMock()
         client.post = MagicMock()
@@ -20,9 +21,11 @@ class TestLocalConfig:
 
     @pytest.fixture
     def local_config_service(self, mock_client):
+        """Create a LocalConfig service instance with mock client."""
         return LocalConfig(mock_client)
 
     def test_list_versions(self, local_config_service, mock_client):
+        """Test that list_versions returns parsed LocalConfigVersionModel list."""
         mock_client.get.return_value = [
             {
                 "id": 1,
@@ -52,6 +55,7 @@ class TestLocalConfig:
         assert versions[1].local_version == "0.9.0"
 
     def test_list_versions_empty(self, local_config_service, mock_client):
+        """Test that list_versions returns empty list when no versions exist."""
         mock_client.get.return_value = []
 
         versions = local_config_service.list_versions(device="007951000123456")
@@ -59,6 +63,7 @@ class TestLocalConfig:
         assert versions == []
 
     def test_download(self, local_config_service, mock_client):
+        """Test that download returns raw bytes content."""
         mock_response = Mock()
         mock_response.content = b"<config>xml content</config>"
         mock_client.get.return_value = mock_response

--- a/tests/scm/operations/test_local_config.py
+++ b/tests/scm/operations/test_local_config.py
@@ -1,0 +1,73 @@
+"""Tests for LocalConfig operations service."""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from scm.models.operations.local_config import LocalConfigVersionModel
+from scm.operations.local_config import LocalConfig
+
+
+class TestLocalConfig:
+    """Tests for the LocalConfig service."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get = MagicMock()
+        client.post = MagicMock()
+        return client
+
+    @pytest.fixture
+    def local_config_service(self, mock_client):
+        return LocalConfig(mock_client)
+
+    def test_list_versions(self, local_config_service, mock_client):
+        mock_client.get.return_value = [
+            {
+                "id": 1,
+                "serial": "007951000123456",
+                "local_version": "1.0.0",
+                "timestamp": "2025-01-15T10:30:00Z",
+                "xfmed_version": "1.0.0-transformed",
+            },
+            {
+                "id": 2,
+                "serial": "007951000123456",
+                "local_version": "0.9.0",
+                "timestamp": "2025-01-14T09:20:00Z",
+                "xfmed_version": "0.9.0-transformed",
+            },
+        ]
+
+        versions = local_config_service.list_versions(device="007951000123456")
+
+        mock_client.get.assert_called_once_with(
+            "/operations/v1/local-config/versions",
+            params={"device": "007951000123456"},
+        )
+        assert len(versions) == 2
+        assert isinstance(versions[0], LocalConfigVersionModel)
+        assert versions[0].id == 1
+        assert versions[1].local_version == "0.9.0"
+
+    def test_list_versions_empty(self, local_config_service, mock_client):
+        mock_client.get.return_value = []
+
+        versions = local_config_service.list_versions(device="007951000123456")
+
+        assert versions == []
+
+    def test_download(self, local_config_service, mock_client):
+        mock_response = Mock()
+        mock_response.content = b"<config>xml content</config>"
+        mock_client.get.return_value = mock_response
+
+        result = local_config_service.download(device="007951000123456", version="1")
+
+        mock_client.get.assert_called_once_with(
+            "/operations/v1/local-config/download",
+            params={"device": "007951000123456", "version": "1"},
+            raw_response=True,
+        )
+        assert result == b"<config>xml content</config>"

--- a/tests/scm/operations/test_local_config.py
+++ b/tests/scm/operations/test_local_config.py
@@ -24,6 +24,10 @@ class TestLocalConfig:
         """Create a LocalConfig service instance with mock client."""
         return LocalConfig(mock_client)
 
+    def test_get_headers_returns_empty(self, local_config_service):
+        """Test that base _get_headers returns empty dict."""
+        assert local_config_service._get_headers() == {}
+
     def test_list_versions(self, local_config_service, mock_client):
         """Test that list_versions returns parsed LocalConfigVersionModel list."""
         mock_client.get.return_value = [

--- a/tests/scm/test_client.py
+++ b/tests/scm/test_client.py
@@ -309,6 +309,21 @@ class TestClientRequest(TestClientBase):
         mock_response.json.assert_called_once()
         assert result == {"key": "value"}
 
+    def test_request_raw_response(self):
+        """Test that raw_response=True returns the Response object directly."""
+        mock_session = self.session
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.content = b"<xml>binary data</xml>"
+        mock_session.request.return_value = mock_response
+
+        result = self.client.request("GET", "/test-endpoint", raw_response=True)
+
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.json.assert_not_called()
+        assert result is mock_response
+
     # def test_request_http_error_no_content(self):
     #     """Test handling of HTTP errors with no content."""
     #     mock_session = self.session


### PR DESCRIPTION
## Summary

- Add SDK support for the **Operations API** (`/operations/v1/`) — device config version tracking, binary config downloads, and async device job dispatch (route table, FIB, DNS proxy, interfaces, rules, BGP policy export, logging status)
- Add SDK support for the **Incidents API** (`/incidents/v1/`) — unified incident search with filtering/pagination and incident detail retrieval
- Introduce `ServiceBase` — thin base class for non-CRUD services, routing all HTTP through the existing `Scm` client
- Add `region` parameter to `Scm` client for APIs requiring `X-PANW-Region` header
- Add `raw_response` support to `Scm.request()` for binary file downloads
- Add `JobTimeoutError` exception for sync polling timeouts
- Add comprehensive mkdocs documentation for all new services and models

### New Services

| Service | Access | Methods |
| --- | --- | --- |
| LocalConfig | `client.local_config` | `list_versions()`, `download()` |
| DeviceOperations | `client.device_operations` | `route_table()`, `fib_table()`, `dns_proxy()`, `device_interfaces()`, `device_rules()`, `bgp_policy_export()`, `logging_service_status()`, `get_job_status()` |
| Incidents | `client.incidents` | `search()`, `get_details()` |

### Files Changed

- 37 files changed, 2511 insertions
- 17 new source/model files
- 11 new test files (63 tests)
- 9 new doc pages + 5 updated docs

## Test plan

- [x] All 63 new tests pass
- [x] All 139 client + insights + new tests pass together
- [x] `make quality-basic` passes clean
- [x] No regressions in existing tests
- [x] Verify mkdocs site renders correctly with `make docs-serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new API surface area and modifies the core HTTP request path (`raw_response`) and client configuration (`region`), which could affect existing request/response handling if misused, though changes are additive and covered by new tests/docs.
> 
> **Overview**
> Adds first-class SDK support for the `/operations/v1` and `/incidents/v1` APIs via new `client.local_config`, `client.device_operations`, and `client.incidents` services (including new Pydantic models and tests), enabling incident search/detail retrieval and device job dispatch/polling plus local config version listing and binary config downloads.
> 
> Extends the core `Scm` client to support a default `region` (used to inject `X-PANW-Region` for region-scoped APIs) and `raw_response=True` request handling for non-JSON downloads, and introduces `JobTimeoutError` for synchronous device-job polling timeouts. Documentation and mkdocs navigation are updated to cover the new services and models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee0f94734258ab05eac9a479287f7400d34b6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->