### PR TITLE
feat(setup/device): add Device.update() with correct devices-put schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-21
+
+### Added
+- **Device updates**: `scm.device.update()` wraps `PUT /config/setup/v1/devices/{id}`, enabling label/snippet attachment, folder moves, and display-name/description edits on enrolled devices. Request body follows the upstream `devices-put` schema exactly.
+- `labels` and `snippets` fields surfaced on `DeviceBaseModel` (and therefore `DeviceResponseModel`), replacing the prior `extra="allow"` pass-through.
+
+### Changed
+- **`DeviceUpdateModel`** rewritten as a standalone model matching the `devices-put` schema: accepts only `id`, `display_name`, `folder`, `description`, `labels`, `snippets`. Previously inherited `DeviceBaseModel`, which exposed read-only fields (`serial_number`, `hostname`, `is_connected`, `family`, `model`, etc.) that the API does not accept on PUT. Callers that were populating the unused update model will need to drop those read-only fields.
+
 ## [0.12.0] - 2026-02-24
 
 ### Added

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,19 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.14.0
+
+**Released:** April 2026
+
+### Added
+
+- **Device Update Support**: `client.device.update()` now wraps `PUT /config/setup/v1/devices/{id}`, letting you attach/detach labels and snippets, move a device into a different folder, or update its `display_name` / `description`. Request body matches the upstream `devices-put` schema exactly.
+- `labels` and `snippets` are now first-class fields on `DeviceBaseModel` / `DeviceResponseModel` (previously accessible only via `extra="allow"` pass-through).
+
+### Changed
+
+- **`DeviceUpdateModel`** is now a standalone model with exactly the six fields the API accepts on PUT: `id`, `display_name`, `folder`, `description`, `labels`, `snippets`. Fields that the API treats as read-only (e.g. `serial_number`, `hostname`, `is_connected`) are no longer accepted by the update model and will raise a validation error. This is a minor breaking change for anyone who was constructing `DeviceUpdateModel` with those fields — but since `Device.update()` did not exist prior to this release, no live code path should be affected.
+
 ## Version 0.13.0
 
 **Released:** April 2026

--- a/docs/sdk/config/setup/device.md
+++ b/docs/sdk/config/setup/device.md
@@ -1,35 +1,38 @@
 # Device Configuration Object
 
-Provides read-only access to device resources for listing, filtering, and retrieving devices in Palo Alto Networks Strata Cloud Manager.
+Provides access to device resources in Palo Alto Networks Strata Cloud Manager. Devices enroll out-of-band, so the SDK does not expose create or delete — but it does expose `update()` to modify the five writable fields defined by the upstream `devices-put` schema (`display_name`, `folder`, `description`, `labels`, `snippets`).
 
 ## Class Overview
 
-The `Device` class provides methods for listing, filtering, and retrieving device resources. This is a read-only resource supporting get, fetch, and list operations.
+The `Device` class supports listing, filtering, retrieving, and updating device resources.
 
 ### Methods
 
-| Method    | Description                  | Parameters         | Return Type                 |
-|-----------|------------------------------|--------------------|-----------------------------|
-| `get()`   | Retrieves a device by ID    | `device_id: str`   | `DeviceResponseModel`       |
-| `fetch()` | Gets device by name         | `name: str`        | `DeviceResponseModel`       |
-| `list()`  | Lists devices with filtering | `**filters`        | `List[DeviceResponseModel]` |
+| Method     | Description                   | Parameters                 | Return Type                 |
+|------------|-------------------------------|----------------------------|-----------------------------|
+| `get()`    | Retrieves a device by ID      | `device_id: str`           | `DeviceResponseModel`       |
+| `fetch()`  | Gets device by name           | `name: str`                | `DeviceResponseModel`       |
+| `list()`   | Lists devices with filtering  | `**filters`                | `List[DeviceResponseModel]` |
+| `update()` | Updates a device's metadata   | `device: DeviceUpdateModel` | `DeviceResponseModel`       |
 
 ### Model Attributes
 
-| Attribute       | Type | Required | Default | Description                       |
-|-----------------|------|----------|---------|-----------------------------------|
-| `name`          | str  | No       | None    | Device name                       |
-| `id`            | str  | Yes*     | None    | Unique device identifier          |
-| `display_name`  | str  | No       | None    | Display name for the device       |
-| `serial_number` | str  | No       | None    | Device serial number              |
-| `family`        | str  | No       | None    | Device family (e.g., 'vm')        |
-| `model`         | str  | No       | None    | Device model (e.g., 'PA-VM')      |
-| `folder`        | str  | No       | None    | Folder name containing the device |
-| `hostname`      | str  | No       | None    | Device hostname                   |
-| `type`          | str  | No       | None    | Device type (e.g., 'on-prem')     |
-| `device_only`   | bool | No       | None    | True if device-only entry         |
-| `is_connected`  | bool | No       | None    | Connection status                 |
-| `description`   | str  | No       | None    | Device description                |
+| Attribute       | Type       | Required | Default | Description                       |
+|-----------------|------------|----------|---------|-----------------------------------|
+| `name`          | str        | No       | None    | Device name                       |
+| `id`            | str        | Yes*     | None    | Unique device identifier          |
+| `display_name`  | str        | No       | None    | Display name for the device       |
+| `serial_number` | str        | No       | None    | Device serial number              |
+| `family`        | str        | No       | None    | Device family (e.g., 'vm')        |
+| `model`         | str        | No       | None    | Device model (e.g., 'PA-VM')      |
+| `folder`        | str        | No       | None    | Folder name containing the device |
+| `hostname`      | str        | No       | None    | Device hostname                   |
+| `type`          | str        | No       | None    | Device type (e.g., 'on-prem')     |
+| `device_only`   | bool       | No       | None    | True if device-only entry         |
+| `is_connected`  | bool       | No       | None    | Connection status                 |
+| `description`   | str        | No       | None    | Device description                |
+| `labels`        | List[str]  | No       | None    | Labels assigned to the device     |
+| `snippets`      | List[str]  | No       | None    | Snippets associated with the device |
 
 \* Only required for response models
 
@@ -128,6 +131,34 @@ print(f"Device: {device.name}")
 print(f"Model: {device.model}")
 print(f"Software Version: {device.software_version}")
 ```
+
+### Update a Device
+
+The upstream `PUT /config/setup/v1/devices/{id}` endpoint accepts only five writable fields: `display_name`, `folder`, `description`, `labels`, and `snippets`. Pass a `DeviceUpdateModel` with the device's `id` plus any subset of those fields.
+
+```python
+from scm.models.setup.device import DeviceUpdateModel
+
+# Attach labels to a device
+updated = client.device.update(
+    DeviceUpdateModel(
+        id="001122334455",
+        labels=["production", "datacenter-1"],
+    )
+)
+
+# Move a device into a different folder and rename it
+updated = client.device.update(
+    DeviceUpdateModel(
+        id="001122334455",
+        folder="Prod",
+        display_name="edge-fw-1",
+        description="Edge firewall, east region",
+    )
+)
+```
+
+Fields not listed in `DeviceUpdateModel` (e.g. `serial_number`, `hostname`, `is_connected`) are not accepted by the API and will raise a validation error at the SDK layer.
 
 ## Error Handling
 

--- a/docs/sdk/models/setup/device_models.md
+++ b/docs/sdk/models/setup/device_models.md
@@ -37,6 +37,8 @@ The `DeviceResponseModel` uses `extra="allow"` to accommodate new API fields.
 | `device_only` | `bool` | No       | None    | True if device-only entry          |
 | `is_connected` | `bool` | No       | None    | Connection status                  |
 | `description` | `str` | No       | None    | Device description                 |
+| `labels` | `List[str]` | No       | None    | Labels assigned to the device      |
+| `snippets` | `List[str]` | No       | None    | Snippets associated with the device |
 
 ### DeviceCreateModel
 
@@ -44,11 +46,16 @@ Inherits all fields from `DeviceBaseModel` without additional fields.
 
 ### DeviceUpdateModel
 
-Extends `DeviceBaseModel` by adding:
+Request body for `PUT /config/setup/v1/devices/{id}`. This is a standalone model — it does **not** inherit from `DeviceBaseModel`. The upstream `devices-put` schema only accepts the five writable fields listed below; `serial_number`, `hostname`, `is_connected`, `family`, `model`, `name`, and `type` are read-only and rejected by the update model.
 
-| Attribute | Type | Required | Default | Description                              |
-|-----------|------|----------|---------|------------------------------------------|
-| `id` | `str` | Yes      | None    | Unique device identifier (serial number) |
+| Attribute      | Type        | Required | Default | Description                              |
+|----------------|-------------|----------|---------|------------------------------------------|
+| `id`           | `str`       | Yes      | —       | Unique device identifier (carried in URL, not payload) |
+| `display_name` | `str`       | No       | None    | Display name for the device              |
+| `folder`       | `str`       | No       | None    | Folder containing the device             |
+| `description`  | `str`       | No       | None    | Device description                       |
+| `labels`       | `List[str]` | No       | None    | Labels to assign to the device           |
+| `snippets`     | `List[str]` | No       | None    | Snippets to associate with the device    |
 
 ### DeviceResponseModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.13.0"
+version = "0.14.0"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"

--- a/scm/config/setup/device.py
+++ b/scm/config/setup/device.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 # Local SDK imports
 from scm.config import BaseObject
 from scm.exceptions import APIError, InvalidObjectError, ObjectNotPresentError
-from scm.models.setup.device import DeviceResponseModel
+from scm.models.setup.device import DeviceResponseModel, DeviceUpdateModel
 
 
 class Device(BaseObject):
@@ -160,6 +160,40 @@ class Device(BaseObject):
             if device.name == name:
                 return device
         return None
+
+    def update(
+        self,
+        device: DeviceUpdateModel,
+    ) -> DeviceResponseModel:
+        """Update an existing device via PUT /config/setup/v1/devices/{id}.
+
+        Only the fields defined in DeviceUpdateModel (display_name, folder,
+        description, labels, snippets) are accepted by the upstream API.
+
+        Args:
+            device: A DeviceUpdateModel with the id of the device to update
+                plus any subset of the writable fields.
+
+        Returns:
+            DeviceResponseModel: The device as returned by the API after update.
+
+        Raises:
+            ObjectNotPresentError: If no device exists with the given id.
+            APIError: If the API request fails for any other reason.
+
+        """
+        payload = device.model_dump(exclude_unset=True)
+        object_id = payload.pop("id")
+        endpoint = f"{self.ENDPOINT}/{object_id}"
+        try:
+            response = self.api_client.put(endpoint, json=payload)
+        except APIError as e:
+            if getattr(e, "http_status_code", None) == 404:
+                raise ObjectNotPresentError(f"Device with ID {object_id} not found")
+            raise
+        if isinstance(response, list) and response:
+            return DeviceResponseModel.model_validate(response[0])
+        return DeviceResponseModel.model_validate(response)
 
     @staticmethod
     def _apply_filters(

--- a/scm/models/setup/device.py
+++ b/scm/models/setup/device.py
@@ -77,6 +77,8 @@ class DeviceBaseModel(BaseModel):
         None, alias="isConnected", description="Connection status."
     )
     description: Optional[str] = Field(None, description="Device description.")
+    labels: Optional[List[str]] = Field(None, description="Labels assigned to the device.")
+    snippets: Optional[List[str]] = Field(None, description="Snippets associated with the device.")
 
 
 class DeviceCreateModel(DeviceBaseModel):
@@ -88,15 +90,26 @@ class DeviceCreateModel(DeviceBaseModel):
     pass
 
 
-class DeviceUpdateModel(DeviceBaseModel):
-    """Model for updating existing Device resources.
+class DeviceUpdateModel(BaseModel):
+    """Request body for PUT /config/setup/v1/devices/{id}.
 
-    Attributes:
-        id: The unique identifier of the device to update.
-
+    Matches the upstream `devices-put` schema exactly: only the writable fields
+    plus `id` (which is carried in the URL, not the payload).
     """
 
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
     id: str = Field(..., description="Unique device identifier (serial number).")
+    display_name: Optional[str] = Field(
+        None, alias="displayName", description="Display name for the device."
+    )
+    folder: Optional[str] = Field(None, description="Folder containing the device.")
+    description: Optional[str] = Field(None, description="Device description.")
+    labels: Optional[List[str]] = Field(None, description="Labels assigned to the device.")
+    snippets: Optional[List[str]] = Field(None, description="Snippets associated with the device.")
 
 
 class DeviceResponseModel(DeviceBaseModel):

--- a/tests/scm/config/setup/test_device.py
+++ b/tests/scm/config/setup/test_device.py
@@ -605,3 +605,11 @@ class TestDeviceUpdate(TestDeviceBase):
         mock_scm_client.put.side_effect = APIError("boom", http_status_code=500)
         with pytest.raises(APIError):
             device_service.update(self._update_model(folder="Prod"))
+
+    def test_update_unwraps_list_response(self, device_service, mock_scm_client):
+        """If the API returns a single-element list (matching get() behavior), unwrap it."""
+        mock_scm_client.put.return_value = [{"id": "abc-123", "name": "edge-1"}]
+        result = device_service.update(self._update_model(folder="Prod"))
+        assert isinstance(result, DeviceResponseModel)
+        assert result.id == "abc-123"
+        assert result.name == "edge-1"

--- a/tests/scm/config/setup/test_device.py
+++ b/tests/scm/config/setup/test_device.py
@@ -530,3 +530,78 @@ class TestDeviceListServerSideFilters(TestDeviceBase):
         mock_scm_client.get.return_value = {"data": []}
         device_service.list(model="PA-VM")
         assert mock_scm_client.get.call_args[1]["params"]["model"] == "PA-VM"
+
+
+class TestDeviceUpdate(TestDeviceBase):
+    """Tests for Device.update — wraps PUT /config/setup/v1/devices/{id}."""
+
+    def _update_model(self, **kwargs):
+        """Build a DeviceUpdateModel with id plus any overrides."""
+        from scm.models.setup.device import DeviceUpdateModel
+
+        data = {"id": "abc-123"}
+        data.update(kwargs)
+        return DeviceUpdateModel.model_validate(data)
+
+    def test_update_puts_to_correct_url(self, device_service, mock_scm_client):
+        """PUT targets /config/setup/v1/devices/{id}."""
+        mock_scm_client.put.return_value = {"id": "abc-123"}
+        device_service.update(self._update_model(labels=["prod"]))
+        assert mock_scm_client.put.call_args[0][0] == "/config/setup/v1/devices/abc-123"
+
+    def test_update_payload_excludes_id_and_unset(self, device_service, mock_scm_client):
+        """Payload excludes id (in URL) and any field the caller didn't set."""
+        mock_scm_client.put.return_value = {"id": "abc-123"}
+        device_service.update(self._update_model(labels=["prod", "east"]))
+        payload = mock_scm_client.put.call_args[1]["json"]
+        assert "id" not in payload
+        assert payload == {"labels": ["prod", "east"]}
+
+    def test_update_attaches_labels_and_snippets(self, device_service, mock_scm_client):
+        """Attach multiple writable fields at once."""
+        mock_scm_client.put.return_value = {
+            "id": "abc-123",
+            "labels": ["prod"],
+            "snippets": ["baseline"],
+            "folder": "Prod",
+        }
+        result = device_service.update(
+            self._update_model(
+                labels=["prod"],
+                snippets=["baseline"],
+                folder="Prod",
+                display_name="edge-1",
+                description="Edge firewall",
+            )
+        )
+        payload = mock_scm_client.put.call_args[1]["json"]
+        assert payload == {
+            "labels": ["prod"],
+            "snippets": ["baseline"],
+            "folder": "Prod",
+            "display_name": "edge-1",
+            "description": "Edge firewall",
+        }
+        assert result.id == "abc-123"
+        assert result.labels == ["prod"]
+        assert result.snippets == ["baseline"]
+
+    def test_update_returns_response_model(self, device_service, mock_scm_client):
+        """Response is revalidated into a DeviceResponseModel."""
+        mock_scm_client.put.return_value = {"id": "abc-123", "name": "edge-1"}
+        result = device_service.update(self._update_model(folder="Prod"))
+        assert isinstance(result, DeviceResponseModel)
+        assert result.id == "abc-123"
+        assert result.name == "edge-1"
+
+    def test_update_404_raises_object_not_present(self, device_service, mock_scm_client):
+        """A 404 from the API becomes ObjectNotPresentError."""
+        mock_scm_client.put.side_effect = APIError("not found", http_status_code=404)
+        with pytest.raises(ObjectNotPresentError):
+            device_service.update(self._update_model(folder="Prod"))
+
+    def test_update_other_errors_propagate(self, device_service, mock_scm_client):
+        """Non-404 API errors propagate unchanged."""
+        mock_scm_client.put.side_effect = APIError("boom", http_status_code=500)
+        with pytest.raises(APIError):
+            device_service.update(self._update_model(folder="Prod"))

--- a/tests/scm/models/setup/test_device.py
+++ b/tests/scm/models/setup/test_device.py
@@ -128,6 +128,72 @@ class TestDeviceResponseModel:
         assert hasattr(model, "__pydantic_extra__")
 
 
+class TestDeviceBaseModelLabelsAndSnippets:
+    """Labels and snippets are writable metadata per the devices-put schema."""
+
+    def test_labels_accepted_on_base(self):
+        """DeviceBaseModel accepts a labels list."""
+        model = DeviceBaseModel.model_validate({"name": "d", "labels": ["prod", "east"]})
+        assert model.labels == ["prod", "east"]
+
+    def test_snippets_accepted_on_base(self):
+        """DeviceBaseModel accepts a snippets list."""
+        model = DeviceBaseModel.model_validate({"name": "d", "snippets": ["s1", "s2"]})
+        assert model.snippets == ["s1", "s2"]
+
+    def test_labels_default_none(self):
+        """Labels default to None when omitted."""
+        model = DeviceBaseModel.model_validate({"name": "d"})
+        assert model.labels is None
+        assert model.snippets is None
+
+
+class TestDeviceUpdateModel:
+    """DeviceUpdateModel must match the devices-put OpenAPI schema exactly."""
+
+    def test_minimal_valid_payload(self):
+        """Id alone is a valid payload (all writable fields are optional)."""
+        model = DeviceUpdateModel.model_validate({"id": "abc-123"})
+        assert model.id == "abc-123"
+
+    def test_all_writable_fields(self):
+        """Accept all five writable fields plus id."""
+        data = {
+            "id": "abc-123",
+            "display_name": "edge-1",
+            "folder": "Prod",
+            "description": "Edge firewall",
+            "labels": ["prod", "east"],
+            "snippets": ["baseline"],
+        }
+        model = DeviceUpdateModel.model_validate(data)
+        assert model.labels == ["prod", "east"]
+        assert model.snippets == ["baseline"]
+        assert model.folder == "Prod"
+
+    def test_id_required(self):
+        """Omitting id is a validation error."""
+        with pytest.raises(ValidationError):
+            DeviceUpdateModel.model_validate({"folder": "Prod"})
+
+    @pytest.mark.parametrize(
+        "field",
+        ["serial_number", "hostname", "family", "model", "is_connected", "name", "type"],
+    )
+    def test_non_writable_fields_rejected(self, field):
+        """Fields not in devices-put must be rejected by the update model."""
+        data = {"id": "abc-123", field: "whatever"}
+        with pytest.raises(ValidationError) as exc_info:
+            DeviceUpdateModel.model_validate(data)
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+
+    def test_payload_excludes_unset(self):
+        """model_dump(exclude_unset=True) omits fields not provided."""
+        model = DeviceUpdateModel.model_validate({"id": "abc", "labels": ["x"]})
+        payload = model.model_dump(exclude_unset=True)
+        assert payload == {"id": "abc", "labels": ["x"]}
+
+
 class TestDeviceListResponseModel:
     """Tests for device list response model validation."""
 


### PR DESCRIPTION
## Summary

- Adds `Device.update()` wrapping `PUT /config/setup/v1/devices/{id}`, enabling label/snippet attachment, folder moves, and display-name/description edits on enrolled devices.
- Rewrites `DeviceUpdateModel` to match the upstream `devices-put` schema exactly (`id`, `display_name`, `folder`, `description`, `labels`, `snippets`). The previous model inherited `DeviceBaseModel` and exposed read-only fields the API does not accept.
- Surfaces `labels` and `snippets` as first-class fields on `DeviceBaseModel` / `DeviceResponseModel`, replacing reliance on `extra="allow"` pass-through.
- Bumps version `0.13.0 → 0.14.0` and updates `CHANGELOG.md` + `docs/about/release-notes.md`.

## Why

The upstream OpenAPI spec (`openapi-specs/scm/config/**/setup/config-setup-feb-v1.yaml`) defines `PUT /devices/{id}` with a `devices-put` body whose whole purpose is to let clients attach metadata — most importantly `labels`. The SDK previously exposed only `get`/`fetch`/`list` on `Device`, forcing downstream consumers like `pan-scm-cli` to treat devices as read-only. This closes that gap and gives the CLI a plumbing path for device labeling.

## Scope

Out of scope: `create()` and `delete()` for devices. The spec does not expose `POST /devices` or `DELETE /devices/{id}` — devices enroll out-of-band.

## Open question

Version bump picked as **0.14.0** (minor — new public API, no breaking change to existing callers since `Device.update()` didn't exist). The `DeviceUpdateModel` shape change is technically breaking for anyone constructing that model directly, but there is no code path that consumed it. Confirm the minor bump is right before releasing.

## Test plan

- [x] New unit tests: `TestDeviceUpdate` (6 cases: URL, payload shape, label/snippet attach, response model, 404 → `ObjectNotPresentError`, other `APIError` propagates)
- [x] New model tests: `TestDeviceUpdateModel` (id required, all writable fields, 7 parametrized cases for rejected read-only fields, payload excludes-unset) + `TestDeviceBaseModelLabelsAndSnippets`
- [x] Full unit suite: `6062 passed, 211 deselected` (api/e2e/integration markers)
- [x] `ruff check`, `ruff format --check`, `flake8`, `mypy` all clean
- [x] `mkdocs build` succeeds (CI does not use `--strict`; pre-existing anchor-case warnings unchanged)

Closes #353