### PR TITLE
fix: add py.typed marker for mypy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/cdot65/pan-scm-sdk"
 repository = "https://github.com/cdot65/pan-scm-sdk"
 documentation = "https://cdot65.github.io/pan-scm-sdk/"
 packages = [{ include = "scm" }]
+include = ["scm/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
## Summary

- Add empty `py.typed` marker file to `scm/` package so mypy recognizes the SDK as typed
- Add `include = ["scm/py.typed"]` to `pyproject.toml` to ensure the marker is included in wheel distributions

Closes #349

## Test plan

- [x] `touch .venv/.../scm/py.typed` workaround from issue confirmed to work
- [x] `py.typed` file created at `scm/py.typed`
- [x] `pyproject.toml` includes `py.typed` in package distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)