### PR TITLE
feat(mobile_agent): add agent profiles (application settings) service

### DIFF
--- a/docs/sdk/config/mobile_agent/agent_profiles.md
+++ b/docs/sdk/config/mobile_agent/agent_profiles.md
@@ -1,0 +1,154 @@
+# GlobalProtect Agent Profiles (Application Settings) Configuration Object
+
+Manages GlobalProtect agent profiles in Palo Alto Networks Strata Cloud Manager. Agent profiles control the GlobalProtect app behavior for mobile users: agent UI options, authentication overrides, gateways, app configuration (connect method, tunnel MTU), HIP collection, and more.
+
+!!! note
+    The Strata Cloud Manager UI refers to this resource as **App Settings** / **Application Settings** (under Workflows → GlobalProtect App). The underlying API resource is `agent-profiles`.
+
+## Class Overview
+
+The `AgentProfiles` class inherits from `BaseObject` and provides CRUD operations for GlobalProtect agent profile objects.
+
+Unlike most SDK resources, the agent-profiles API exposes **no `/{id}` paths**: objects are addressed by `name` within the `Mobile Users` folder. Updates are sent to the collection endpoint and deletes are performed by name.
+
+### Methods
+
+| Method     | Description                          | Parameters                                | Return Type                              |
+|------------|--------------------------------------|-------------------------------------------|------------------------------------------|
+| `create()` | Creates a new agent profile          | `data: Dict[str, Any]`                    | `AgentProfilesResponseModel`             |
+| `update()` | Updates an existing profile by name  | `data: Dict[str, Any]`                    | `Optional[AgentProfilesResponseModel]`   |
+| `delete()` | Deletes an agent profile by name     | `name: str`, `folder: str`                | `None`                                   |
+| `list()`   | Lists profiles with filtering        | `folder: str`, `name: Optional[str]`, `**filters` | `List[AgentProfilesResponseModel]` |
+| `fetch()`  | Gets a profile by name and folder    | `name: str`, `folder: str`                | `AgentProfilesResponseModel`             |
+
+!!! note
+    `update()` returns `None` when the API responds with `200 OK` and no body (the documented behavior); use `fetch()` afterwards if you need the updated object.
+
+### Model Attributes
+
+| Attribute                              | Type                                  | Required | Description                                              |
+|----------------------------------------|---------------------------------------|----------|----------------------------------------------------------|
+| `name`                                 | str                                   | Yes      | Name of the agent profile                                |
+| `folder`                               | str                                   | Yes*     | Must be "Mobile Users" for all operations                |
+| `agent_ui`                             | AgentUI                               | No       | Agent UI options (passcode, overrides, welcome page)     |
+| `authentication_override`              | AuthenticationOverride                | No       | Authentication override cookie settings                  |
+| `certificate`                          | AgentProfileCertificate               | No       | Certificate profile matching criteria                    |
+| `client_certificate`                   | ClientCertificate                     | No       | Local or SCEP client certificate                         |
+| `custom_checks`                        | CustomChecks                          | No       | Custom plist/registry matching criteria                  |
+| `gateways`                             | Gateways                              | No       | External and internal gateway configuration              |
+| `gp_app_config`                        | GPAppConfig                           | No       | App config (connect-method, tunnel-mtu)                  |
+| `hip_collection`                       | HipCollection                         | No       | HIP data collection settings                             |
+| `internal_host_detection`              | InternalHostDetection                 | No       | Internal host detection (IPv4)                           |
+| `internal_host_detection_v6`           | InternalHostDetectionV6               | No       | Internal host detection (IPv6)                           |
+| `machine_account_exists_with_serialno` | MachineAccountExistsWithSerialno      | No       | Machine account exists with serial number setting        |
+| `os`                                   | List[AgentProfileOperatingSystem]     | No       | Operating systems the profile applies to                 |
+| `save_user_credentials`                | SaveUserCredentials                   | No       | Save user credentials behavior ("0"–"3")                 |
+| `source_user`                          | List[str]                             | No       | Source users the profile applies to                      |
+| `third_party_vpn_clients`              | List[ThirdPartyVpnClient]             | No       | Supported third party VPN clients                        |
+
+\* Required for create and update operations (sent as a query parameter)
+
+### Exceptions
+
+| Exception                    | HTTP Code | Description                          |
+|------------------------------|-----------|--------------------------------------|
+| `InvalidObjectError`         | 400       | Invalid profile data or folder value |
+| `MissingQueryParameterError` | 400       | Missing required parameters          |
+| `ObjectNotPresentError`      | 404       | Agent profile not found              |
+| `AuthenticationError`        | 401       | Authentication failed                |
+| `ServerError`                | 500       | Internal server error                |
+
+### Basic Configuration
+
+```python
+from scm.client import Scm
+
+client = Scm(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+agent_profiles = client.agent_profile
+```
+
+## Methods
+
+### List Agent Profiles
+
+```python
+profiles = client.agent_profile.list(folder="Mobile Users")
+
+for profile in profiles:
+    print(f"{profile.name}: os={profile.os}")
+```
+
+### Fetch an Agent Profile
+
+```python
+profile = client.agent_profile.fetch(name="windows-profile", folder="Mobile Users")
+print(profile.model_dump(exclude_unset=True))
+```
+
+### Create an Agent Profile
+
+```python
+profile_data = {
+    "name": "windows-profile",
+    "folder": "Mobile Users",
+    "os": ["Windows"],
+    "source_user": ["any"],
+    "agent_ui": {
+        "agent_user_override_timeout": 30,
+        "max_agent_user_overrides": 5,
+        "passcode": "secret-passcode",
+    },
+    "gp_app_config": {
+        "config": [
+            {"name": "connect-method", "value": ["user-logon"]},
+            {"name": "tunnel-mtu", "value": [1400]},
+        ]
+    },
+    "gateways": {
+        "external": {
+            "list": [
+                {
+                    "name": "us-east-gateway",
+                    "choice": {"fqdn": "gw.example.com"},
+                    "manual": True,
+                    "priority_rule": [{"name": "rule-1", "priority": "1"}],
+                }
+            ]
+        }
+    },
+}
+
+new_profile = client.agent_profile.create(profile_data)
+print(f"Created: {new_profile.name}")
+```
+
+### Update an Agent Profile
+
+```python
+update_data = {
+    "name": "windows-profile",   # addressed by name, no id
+    "folder": "Mobile Users",
+    "os": ["Windows", "Mac"],
+    "save_user_credentials": "1",
+}
+
+result = client.agent_profile.update(update_data)
+# The API returns 200 OK with no body; re-fetch if you need the updated object
+updated = client.agent_profile.fetch(name="windows-profile")
+```
+
+### Delete an Agent Profile
+
+```python
+client.agent_profile.delete(name="windows-profile", folder="Mobile Users")
+```
+
+## Related Documentation
+
+- [Agent Profiles Models](../../models/mobile_agent/agent_profiles_models.md)
+- [Mobile Agent Configuration Overview](index.md)

--- a/docs/sdk/config/mobile_agent/index.md
+++ b/docs/sdk/config/mobile_agent/index.md
@@ -12,6 +12,7 @@ This section covers the Mobile Agent configuration objects provided by the Palo 
 |--------------------------------------------------------|--------------------------------------------------------------------|
 | [Authentication Settings](auth_settings.md)            | Manage GlobalProtect authentication settings by OS                 |
 | [Agent Versions](agent_versions.md)                    | List and retrieve available GlobalProtect agent versions           |
+| [Application Settings (Agent Profiles)](agent_profiles.md) | Manage GlobalProtect agent profiles (App Settings in the SCM UI) |
 | [Global Settings](global_settings.md)                  | Manage the GlobalProtect global settings singleton                 |
 | [Infrastructure Settings](infrastructure_settings.md)  | Manage GlobalProtect infrastructure (DNS, IP pools, portal, WINS)  |
 | [Tunnel Profiles](tunnel_profiles.md)                  | Manage GlobalProtect tunnel settings (split tunneling)             |

--- a/docs/sdk/models/mobile_agent/agent_profiles_models.md
+++ b/docs/sdk/models/mobile_agent/agent_profiles_models.md
@@ -1,0 +1,87 @@
+# GlobalProtect Agent Profiles (Application Settings) Models
+
+Pydantic models for GlobalProtect agent profiles in Palo Alto Networks Strata Cloud Manager.
+
+!!! note
+    The Strata Cloud Manager UI refers to this resource as **App Settings** / **Application Settings**. The underlying API resource is `agent-profiles`.
+
+## Model Hierarchy
+
+| Model                        | Purpose                                                  |
+|------------------------------|----------------------------------------------------------|
+| `AgentProfilesBaseModel`     | Common fields shared across all operations               |
+| `AgentProfilesCreateModel`   | Creating new profiles (requires `folder="Mobile Users"`) |
+| `AgentProfilesUpdateModel`   | Updating profiles by name (requires `folder`)            |
+| `AgentProfilesResponseModel` | API responses (ignores unknown fields)                   |
+
+Agent profiles are addressed by `name` within the `Mobile Users` folder — there is no `id` field on any of these models.
+
+## Enums
+
+| Enum                          | Values                                                                  |
+|-------------------------------|-------------------------------------------------------------------------|
+| `AgentProfileOperatingSystem` | `Android`, `Chrome`, `IoT`, `Linux`, `Mac`, `Windows`, `WindowsUWP`, `iOS` |
+| `SaveUserCredentials`         | `"0"` (no), `"1"` (yes), `"2"` (username only), `"3"` (with fingerprint) |
+| `ThirdPartyVpnClient`         | `PAN Virtual Ethernet Adapter`, `Juniper Network Virtual Adapter`, `Cisco Systems VPN Adapter` |
+| `ConnectMethodValue`          | `user-logon`, `pre-logon`, `on-demand`, `pre-logon-then-on-demand`      |
+| `GatewayPriority`             | `"0"` (highest) through `"4"` (lowest), `"5"` (manual only)             |
+
+## Nested Models
+
+| Model                                | Description                                                       |
+|--------------------------------------|-------------------------------------------------------------------|
+| `AgentUI` / `WelcomePage`            | Agent UI options: override timeout/count, passcode, uninstall password, welcome page |
+| `AuthenticationOverride` / `AcceptCookie` / `CookieLifetime` | Authentication override cookie generation and lifetime |
+| `AgentProfileCertificate` / `CertificateCriteria` | Certificate profile matching criteria                |
+| `ClientCertificate`                  | Local or SCEP client certificate                                  |
+| `CustomChecks` / `CustomChecksCriteria` / `PlistEntry` / `PlistKeyEntry` / `RegistryKeyEntry` / `RegistryValueEntry` | Custom plist (macOS) and registry (Windows) matching criteria |
+| `Gateways` / `ExternalGateways` / `ExternalGatewayEntry` / `InternalGateways` / `InternalGatewayEntry` / `GatewayChoice` / `GatewayAddress` / `GatewayPriorityRule` | External and internal gateway configuration |
+| `GPAppConfig` / `ConnectMethodAppConfig` / `TunnelMtuAppConfig` | App configuration entries (discriminated union on `name`) |
+| `HipCollection` / `HipCustomChecks` / `HipExclusion` (+ per-OS models) | HIP data collection, custom checks, and exclusions |
+| `InternalHostDetection` / `InternalHostDetectionV6` | Internal host detection by IPv4/IPv6 address and hostname |
+| `MachineAccountExistsWithSerialno`   | Machine account exists with serial number setting (`yes`/`no` empty objects) |
+
+### Validation Highlights
+
+- `folder` must be `"Mobile Users"` on all models; create and update additionally require it to be set.
+- `GatewayChoice` enforces exactly one of `fqdn` or `ip` (mirrors the API's `oneOf`).
+- `GPAppConfig.config` is a discriminated union: entries with `name="connect-method"` accept a single `ConnectMethodValue`; entries with `name="tunnel-mtu"` accept a single number between 1000 and 1420.
+- `AgentUI`: `agent_user_override_timeout` 0–65535, `max_agent_user_overrides` 0–25, `passcode` 6–64 chars, `uninstall_password` 6–32 chars.
+- `CookieLifetime`: days 1–365, hours 1–72, minutes 1–59.
+- `HipCollection.max_wait_time`: 10–60 seconds; macOS plist and Windows registry key entries require `name`.
+
+## Usage Example
+
+```python
+from scm.client import Scm
+from scm.models.mobile_agent.agent_profiles import (
+    AgentProfilesCreateModel,
+    AgentProfileOperatingSystem,
+)
+
+client = Scm(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+profile = AgentProfilesCreateModel(
+    name="windows-profile",
+    folder="Mobile Users",
+    os=[AgentProfileOperatingSystem.WINDOWS],
+    gp_app_config={
+        "config": [
+            {"name": "connect-method", "value": ["user-logon"]},
+            {"name": "tunnel-mtu", "value": [1400]},
+        ]
+    },
+)
+
+result = client.agent_profile.create(profile.model_dump(exclude_unset=True))
+print(f"Created: {result.name}")
+```
+
+## Related Documentation
+
+- [Agent Profiles Configuration](../../config/mobile_agent/agent_profiles.md)
+- [Mobile Agent Models Overview](index.md)

--- a/docs/sdk/models/mobile_agent/index.md
+++ b/docs/sdk/models/mobile_agent/index.md
@@ -20,6 +20,7 @@ Key model patterns:
 
 - [Authentication Settings Models](auth_settings_models.md) - Models for GlobalProtect authentication rules
 - [Agent Version Models](agent_versions_models.md) - Models for GlobalProtect agent version information
+- [Application Settings (Agent Profiles) Models](agent_profiles_models.md) - Models for GlobalProtect agent profiles (App Settings in the SCM UI)
 - [Global Settings Models](global_settings_models.md) - Models for the GlobalProtect global settings singleton
 - [Infrastructure Settings Models](infrastructure_settings_models.md) - Models for GlobalProtect infrastructure settings
 - [Tunnel Profiles Models](tunnel_profiles_models.md) - Models for GlobalProtect tunnel settings

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
           - Overview: sdk/config/mobile_agent/index.md
           - Authentication Settings: sdk/config/mobile_agent/auth_settings.md
           - Agent Versions: sdk/config/mobile_agent/agent_versions.md
+          - Application Settings (Agent Profiles): sdk/config/mobile_agent/agent_profiles.md
           - Global Settings: sdk/config/mobile_agent/global_settings.md
           - Infrastructure Settings: sdk/config/mobile_agent/infrastructure_settings.md
           - Tunnel Profiles: sdk/config/mobile_agent/tunnel_profiles.md
@@ -236,6 +237,7 @@ nav:
           - Overview: sdk/models/mobile_agent/index.md
           - Authentication Settings: sdk/models/mobile_agent/auth_settings_models.md
           - Agent Versions: sdk/models/mobile_agent/agent_versions_models.md
+          - Application Settings (Agent Profiles): sdk/models/mobile_agent/agent_profiles_models.md
           - Global Settings: sdk/models/mobile_agent/global_settings_models.md
           - Infrastructure Settings: sdk/models/mobile_agent/infrastructure_settings_models.md
           - Tunnel Profiles: sdk/models/mobile_agent/tunnel_profiles_models.md

--- a/scm/client.py
+++ b/scm/client.py
@@ -483,6 +483,10 @@ class Scm:
                 "scm.insights.alerts",
                 "Alerts",
             ),
+            "agent_profile": (
+                "scm.config.mobile_agent.agent_profiles",
+                "AgentProfiles",
+            ),
             "agent_version": (
                 "scm.config.mobile_agent.agent_versions",
                 "AgentVersions",

--- a/scm/config/mobile_agent/__init__.py
+++ b/scm/config/mobile_agent/__init__.py
@@ -1,6 +1,7 @@
 """scm.config.mobile_agent: Mobile Agent service classes."""
 # scm/config/mobile_agent/__init__.py
 
+from scm.config.mobile_agent.agent_profiles import AgentProfiles
 from scm.config.mobile_agent.agent_versions import AgentVersions
 from scm.config.mobile_agent.auth_settings import AuthSettings
 from scm.config.mobile_agent.global_settings import GlobalSettings
@@ -8,6 +9,7 @@ from scm.config.mobile_agent.infrastructure_settings import InfrastructureSettin
 from scm.config.mobile_agent.tunnel_profiles import TunnelProfiles
 
 __all__ = [
+    "AgentProfiles",
     "AgentVersions",
     "AuthSettings",
     "GlobalSettings",

--- a/scm/config/mobile_agent/agent_profiles.py
+++ b/scm/config/mobile_agent/agent_profiles.py
@@ -1,0 +1,368 @@
+"""Mobile Agent Agent Profiles (Application Settings) configuration service for Strata Cloud Manager SDK.
+
+Provides service class for managing GlobalProtect agent profiles via the SCM API. The
+SCM UI refers to this resource as "App Settings" / "Application Settings".
+"""
+
+# scm/config/mobile_agent/agent_profiles.py
+
+# Standard library imports
+import logging
+from typing import Any, Dict, List, Optional
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+from scm.models.mobile_agent import (
+    AgentProfilesCreateModel,
+    AgentProfilesResponseModel,
+    AgentProfilesUpdateModel,
+)
+
+
+class AgentProfiles(BaseObject):
+    """Manages GlobalProtect Agent Profiles (Application Settings) in Palo Alto Networks' Strata Cloud Manager.
+
+    Agent profiles are addressed by name within the 'Mobile Users' folder. Unlike most
+    SDK resources, the API exposes no `/{id}` paths for this resource: updates are
+    performed against the collection endpoint and deletes are performed by name.
+
+    Args:
+        api_client: The API client instance
+        max_limit (Optional[int]): Maximum number of objects to return in a single API request.
+            Defaults to 2500. Must be between 1 and 5000.
+
+    """
+
+    ENDPOINT = "/config/mobile-agent/v1/agent-profiles"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000  # Maximum allowed by the API
+
+    def __init__(
+        self,
+        api_client,
+        max_limit: Optional[int] = None,
+    ):
+        """Initialize the AgentProfiles service with the given API client.
+
+        Args:
+            api_client: The API client instance.
+            max_limit: Maximum number of items per API request. Defaults to API maximum.
+
+        """
+        super().__init__(api_client)
+        self.logger = logging.getLogger(__name__)
+
+        # Validate and set max_limit
+        self._max_limit = self._validate_max_limit(max_limit)
+
+    @property
+    def max_limit(self) -> int:
+        """Get the current maximum limit for API requests.
+
+        Returns:
+            int
+
+        """
+        return self._max_limit
+
+    @max_limit.setter
+    def max_limit(self, value: int) -> None:
+        """Set a new maximum limit for API requests.
+
+        Args:
+            value: The maximum number of items to return in a single API request.
+
+        """
+        self._max_limit = self._validate_max_limit(value)
+
+    def _validate_max_limit(self, limit: Optional[int]) -> int:
+        """Validate the max_limit parameter.
+
+        Args:
+            limit: The limit to validate
+
+        Returns:
+            int: The validated limit
+
+        Raises:
+            InvalidObjectError: If the limit is invalid
+
+        """
+        if limit is None:
+            return self.DEFAULT_MAX_LIMIT
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            raise InvalidObjectError(
+                message="max_limit must be an integer",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit type"},
+            )
+
+        if limit_int < 1:
+            raise InvalidObjectError(
+                message="max_limit must be greater than 0",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit value"},
+            )
+
+        if limit_int > self.ABSOLUTE_MAX_LIMIT:
+            raise InvalidObjectError(
+                message=f"max_limit cannot exceed {self.ABSOLUTE_MAX_LIMIT}",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "max_limit exceeds maximum allowed value"},
+            )
+
+        return limit_int
+
+    @staticmethod
+    def _validate_folder(folder: str) -> None:
+        """Validate that folder is 'Mobile Users'.
+
+        Args:
+            folder: The folder value to validate
+
+        Raises:
+            InvalidObjectError: If the folder is not 'Mobile Users'
+
+        """
+        if folder != "Mobile Users":
+            raise InvalidObjectError(
+                message="Folder must be 'Mobile Users' for GlobalProtect Agent Profiles",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid folder value"},
+            )
+
+    def create(
+        self,
+        data: Dict[str, Any],
+    ) -> AgentProfilesResponseModel:
+        """Create a new GlobalProtect Agent Profile object.
+
+        Args:
+            data: Dictionary containing the agent profile configuration. Must include
+                'folder' set to 'Mobile Users' (sent as a query parameter).
+
+        Returns:
+            AgentProfilesResponseModel
+
+        """
+        # Use the dictionary "data" to pass into Pydantic and return a modeled object
+        profile = AgentProfilesCreateModel(**data)
+
+        # Convert back to a Python dictionary, removing any unset fields and using aliases
+        payload = profile.model_dump(
+            exclude_unset=True,
+            by_alias=True,
+        )
+
+        # Send the new object to the remote API as JSON; folder is a query parameter
+        response: Dict[str, Any] = self.api_client.post(
+            self.ENDPOINT,
+            params={"folder": profile.folder},
+            json=payload,
+        )
+
+        # Return the API response as a new Pydantic object
+        return AgentProfilesResponseModel(**response)
+
+    def update(
+        self,
+        data: Dict[str, Any],
+    ) -> Optional[AgentProfilesResponseModel]:
+        """Update an existing GlobalProtect Agent Profile object.
+
+        The agent-profiles API has no `/{id}` path: the object is addressed by its
+        name within the folder, both carried in the request body / query parameters.
+
+        Args:
+            data: Dictionary containing the agent profile configuration. Must include
+                'name' and 'folder' set to 'Mobile Users'.
+
+        Returns:
+            Optional[AgentProfilesResponseModel]: The updated agent profile if the API
+                returns a body, otherwise None (the API returns 200 OK with no content).
+
+        """
+        # Use the dictionary "data" to pass into Pydantic and return a modeled object
+        profile = AgentProfilesUpdateModel(**data)
+
+        # Convert back to a Python dictionary, removing any unset fields and using aliases
+        payload = profile.model_dump(
+            exclude_unset=True,
+            by_alias=True,
+        )
+
+        # Send the updated object to the remote API as JSON; folder is a query parameter
+        response = self.api_client.put(
+            self.ENDPOINT,
+            params={"folder": profile.folder},
+            json=payload,
+        )
+
+        # The API returns 200 OK with no body for updates
+        if isinstance(response, dict) and response:
+            return AgentProfilesResponseModel(**response)
+        return None
+
+    def list(
+        self,
+        folder: str = "Mobile Users",
+        name: Optional[str] = None,
+        **filters,
+    ) -> List[AgentProfilesResponseModel]:
+        """List GlobalProtect Agent Profile objects with optional filtering.
+
+        Args:
+            folder: Folder name (defaults to "Mobile Users" as it's the only valid value)
+            name: Optional name to filter on server-side
+            **filters: Additional filters (not currently used but included for future expansion)
+
+        Returns:
+            List[AgentProfilesResponseModel]: A list of agent profile objects
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
+        """
+        self._validate_folder(folder)
+
+        params: Dict[str, Any] = {"folder": folder}
+        if name is not None:
+            params["name"] = name
+
+        limit = self._max_limit
+        offset = 0
+        all_objects: List[AgentProfilesResponseModel] = []
+
+        try:
+            while True:
+                params.update({"limit": limit, "offset": offset})
+                response = self.api_client.get(
+                    self.ENDPOINT,
+                    params=params,
+                )
+
+                # Handle direct list response (no pagination metadata available)
+                if isinstance(response, list):
+                    all_objects.extend(AgentProfilesResponseModel(**item) for item in response)
+                    break
+
+                # Handle dict response with data array
+                if (
+                    isinstance(response, dict)
+                    and "data" in response
+                    and isinstance(response["data"], list)
+                ):
+                    data_items = response["data"]
+                    all_objects.extend(AgentProfilesResponseModel(**item) for item in data_items)
+                    if len(data_items) < limit:
+                        break
+                    offset += limit
+                    continue
+
+                # Handle unexpected response format
+                raise InvalidObjectError(
+                    message="Invalid response format: expected list or dictionary with 'data' field",
+                    error_code="E003",
+                    http_status_code=500,
+                    details={"error": "Response has invalid structure"},
+                )
+        except Exception as e:
+            self.logger.error(f"Error listing agent profiles: {str(e)}")
+            raise
+
+        return all_objects
+
+    def fetch(
+        self,
+        name: str,
+        folder: str = "Mobile Users",
+    ) -> AgentProfilesResponseModel:
+        """Fetch a single GlobalProtect Agent Profile by name.
+
+        Args:
+            name: The name of the agent profile to fetch
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Returns:
+            AgentProfilesResponseModel: The fetched agent profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        self._validate_folder(folder)
+
+        # Filter server-side by name, then confirm the exact match client-side
+        matching_profiles = [
+            profile for profile in self.list(folder=folder, name=name) if profile.name == name
+        ]
+
+        if not matching_profiles:
+            raise InvalidObjectError(
+                message=f"Agent profile '{name}' not found",
+                error_code="E002",
+                http_status_code=404,
+                details={"error": "No matching agent profile found"},
+            )
+
+        if len(matching_profiles) > 1:
+            self.logger.warning(f"Multiple agent profiles found for '{name}'. Using the first one.")
+
+        return matching_profiles[0]
+
+    def delete(
+        self,
+        name: str,
+        folder: str = "Mobile Users",
+    ) -> None:
+        """Delete a GlobalProtect Agent Profile object.
+
+        The agent-profiles API has no `/{id}` path: the object is deleted by its name
+        within the folder, both passed as query parameters.
+
+        Args:
+            name: The name of the agent profile to delete
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the folder is not 'Mobile Users'.
+
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        self._validate_folder(folder)
+
+        self.api_client.delete(
+            self.ENDPOINT,
+            params={"name": name, "folder": folder},
+        )

--- a/scm/models/mobile_agent/__init__.py
+++ b/scm/models/mobile_agent/__init__.py
@@ -1,6 +1,17 @@
 """scm.models.mobile_agent: Mobile Agent models."""
 # scm/models/deployment/__init__.py
 
+from .agent_profiles import (
+    AgentProfileOperatingSystem,
+    AgentProfilesBaseModel,
+    AgentProfilesCreateModel,
+    AgentProfilesResponseModel,
+    AgentProfilesUpdateModel,
+    ConnectMethodValue,
+    GatewayPriority,
+    SaveUserCredentials,
+    ThirdPartyVpnClient,
+)
 from .agent_versions import AgentVersionsModel
 from .auth_settings import (
     AuthSettingsBaseModel,
@@ -55,6 +66,15 @@ from .tunnel_profiles import (
 )
 
 __all__ = [
+    "AgentProfileOperatingSystem",
+    "AgentProfilesBaseModel",
+    "AgentProfilesCreateModel",
+    "AgentProfilesUpdateModel",
+    "AgentProfilesResponseModel",
+    "ConnectMethodValue",
+    "GatewayPriority",
+    "SaveUserCredentials",
+    "ThirdPartyVpnClient",
     "OperatingSystem",
     "AuthSettingsBaseModel",
     "AuthSettingsCreateModel",

--- a/scm/models/mobile_agent/agent_profiles.py
+++ b/scm/models/mobile_agent/agent_profiles.py
@@ -1,0 +1,1029 @@
+"""Agent Profiles (Application Settings) models for Strata Cloud Manager SDK.
+
+Contains Pydantic models for representing GlobalProtect agent profiles and their
+nested configuration structures. The SCM UI refers to this resource as
+"App Settings" / "Application Settings".
+"""
+
+# scm/models/mobile_agent/agent_profiles.py
+
+# Standard library imports
+from enum import Enum
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+# External libraries
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class AgentProfileOperatingSystem(str, Enum):
+    """Available operating systems for GlobalProtect agent profiles."""
+
+    ANDROID = "Android"
+    CHROME = "Chrome"
+    IOT = "IoT"
+    LINUX = "Linux"
+    MAC = "Mac"
+    WINDOWS = "Windows"
+    WINDOWS_UWP = "WindowsUWP"
+    IOS = "iOS"
+
+
+class SaveUserCredentials(str, Enum):
+    """Available save user credential options for GlobalProtect agent profiles.
+
+    Values map to the GlobalProtect agent behavior:
+        "0": No
+        "1": Yes
+        "2": Save username only
+        "3": Only with user fingerprint
+    """
+
+    NO = "0"
+    YES = "1"
+    SAVE_USERNAME_ONLY = "2"
+    ONLY_WITH_USER_FINGERPRINT = "3"
+
+
+class ThirdPartyVpnClient(str, Enum):
+    """Supported third party VPN clients for GlobalProtect agent profiles."""
+
+    PAN_VIRTUAL_ETHERNET_ADAPTER = "PAN Virtual Ethernet Adapter"
+    JUNIPER_NETWORK_VIRTUAL_ADAPTER = "Juniper Network Virtual Adapter"
+    CISCO_SYSTEMS_VPN_ADAPTER = "Cisco Systems VPN Adapter"
+
+
+class ConnectMethodValue(str, Enum):
+    """Available connect methods for the GlobalProtect app configuration."""
+
+    USER_LOGON = "user-logon"
+    PRE_LOGON = "pre-logon"
+    ON_DEMAND = "on-demand"
+    PRE_LOGON_THEN_ON_DEMAND = "pre-logon-then-on-demand"
+
+
+class GatewayPriority(str, Enum):
+    """Available priority values for external gateway priority rules."""
+
+    HIGHEST = "0"
+    HIGH = "1"
+    MEDIUM = "2"
+    LOW = "3"
+    LOWEST = "4"
+    MANUAL_ONLY = "5"
+
+
+class WelcomePage(BaseModel):
+    """The welcome page displayed upon login."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    page: Optional[str] = Field(
+        None,
+        description="The name of the welcome page",
+    )
+
+
+class AgentUI(BaseModel):
+    """Agent UI configuration settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    agent_user_override_timeout: Optional[int] = Field(
+        None,
+        ge=0,
+        le=65535,
+        description=(
+            "Agent disabled duration (minutes). A value of `0` means the agent will "
+            "remain disabled until manually enabled."
+        ),
+    )
+    max_agent_user_overrides: Optional[int] = Field(
+        None,
+        ge=0,
+        le=25,
+        description=(
+            "The maximum number of times the agent can be disabled. A value of `0` "
+            "means there are no limits to the number of times the agent can be disabled."
+        ),
+    )
+    passcode: Optional[str] = Field(
+        None,
+        min_length=6,
+        max_length=64,
+        description="The passcode used to disable the agent",
+    )
+    uninstall_password: Optional[str] = Field(
+        None,
+        min_length=6,
+        max_length=32,
+        description="The password used to uninstall the agent",
+    )
+    welcome_page: Optional[WelcomePage] = Field(
+        None,
+        description="The welcome page displayed upon login",
+    )
+
+
+class CookieLifetime(BaseModel):
+    """Authentication cookie lifetime configuration."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    lifetime_in_days: Optional[float] = Field(
+        None,
+        ge=1,
+        le=365,
+        description="Cookie lifetime in days",
+    )
+    lifetime_in_hours: Optional[float] = Field(
+        None,
+        ge=1,
+        le=72,
+        description="Cookie lifetime in hours",
+    )
+    lifetime_in_minutes: Optional[float] = Field(
+        None,
+        ge=1,
+        le=59,
+        description="Cookie lifetime in minutes",
+    )
+
+
+class AcceptCookie(BaseModel):
+    """Accept cookie configuration for authentication override."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    cookie_lifetime: Optional[CookieLifetime] = Field(
+        None,
+        description="The lifetime of the authentication override cookie",
+    )
+
+
+class AuthenticationOverride(BaseModel):
+    """Authentication override settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    accept_cookie: Optional[AcceptCookie] = Field(
+        None,
+        description="Accept an authentication override cookie",
+    )
+    cookie_encrypt_decrypt_cert: Optional[str] = Field(
+        None,
+        description="The certificate used to encrypt and decrypt the cookie",
+    )
+    generate_cookie: Optional[bool] = Field(
+        None,
+        description="Generate an authentication override cookie",
+    )
+
+
+class CertificateCriteria(BaseModel):
+    """Certificate criteria for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    certificate_profile: Optional[str] = Field(
+        None,
+        description="The certificate profile used to match this agent profile",
+    )
+
+
+class AgentProfileCertificate(BaseModel):
+    """Certificate settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    criteria: Optional[CertificateCriteria] = Field(
+        None,
+        description="The certificate matching criteria",
+    )
+
+
+class ClientCertificate(BaseModel):
+    """Client certificate settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    local: Optional[str] = Field(
+        None,
+        description="The local client certificate",
+    )
+    scep: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="The SCEP profile used to obtain the client certificate",
+    )
+
+
+class PlistKeyEntry(BaseModel):
+    """A plist key entry within a custom checks plist."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the plist key",
+    )
+    negate: Optional[bool] = Field(
+        None,
+        description="Whether to negate the key match",
+    )
+    value: Optional[str] = Field(
+        None,
+        max_length=1024,
+        description="The value of the plist key",
+    )
+
+
+class PlistEntry(BaseModel):
+    """A plist entry for custom checks criteria (macOS)."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the preference list",
+    )
+    key: Optional[List[PlistKeyEntry]] = Field(
+        None,
+        description="The plist keys to match",
+    )
+    negate: Optional[bool] = Field(
+        None,
+        description="Whether to negate the plist match",
+    )
+
+
+class RegistryValueEntry(BaseModel):
+    """A registry value entry within a custom checks registry key."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the registry value",
+    )
+    negate: Optional[bool] = Field(
+        None,
+        description="Whether to negate the registry value match",
+    )
+    value_data: Optional[str] = Field(
+        None,
+        description="The data of the registry value",
+    )
+
+
+class RegistryKeyEntry(BaseModel):
+    """A registry key entry for custom checks criteria (Windows)."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        max_length=1023,
+        description="The name of the registry key",
+    )
+    default_value_data: Optional[str] = Field(
+        None,
+        max_length=1024,
+        description="The default value data of the registry key",
+    )
+    negate: Optional[bool] = Field(
+        None,
+        description="Whether to negate the registry key match",
+    )
+    registry_value: Optional[List[RegistryValueEntry]] = Field(
+        None,
+        description="The registry values to match",
+    )
+
+
+class CustomChecksCriteria(BaseModel):
+    """Custom checks criteria for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    plist: Optional[List[PlistEntry]] = Field(
+        None,
+        description="The plist entries to match (macOS)",
+    )
+    registry_key: Optional[List[RegistryKeyEntry]] = Field(
+        None,
+        description="The registry keys to match (Windows)",
+    )
+
+
+class CustomChecks(BaseModel):
+    """Custom checks settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    criteria: Optional[CustomChecksCriteria] = Field(
+        None,
+        description="The custom checks matching criteria",
+    )
+
+
+class GatewayAddress(BaseModel):
+    """IP address of a GlobalProtect gateway."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    ipv4: Optional[str] = Field(
+        None,
+        pattern=r"^([:0-9.])+$",
+        max_length=100,
+        description="The IPv4 address of the gateway",
+    )
+    ipv6: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="The IPv6 address of the gateway",
+    )
+
+
+class GatewayChoice(BaseModel):
+    """Address of a GlobalProtect gateway, as either an FQDN or an IP address."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    fqdn: Optional[str] = Field(
+        None,
+        description="The FQDN of the gateway",
+    )
+    ip: Optional[GatewayAddress] = Field(
+        None,
+        description="The IP address of the gateway",
+    )
+
+    @model_validator(mode="after")
+    def validate_fqdn_or_ip(self) -> "GatewayChoice":
+        """Validate that exactly one of fqdn or ip is provided."""
+        if self.fqdn is not None and self.ip is not None:
+            raise ValueError("Exactly one of 'fqdn' or 'ip' must be provided, not both")
+        if self.fqdn is None and self.ip is None:
+            raise ValueError("Exactly one of 'fqdn' or 'ip' must be provided")
+        return self
+
+
+class GatewayPriorityRule(BaseModel):
+    """A priority rule for an external GlobalProtect gateway."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the priority rule",
+    )
+    priority: Optional[GatewayPriority] = Field(
+        None,
+        description="The priority of the gateway ('0' highest through '5' manual only)",
+    )
+
+
+class ExternalGatewayEntry(BaseModel):
+    """An external gateway entry for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the external gateway",
+    )
+    choice: Optional[GatewayChoice] = Field(
+        None,
+        description="The address of the gateway, as either an FQDN or an IP address",
+    )
+    manual: Optional[bool] = Field(
+        None,
+        description="If this GlobalProtect gateway can be manually selected",
+    )
+    priority_rule: Optional[List[GatewayPriorityRule]] = Field(
+        None,
+        description="The priority rules for the gateway",
+    )
+
+
+class ExternalGateways(BaseModel):
+    """External gateways configuration for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    list: Optional[List[ExternalGatewayEntry]] = Field(  # noqa: A003
+        None,
+        description="The list of external gateways",
+    )
+
+
+class InternalGatewayEntry(BaseModel):
+    """An internal gateway entry for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the internal gateway",
+    )
+    choice: Optional[GatewayChoice] = Field(
+        None,
+        description="The address of the gateway, as either an FQDN or an IP address",
+    )
+    source_ip: Optional[List[str]] = Field(
+        None,
+        description="The source IP addresses used to match this internal gateway",
+    )
+
+
+class InternalGateways(BaseModel):
+    """Internal gateways configuration for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    list: Optional[List[InternalGatewayEntry]] = Field(  # noqa: A003
+        None,
+        description="The list of internal gateways",
+    )
+
+
+class Gateways(BaseModel):
+    """Gateways configuration for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    external: Optional[ExternalGateways] = Field(
+        None,
+        description="The external gateways configuration",
+    )
+    internal: Optional[InternalGateways] = Field(
+        None,
+        description="The internal gateways configuration",
+    )
+
+
+class ConnectMethodAppConfig(BaseModel):
+    """The connect-method GlobalProtect app configuration entry."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Literal["connect-method"] = Field(
+        "connect-method",
+        description="The name of the app configuration entry",
+    )
+    value: Optional[List[ConnectMethodValue]] = Field(
+        None,
+        min_length=1,
+        max_length=1,
+        description="The connect method",
+    )
+
+
+class TunnelMtuAppConfig(BaseModel):
+    """The tunnel-mtu GlobalProtect app configuration entry."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Literal["tunnel-mtu"] = Field(
+        "tunnel-mtu",
+        description="The name of the app configuration entry",
+    )
+    value: Optional[List[Annotated[float, Field(ge=1000, le=1420)]]] = Field(
+        None,
+        min_length=1,
+        max_length=1,
+        description="GlobalProtect Connection MTU (bytes)",
+    )
+
+
+GPAppConfigEntry = Annotated[
+    Union[ConnectMethodAppConfig, TunnelMtuAppConfig],
+    Field(discriminator="name"),
+]
+
+
+class GPAppConfig(BaseModel):
+    """GlobalProtect app configuration for an agent profile.
+
+    Currently only connect-method and tunnel-mtu are supported as app-config.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    config: Optional[List[GPAppConfigEntry]] = Field(
+        None,
+        description="The app configuration entries (connect-method and tunnel-mtu)",
+    )
+
+
+class HipLinuxCustomChecks(BaseModel):
+    """Linux custom checks for HIP collection."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    process_list: Optional[List[str]] = Field(
+        None,
+        description="The processes to check for",
+    )
+
+
+class HipMacOsPlistEntry(BaseModel):
+    """A macOS plist entry for HIP collection custom checks."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: str = Field(
+        ...,
+        max_length=1023,
+        description="Preference list",
+    )
+    key: Optional[List[str]] = Field(
+        None,
+        description="The plist keys to collect",
+    )
+
+
+class HipMacOsCustomChecks(BaseModel):
+    """macOS custom checks for HIP collection."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    plist: Optional[List[HipMacOsPlistEntry]] = Field(
+        None,
+        description="The preference lists to collect",
+    )
+    process_list: Optional[List[str]] = Field(
+        None,
+        description="The processes to check for",
+    )
+
+
+class HipWindowsRegistryKey(BaseModel):
+    """A Windows registry key entry for HIP collection custom checks."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: str = Field(
+        ...,
+        max_length=1023,
+        description="Registry key",
+    )
+    registry_value: Optional[List[str]] = Field(
+        None,
+        description="The registry values to collect",
+    )
+
+
+class HipWindowsCustomChecks(BaseModel):
+    """Windows custom checks for HIP collection."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    process_list: Optional[List[str]] = Field(
+        None,
+        description="The processes to check for",
+    )
+    registry_key: Optional[List[HipWindowsRegistryKey]] = Field(
+        None,
+        description="The registry keys to collect",
+    )
+
+
+class HipCustomChecks(BaseModel):
+    """Custom checks for HIP collection, by operating system."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    linux: Optional[HipLinuxCustomChecks] = Field(
+        None,
+        description="Linux custom checks",
+    )
+    mac_os: Optional[HipMacOsCustomChecks] = Field(
+        None,
+        description="macOS custom checks",
+    )
+    windows: Optional[HipWindowsCustomChecks] = Field(
+        None,
+        description="Windows custom checks",
+    )
+
+
+class HipExclusionVendor(BaseModel):
+    """A vendor entry for a HIP collection exclusion category."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the vendor",
+    )
+    product: Optional[List[str]] = Field(
+        None,
+        description="The products of the vendor to exclude",
+    )
+
+
+class HipExclusionCategory(BaseModel):
+    """A category entry for HIP collection exclusion."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the category",
+    )
+    vendor: Optional[List[HipExclusionVendor]] = Field(
+        None,
+        description="The vendors to exclude",
+    )
+
+
+class HipExclusion(BaseModel):
+    """Exclusion settings for HIP collection."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    category: Optional[List[HipExclusionCategory]] = Field(
+        None,
+        description="The categories to exclude from HIP collection",
+    )
+
+
+class HipCollection(BaseModel):
+    """HIP collection settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    certificate_profile: Optional[str] = Field(
+        None,
+        description="The certificate profile used for HIP collection",
+    )
+    collect_hip_data: Optional[bool] = Field(
+        None,
+        description="Whether to collect HIP data",
+    )
+    custom_checks: Optional[HipCustomChecks] = Field(
+        None,
+        description="Custom checks for HIP collection",
+    )
+    exclusion: Optional[HipExclusion] = Field(
+        None,
+        description="Exclusion settings for HIP collection",
+    )
+    max_wait_time: Optional[float] = Field(
+        None,
+        ge=10,
+        le=60,
+        description="The maximum time (seconds) to wait for HIP data collection",
+    )
+
+
+class InternalHostDetection(BaseModel):
+    """Internal host detection (IPv4) settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    hostname: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9._-]+$",
+        max_length=256,
+        description="Host name of the IPv4 in DNS record",
+    )
+    ip_address: Optional[str] = Field(
+        None,
+        description="Internal IPv4 address of a host",
+    )
+
+
+class InternalHostDetectionV6(BaseModel):
+    """Internal host detection (IPv6) settings for a GlobalProtect agent profile."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    hostname: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9._-]+$",
+        max_length=256,
+        description="Host name of the IPv4 in DNS record",
+    )
+    ip_address: Optional[str] = Field(
+        None,
+        description="Internal IPv6 address of a host",
+    )
+
+
+class MachineAccountExistsWithSerialno(BaseModel):
+    """Machine account exists with serial number setting.
+
+    Exactly one of `yes` or `no` is expected to be set (each is an empty object
+    in the API payload).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+    yes: Optional[Dict[str, Any]] = Field(
+        None,
+        description="The machine account exists with the serial number",
+    )
+    no: Optional[Dict[str, Any]] = Field(
+        None,
+        description="The machine account does not exist with the serial number",
+    )
+
+
+class AgentProfilesBaseModel(BaseModel):
+    """Base model for GlobalProtect Agent Profiles containing fields common to all CRUD operations.
+
+    The SCM UI refers to this resource as "App Settings" / "Application Settings".
+
+    Attributes:
+        name (str): The name of the agent profile.
+        folder (Optional[str]): The folder in which the resource is defined (must be
+            'Mobile Users').
+        agent_ui (Optional[AgentUI]): Agent UI configuration settings.
+        authentication_override (Optional[AuthenticationOverride]): Authentication
+            override settings.
+        certificate (Optional[AgentProfileCertificate]): Certificate settings.
+        client_certificate (Optional[ClientCertificate]): Client certificate settings.
+        custom_checks (Optional[CustomChecks]): Custom checks settings.
+        gateways (Optional[Gateways]): Gateways configuration.
+        gp_app_config (Optional[GPAppConfig]): GlobalProtect app configuration.
+        hip_collection (Optional[HipCollection]): HIP collection settings.
+        internal_host_detection (Optional[InternalHostDetection]): Internal host
+            detection (IPv4) settings.
+        internal_host_detection_v6 (Optional[InternalHostDetectionV6]): Internal host
+            detection (IPv6) settings.
+        machine_account_exists_with_serialno (Optional[MachineAccountExistsWithSerialno]):
+            Machine account exists with serial number setting.
+        os (Optional[List[AgentProfileOperatingSystem]]): The operating systems this
+            agent profile applies to.
+        save_user_credentials (Optional[SaveUserCredentials]): Save user credentials
+            behavior.
+        source_user (Optional[List[str]]): The source users this agent profile
+            applies to.
+        third_party_vpn_clients (Optional[List[ThirdPartyVpnClient]]): The third party
+            VPN clients supported by this agent profile.
+
+    Error:
+        ValueError: Raised when validation fails for any field or when folder is not
+            'Mobile Users'.
+
+    """
+
+    # Pydantic model configuration
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    # Required fields
+    name: str = Field(
+        ...,
+        description="The name of the agent profile",
+    )
+
+    # Container fields
+    folder: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z\d\-_. ]+$",
+        max_length=64,
+        description="The folder in which the resource is defined",
+        examples=["Mobile Users"],
+    )
+
+    # Optional fields
+    agent_ui: Optional[AgentUI] = Field(
+        None,
+        description="Agent UI configuration settings",
+    )
+    authentication_override: Optional[AuthenticationOverride] = Field(
+        None,
+        description="Authentication override settings",
+    )
+    certificate: Optional[AgentProfileCertificate] = Field(
+        None,
+        description="Certificate settings",
+    )
+    client_certificate: Optional[ClientCertificate] = Field(
+        None,
+        description="Client certificate settings",
+    )
+    custom_checks: Optional[CustomChecks] = Field(
+        None,
+        description="Custom checks settings",
+    )
+    gateways: Optional[Gateways] = Field(
+        None,
+        description="Gateways configuration",
+    )
+    gp_app_config: Optional[GPAppConfig] = Field(
+        None,
+        description="GlobalProtect app configuration",
+    )
+    hip_collection: Optional[HipCollection] = Field(
+        None,
+        description="HIP collection settings",
+    )
+    internal_host_detection: Optional[InternalHostDetection] = Field(
+        None,
+        description="Internal host detection (IPv4) settings",
+    )
+    internal_host_detection_v6: Optional[InternalHostDetectionV6] = Field(
+        None,
+        description="Internal host detection (IPv6) settings",
+    )
+    machine_account_exists_with_serialno: Optional[MachineAccountExistsWithSerialno] = Field(
+        None,
+        description="Machine account exists with serial number setting",
+    )
+    os: Optional[List[AgentProfileOperatingSystem]] = Field(
+        None,
+        description="The operating systems this agent profile applies to",
+    )
+    save_user_credentials: Optional[SaveUserCredentials] = Field(
+        None,
+        description="Save user credentials behavior",
+    )
+    source_user: Optional[List[str]] = Field(
+        None,
+        description="The source users this agent profile applies to",
+    )
+    third_party_vpn_clients: Optional[List[ThirdPartyVpnClient]] = Field(
+        None,
+        description="The third party VPN clients supported by this agent profile",
+    )
+
+    @field_validator("folder")
+    def validate_folder(cls, v):  # noqa
+        """Validate that folder is 'Mobile Users' if provided."""
+        if v is not None and v != "Mobile Users":
+            raise ValueError("Folder must be 'Mobile Users' for GlobalProtect Agent Profiles")
+        return v
+
+
+class AgentProfilesCreateModel(AgentProfilesBaseModel):
+    """Represents the creation of a new GlobalProtect Agent Profile.
+
+    This class defines the structure and validation rules for creating agent profiles,
+    ensuring that folder is set to 'Mobile Users'.
+
+    Error:
+        ValueError: Raised when folder is not provided or not set to 'Mobile Users'.
+
+    """
+
+    @model_validator(mode="after")
+    def validate_container_type(self) -> "AgentProfilesCreateModel":
+        """Validate that folder is provided and set to 'Mobile Users'."""
+        if not self.folder:
+            raise ValueError("Folder is required for GlobalProtect Agent Profiles")
+        return self
+
+
+class AgentProfilesUpdateModel(AgentProfilesBaseModel):
+    """Represents the update of an existing GlobalProtect Agent Profile.
+
+    Agent profiles are addressed by name within the 'Mobile Users' folder (there is
+    no id in the update path), so both name and folder are required for updates.
+
+    Error:
+        ValueError: Raised when folder is not provided or not set to 'Mobile Users'.
+
+    """
+
+    @model_validator(mode="after")
+    def validate_container_type(self) -> "AgentProfilesUpdateModel":
+        """Validate that folder is provided and set to 'Mobile Users'."""
+        if not self.folder:
+            raise ValueError("Folder is required for GlobalProtect Agent Profiles")
+        return self
+
+
+class AgentProfilesResponseModel(AgentProfilesBaseModel):
+    """Represents the response model for GlobalProtect Agent Profiles.
+
+    This class defines the structure for agent profiles returned by the API.
+    """
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )

--- a/tests/scm/config/mobile_agent/test_agent_profiles.py
+++ b/tests/scm/config/mobile_agent/test_agent_profiles.py
@@ -1,0 +1,366 @@
+"""Test module for Mobile Agent Agent Profiles (Application Settings) configuration service.
+
+This module contains unit tests for the Mobile Agent Agent Profiles configuration service.
+"""
+# tests/scm/config/mobile_agent/test_agent_profiles.py
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scm.config.mobile_agent import AgentProfiles
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+from scm.models.mobile_agent import AgentProfilesResponseModel
+
+
+class TestAgentProfiles:
+    """Test cases for AgentProfiles mobile agent configuration."""
+
+    @pytest.fixture
+    def mock_api_client(self):
+        """Test fixture for mock API client."""
+        mock_client = MagicMock()
+        return mock_client
+
+    @pytest.fixture
+    def agent_profiles(self, mock_api_client):
+        """Test fixture for AgentProfiles instance."""
+        # Patch the isinstance check
+        with patch("scm.config.isinstance", return_value=True):
+            service = AgentProfiles(mock_api_client)
+            service.logger = MagicMock()
+            return service
+
+    def test_init_with_default_max_limit(self, mock_api_client):
+        """Test initialization with default max limit value."""
+        with patch("scm.config.isinstance", return_value=True):
+            service = AgentProfiles(mock_api_client)
+            assert service._max_limit == AgentProfiles.DEFAULT_MAX_LIMIT
+
+    def test_init_with_custom_max_limit(self, mock_api_client):
+        """Test initialization with custom max limit."""
+        with patch("scm.config.isinstance", return_value=True):
+            custom_limit = 1000
+            service = AgentProfiles(mock_api_client, max_limit=custom_limit)
+            assert service._max_limit == custom_limit
+
+    def test_validate_max_limit_with_invalid_type(self, agent_profiles):
+        """Test validate_max_limit with invalid type."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles._validate_max_limit("not_an_int")
+        error = excinfo.value
+        assert "Invalid max_limit type" in str(error.details)
+
+    def test_validate_max_limit_with_negative_value(self, agent_profiles):
+        """Test validate_max_limit with negative value."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles._validate_max_limit(-1)
+        error = excinfo.value
+        assert "Invalid max_limit value" in str(error.details)
+
+    def test_validate_max_limit_with_too_large_value(self, agent_profiles):
+        """Test validate_max_limit with value exceeding absolute max."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles._validate_max_limit(AgentProfiles.ABSOLUTE_MAX_LIMIT + 1)
+        error = excinfo.value
+        assert "max_limit exceeds maximum allowed value" in str(error.details)
+
+    def test_validate_max_limit_with_valid_value(self, agent_profiles):
+        """Test validate_max_limit with valid value."""
+        result = agent_profiles._validate_max_limit(1000)
+        assert result == 1000
+
+    def test_max_limit_property_getter(self, agent_profiles):
+        """Test max_limit property getter."""
+        agent_profiles._max_limit = 1000
+        assert agent_profiles.max_limit == 1000
+
+    def test_max_limit_property_setter(self, agent_profiles):
+        """Test max_limit property setter."""
+        agent_profiles._validate_max_limit = MagicMock(return_value=1000)
+        agent_profiles.max_limit = 1000
+        assert agent_profiles._max_limit == 1000
+
+    def test_create(self, agent_profiles, mock_api_client):
+        """Test create method for agent profiles."""
+        # Prepare test data
+        test_data = {
+            "name": "test-profile",
+            "folder": "Mobile Users",
+            "os": ["Windows"],
+            "gp_app_config": {"config": [{"name": "connect-method", "value": ["user-logon"]}]},
+        }
+        mock_response = {
+            "name": "test-profile",
+            "folder": "Mobile Users",
+            "os": ["Windows"],
+            "gp_app_config": {"config": [{"name": "connect-method", "value": ["user-logon"]}]},
+        }
+        mock_api_client.post.return_value = mock_response
+
+        # Call the method
+        result = agent_profiles.create(test_data)
+
+        # Verify the result
+        assert isinstance(result, AgentProfilesResponseModel)
+        assert result.name == "test-profile"
+
+        # Verify the API client was called correctly: folder goes as a query parameter
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == agent_profiles.ENDPOINT
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert "json" in call_args[1]
+        assert call_args[1]["json"]["name"] == "test-profile"
+
+    def test_create_with_invalid_folder(self, agent_profiles):
+        """Test create method with invalid folder raises a validation error."""
+        test_data = {
+            "name": "test-profile",
+            "folder": "Invalid Folder",
+        }
+        with pytest.raises(ValueError) as excinfo:
+            agent_profiles.create(test_data)
+        assert "Folder must be 'Mobile Users'" in str(excinfo.value)
+
+    def test_update(self, agent_profiles, mock_api_client):
+        """Test update method for modifying agent profiles (no id in path)."""
+        # Prepare test data
+        test_data = {
+            "name": "test-profile",
+            "folder": "Mobile Users",
+            "os": ["Mac"],
+        }
+        # The API returns 200 OK with no body for updates
+        mock_api_client.put.return_value = None
+
+        # Call the method
+        result = agent_profiles.update(test_data)
+
+        # Verify the result
+        assert result is None
+
+        # Verify the API client was called correctly: collection endpoint, folder param
+        mock_api_client.put.assert_called_once()
+        call_args = mock_api_client.put.call_args
+        assert call_args[0][0] == agent_profiles.ENDPOINT
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert "json" in call_args[1]
+        assert call_args[1]["json"]["name"] == "test-profile"
+
+    def test_update_with_response_body(self, agent_profiles, mock_api_client):
+        """Test update method when the API returns a body."""
+        test_data = {
+            "name": "test-profile",
+            "folder": "Mobile Users",
+        }
+        mock_response = {
+            "name": "test-profile",
+            "folder": "Mobile Users",
+            "os": ["Mac"],
+        }
+        mock_api_client.put.return_value = mock_response
+
+        result = agent_profiles.update(test_data)
+
+        assert isinstance(result, AgentProfilesResponseModel)
+        assert result.name == "test-profile"
+
+    def test_update_with_missing_folder(self, agent_profiles):
+        """Test update method without folder raises a validation error."""
+        with pytest.raises(ValueError) as excinfo:
+            agent_profiles.update({"name": "test-profile"})
+        assert "Folder is required" in str(excinfo.value)
+
+    def test_list_with_invalid_folder(self, agent_profiles):
+        """Test list method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles.list(folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_list_with_list_response(self, agent_profiles, mock_api_client):
+        """Test list method with list response format."""
+        # Prepare test data
+        mock_response = [
+            {"name": "profile-1", "folder": "Mobile Users"},
+            {"name": "profile-2", "folder": "Mobile Users"},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = agent_profiles.list()
+
+        # Verify the result
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(item, AgentProfilesResponseModel) for item in result)
+        assert result[0].name == "profile-1"
+        assert result[1].name == "profile-2"
+
+        # Verify the API client was called correctly
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == agent_profiles.ENDPOINT
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+        assert call_args[1]["params"]["limit"] == agent_profiles.max_limit
+        assert call_args[1]["params"]["offset"] == 0
+
+    def test_list_with_dict_response(self, agent_profiles, mock_api_client):
+        """Test list method with dictionary response format."""
+        # Prepare test data
+        mock_response = {
+            "data": [
+                {"name": "profile-1", "folder": "Mobile Users"},
+                {"name": "profile-2", "folder": "Mobile Users"},
+            ],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = agent_profiles.list()
+
+        # Verify the result
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(item, AgentProfilesResponseModel) for item in result)
+        assert result[0].name == "profile-1"
+        assert result[1].name == "profile-2"
+
+    def test_list_with_name_filter(self, agent_profiles, mock_api_client):
+        """Test list method passes the name filter server-side."""
+        mock_api_client.get.return_value = {"data": []}
+
+        agent_profiles.list(name="profile-1")
+
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["name"] == "profile-1"
+
+    def test_list_with_pagination(self, agent_profiles, mock_api_client):
+        """Test list method auto-paginates dict responses."""
+        agent_profiles._max_limit = 2
+        first_page = {
+            "data": [
+                {"name": "profile-1", "folder": "Mobile Users"},
+                {"name": "profile-2", "folder": "Mobile Users"},
+            ]
+        }
+        second_page = {
+            "data": [
+                {"name": "profile-3", "folder": "Mobile Users"},
+            ]
+        }
+        mock_api_client.get.side_effect = [first_page, second_page]
+
+        result = agent_profiles.list()
+
+        assert len(result) == 3
+        assert mock_api_client.get.call_count == 2
+        second_call_params = mock_api_client.get.call_args_list[1][1]["params"]
+        assert second_call_params["offset"] == 2
+
+    def test_list_with_invalid_response(self, agent_profiles, mock_api_client):
+        """Test list method with invalid response structure."""
+        # Prepare test data
+        mock_response = {"invalid": "response"}
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles.list()
+        error = excinfo.value
+        assert "Response has invalid structure" in str(error.details)
+
+    def test_fetch_with_empty_name(self, agent_profiles):
+        """Test fetch method with empty name parameter."""
+        with pytest.raises(MissingQueryParameterError) as excinfo:
+            agent_profiles.fetch("")
+        error = excinfo.value
+        assert "name" in str(error.details["field"])
+
+    def test_fetch_with_invalid_folder(self, agent_profiles):
+        """Test fetch method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles.fetch("test-name", folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_fetch_with_no_matching_profiles(self, agent_profiles, mock_api_client):
+        """Test fetch method when no matching profiles are found."""
+        # Prepare test data
+        mock_api_client.get.return_value = []
+
+        # Call the method
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles.fetch("non-existent")
+        error = excinfo.value
+        assert "No matching agent profile found" in str(error.details)
+
+    def test_fetch_with_one_matching_profile(self, agent_profiles, mock_api_client):
+        """Test fetch method when one matching profile is found."""
+        # Prepare test data
+        test_name = "test-profile"
+        mock_response = [
+            {"name": test_name, "folder": "Mobile Users"},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = agent_profiles.fetch(test_name)
+
+        # Verify the result
+        assert isinstance(result, AgentProfilesResponseModel)
+        assert result.name == test_name
+
+        # Verify the API client was called correctly: name passed server-side
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == agent_profiles.ENDPOINT
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+        assert call_args[1]["params"]["name"] == test_name
+
+    def test_fetch_with_multiple_matching_profiles(self, agent_profiles, mock_api_client):
+        """Test fetch method when multiple matching profiles are found."""
+        # Prepare test data
+        test_name = "test-profile"
+        mock_response = [
+            {"name": test_name, "folder": "Mobile Users", "os": ["Windows"]},
+            {"name": test_name, "folder": "Mobile Users", "os": ["Mac"]},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = agent_profiles.fetch(test_name)
+
+        # Verify the result: should return the first match
+        assert isinstance(result, AgentProfilesResponseModel)
+        assert result.name == test_name
+        assert result.os[0] == "Windows"
+
+    def test_delete(self, agent_profiles, mock_api_client):
+        """Test delete method for removing agent profiles by name."""
+        # Call the method
+        agent_profiles.delete("test-profile")
+
+        # Verify the API client was called correctly: name+folder as query parameters
+        mock_api_client.delete.assert_called_once_with(
+            agent_profiles.ENDPOINT,
+            params={"name": "test-profile", "folder": "Mobile Users"},
+        )
+
+    def test_delete_with_empty_name(self, agent_profiles):
+        """Test delete method with empty name parameter."""
+        with pytest.raises(MissingQueryParameterError) as excinfo:
+            agent_profiles.delete("")
+        error = excinfo.value
+        assert "name" in str(error.details["field"])
+
+    def test_delete_with_invalid_folder(self, agent_profiles):
+        """Test delete method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            agent_profiles.delete("test-profile", folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)

--- a/tests/scm/models/mobile_agent/factories.py
+++ b/tests/scm/models/mobile_agent/factories.py
@@ -4,6 +4,13 @@ from factory import Factory, Faker  # type: ignore
 import factory.fuzzy  # type: ignore
 from faker import Faker as FakerGenerator
 
+from scm.models.mobile_agent.agent_profiles import (
+    AgentProfileOperatingSystem,
+    AgentProfilesBaseModel,
+    AgentProfilesCreateModel,
+    AgentProfilesResponseModel,
+    AgentProfilesUpdateModel,
+)
 from scm.models.mobile_agent.agent_versions import AgentVersionModel, AgentVersionsModel
 from scm.models.mobile_agent.auth_settings import (
     AuthSettingsBaseModel,
@@ -545,3 +552,161 @@ class TunnelProfileResponseModelFactory(Factory):
     os = factory.LazyFunction(lambda: [TunnelOperatingSystem.WINDOWS])
     retrieve_framed_ip_address = Faker("pybool")
     folder = "Mobile Users"
+
+
+class AgentProfilesBaseModelFactory(Factory):
+    """Factory for AgentProfilesBaseModel."""
+
+    class Meta:
+        """Meta class for AgentProfilesBaseModelFactory."""
+
+        model = AgentProfilesBaseModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    folder = "Mobile Users"
+    os = factory.LazyFunction(lambda: [fake.random_element(list(AgentProfileOperatingSystem))])
+    source_user = factory.LazyFunction(lambda: [fake.user_name()])
+
+
+class AgentProfilesCreateModelFactory(Factory):
+    """Factory for AgentProfilesCreateModel."""
+
+    class Meta:
+        """Meta class for AgentProfilesCreateModelFactory."""
+
+        model = AgentProfilesCreateModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    folder = "Mobile Users"
+    os = factory.LazyFunction(lambda: [fake.random_element(list(AgentProfileOperatingSystem))])
+    source_user = factory.LazyFunction(lambda: [fake.user_name()])
+
+    @classmethod
+    def build_valid(cls):
+        """Build valid data for AgentProfilesCreateModel."""
+        model = cls.build()
+        return {
+            "name": model.name,
+            "folder": model.folder,
+            "os": model.os,
+            "source_user": model.source_user,
+        }
+
+    @classmethod
+    def build_valid_nested(cls):
+        """Build valid data with nested structures for AgentProfilesCreateModel."""
+        data = cls.build_valid()
+        data.update(
+            {
+                "agent_ui": {
+                    "agent_user_override_timeout": 30,
+                    "max_agent_user_overrides": 5,
+                    "passcode": "secret-passcode",
+                    "welcome_page": {"page": "factory-default"},
+                },
+                "authentication_override": {
+                    "accept_cookie": {"cookie_lifetime": {"lifetime_in_hours": 24}},
+                    "generate_cookie": True,
+                },
+                "gateways": {
+                    "external": {
+                        "list": [
+                            {
+                                "name": "gw-external",
+                                "choice": {"fqdn": "gw.example.com"},
+                                "manual": True,
+                                "priority_rule": [{"name": "rule-1", "priority": "1"}],
+                            }
+                        ]
+                    },
+                    "internal": {
+                        "list": [
+                            {
+                                "name": "gw-internal",
+                                "choice": {"ip": {"ipv4": "10.0.0.1"}},
+                                "source_ip": ["10.0.0.0/8"],
+                            }
+                        ]
+                    },
+                },
+                "gp_app_config": {
+                    "config": [
+                        {"name": "connect-method", "value": ["user-logon"]},
+                        {"name": "tunnel-mtu", "value": [1400]},
+                    ]
+                },
+                "hip_collection": {
+                    "collect_hip_data": True,
+                    "max_wait_time": 20,
+                    "custom_checks": {
+                        "windows": {"process_list": ["winproc.exe"]},
+                        "mac_os": {"plist": [{"name": "com.example.plist", "key": ["k1"]}]},
+                        "linux": {"process_list": ["linuxproc"]},
+                    },
+                },
+                "internal_host_detection": {
+                    "hostname": "internal.example.com",
+                    "ip_address": "10.1.1.1",
+                },
+                "save_user_credentials": "1",
+                "third_party_vpn_clients": ["PAN Virtual Ethernet Adapter"],
+            }
+        )
+        return data
+
+    @classmethod
+    def build_invalid_folder(cls):
+        """Build data with invalid folder for AgentProfilesCreateModel."""
+        data = cls.build_valid()
+        data["folder"] = "Invalid Folder"
+        return data
+
+    @classmethod
+    def build_missing_folder(cls):
+        """Build data with missing folder for AgentProfilesCreateModel."""
+        data = cls.build_valid()
+        del data["folder"]
+        return data
+
+
+class AgentProfilesUpdateModelFactory(Factory):
+    """Factory for AgentProfilesUpdateModel."""
+
+    class Meta:
+        """Meta class for AgentProfilesUpdateModelFactory."""
+
+        model = AgentProfilesUpdateModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    folder = "Mobile Users"
+    os = factory.LazyFunction(lambda: [fake.random_element(list(AgentProfileOperatingSystem))])
+
+    @classmethod
+    def build_valid(cls):
+        """Build valid data for AgentProfilesUpdateModel."""
+        model = cls.build()
+        return {
+            "name": model.name,
+            "folder": model.folder,
+            "os": model.os,
+        }
+
+    @classmethod
+    def build_missing_folder(cls):
+        """Build data with missing folder for AgentProfilesUpdateModel."""
+        data = cls.build_valid()
+        del data["folder"]
+        return data
+
+
+class AgentProfilesResponseModelFactory(Factory):
+    """Factory for AgentProfilesResponseModel."""
+
+    class Meta:
+        """Meta class for AgentProfilesResponseModelFactory."""
+
+        model = AgentProfilesResponseModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    folder = "Mobile Users"
+    os = factory.LazyFunction(lambda: [fake.random_element(list(AgentProfileOperatingSystem))])

--- a/tests/scm/models/mobile_agent/test_agent_profiles_models.py
+++ b/tests/scm/models/mobile_agent/test_agent_profiles_models.py
@@ -1,0 +1,417 @@
+# tests/scm/models/mobile_agent/test_agent_profiles_models.py
+
+"""Tests for mobile agent agent profiles (application settings) models."""
+
+# External libraries
+from pydantic import ValidationError
+import pytest
+
+# Local SDK imports
+from scm.models.mobile_agent.agent_profiles import (
+    AgentProfileOperatingSystem,
+    AgentProfilesBaseModel,
+    AgentProfilesCreateModel,
+    AgentProfilesResponseModel,
+    AgentProfilesUpdateModel,
+    AgentUI,
+    ConnectMethodAppConfig,
+    ConnectMethodValue,
+    CookieLifetime,
+    GatewayChoice,
+    GatewayPriority,
+    GPAppConfig,
+    HipCollection,
+    HipMacOsPlistEntry,
+    HipWindowsRegistryKey,
+    InternalHostDetection,
+    SaveUserCredentials,
+    ThirdPartyVpnClient,
+    TunnelMtuAppConfig,
+)
+from tests.scm.models.mobile_agent.factories import (
+    AgentProfilesBaseModelFactory,
+    AgentProfilesCreateModelFactory,
+    AgentProfilesResponseModelFactory,
+    AgentProfilesUpdateModelFactory,
+)
+
+
+class TestAgentProfileOperatingSystem:
+    """Tests for the AgentProfileOperatingSystem enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert AgentProfileOperatingSystem.ANDROID == "Android"
+        assert AgentProfileOperatingSystem.CHROME == "Chrome"
+        assert AgentProfileOperatingSystem.IOT == "IoT"
+        assert AgentProfileOperatingSystem.LINUX == "Linux"
+        assert AgentProfileOperatingSystem.MAC == "Mac"
+        assert AgentProfileOperatingSystem.WINDOWS == "Windows"
+        assert AgentProfileOperatingSystem.WINDOWS_UWP == "WindowsUWP"
+        assert AgentProfileOperatingSystem.IOS == "iOS"
+
+
+class TestSaveUserCredentials:
+    """Tests for the SaveUserCredentials enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert SaveUserCredentials.NO == "0"
+        assert SaveUserCredentials.YES == "1"
+        assert SaveUserCredentials.SAVE_USERNAME_ONLY == "2"
+        assert SaveUserCredentials.ONLY_WITH_USER_FINGERPRINT == "3"
+
+
+class TestThirdPartyVpnClient:
+    """Tests for the ThirdPartyVpnClient enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert ThirdPartyVpnClient.PAN_VIRTUAL_ETHERNET_ADAPTER == "PAN Virtual Ethernet Adapter"
+        assert (
+            ThirdPartyVpnClient.JUNIPER_NETWORK_VIRTUAL_ADAPTER
+            == "Juniper Network Virtual Adapter"
+        )
+        assert ThirdPartyVpnClient.CISCO_SYSTEMS_VPN_ADAPTER == "Cisco Systems VPN Adapter"
+
+
+class TestConnectMethodValue:
+    """Tests for the ConnectMethodValue enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert ConnectMethodValue.USER_LOGON == "user-logon"
+        assert ConnectMethodValue.PRE_LOGON == "pre-logon"
+        assert ConnectMethodValue.ON_DEMAND == "on-demand"
+        assert ConnectMethodValue.PRE_LOGON_THEN_ON_DEMAND == "pre-logon-then-on-demand"
+
+
+class TestGatewayPriority:
+    """Tests for the GatewayPriority enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert GatewayPriority.HIGHEST == "0"
+        assert GatewayPriority.HIGH == "1"
+        assert GatewayPriority.MEDIUM == "2"
+        assert GatewayPriority.LOW == "3"
+        assert GatewayPriority.LOWEST == "4"
+        assert GatewayPriority.MANUAL_ONLY == "5"
+
+
+class TestAgentProfilesBaseModel:
+    """Tests for AgentProfilesBaseModel validation."""
+
+    def test_base_model_minimal(self):
+        """Test that a minimal base model can be created with only a name."""
+        model = AgentProfilesBaseModel(name="test-profile")
+        assert model.name == "test-profile"
+        assert model.folder is None
+        assert model.agent_ui is None
+        assert model.gateways is None
+
+    def test_base_model_from_factory(self):
+        """Test that a base model can be created from the factory."""
+        model = AgentProfilesBaseModelFactory()
+        assert model.name is not None
+        assert model.folder == "Mobile Users"
+        assert model.os is not None
+
+    def test_base_model_missing_name(self):
+        """Test validation when the required name field is missing."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentProfilesBaseModel(folder="Mobile Users")
+        assert "name\n  Field required" in str(exc_info.value)
+
+    def test_base_model_invalid_folder(self):
+        """Test validation when folder value is invalid."""
+        with pytest.raises(ValueError) as exc_info:
+            AgentProfilesBaseModel(name="test-profile", folder="Invalid Folder")
+        assert "Folder must be 'Mobile Users'" in str(exc_info.value)
+
+    def test_base_model_folder_pattern_validation(self):
+        """Test folder pattern validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentProfilesBaseModel(name="test-profile", folder="Invalid@Folder")
+        assert "folder\n  String should match pattern" in str(exc_info.value)
+
+    def test_base_model_extra_field_forbidden(self):
+        """Test that unknown fields are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            AgentProfilesBaseModel(name="test-profile", unknown_field="value")
+        assert "unknown_field" in str(exc_info.value)
+
+    def test_base_model_nested_structures(self):
+        """Test that a fully nested model can be created."""
+        data = AgentProfilesCreateModelFactory.build_valid_nested()
+        model = AgentProfilesCreateModel(**data)
+        assert model.agent_ui.agent_user_override_timeout == 30
+        assert model.agent_ui.welcome_page.page == "factory-default"
+        assert model.authentication_override.accept_cookie.cookie_lifetime.lifetime_in_hours == 24
+        assert model.gateways.external.list[0].choice.fqdn == "gw.example.com"
+        assert model.gateways.internal.list[0].choice.ip.ipv4 == "10.0.0.1"
+        assert model.gp_app_config.config[0].name == "connect-method"
+        assert model.gp_app_config.config[1].name == "tunnel-mtu"
+        assert model.hip_collection.custom_checks.mac_os.plist[0].name == "com.example.plist"
+        assert model.save_user_credentials == SaveUserCredentials.YES
+        assert model.third_party_vpn_clients == [ThirdPartyVpnClient.PAN_VIRTUAL_ETHERNET_ADAPTER]
+
+    def test_base_model_invalid_os_value(self):
+        """Test validation when os contains an invalid value."""
+        with pytest.raises(ValidationError):
+            AgentProfilesBaseModel(name="test-profile", os=["NotAnOS"])
+
+    def test_model_dump_excludes_unset(self):
+        """Test that model_dump(exclude_unset=True) only includes set fields."""
+        model = AgentProfilesBaseModel(name="test-profile", folder="Mobile Users")
+        model_dict = model.model_dump(exclude_unset=True)
+        assert model_dict == {"name": "test-profile", "folder": "Mobile Users"}
+
+
+class TestAgentUI:
+    """Tests for AgentUI nested model validation."""
+
+    def test_valid_agent_ui(self):
+        """Test that a valid agent UI configuration can be created."""
+        model = AgentUI(
+            agent_user_override_timeout=0,
+            max_agent_user_overrides=25,
+            passcode="123456",
+            uninstall_password="abcdef",
+        )
+        assert model.agent_user_override_timeout == 0
+        assert model.max_agent_user_overrides == 25
+
+    def test_timeout_out_of_range(self):
+        """Test validation when agent_user_override_timeout exceeds the maximum."""
+        with pytest.raises(ValidationError):
+            AgentUI(agent_user_override_timeout=65536)
+
+    def test_max_overrides_out_of_range(self):
+        """Test validation when max_agent_user_overrides exceeds the maximum."""
+        with pytest.raises(ValidationError):
+            AgentUI(max_agent_user_overrides=26)
+
+    def test_passcode_too_short(self):
+        """Test validation when passcode is shorter than the minimum length."""
+        with pytest.raises(ValidationError):
+            AgentUI(passcode="12345")
+
+    def test_uninstall_password_too_long(self):
+        """Test validation when uninstall_password exceeds the maximum length."""
+        with pytest.raises(ValidationError):
+            AgentUI(uninstall_password="x" * 33)
+
+
+class TestCookieLifetime:
+    """Tests for CookieLifetime nested model validation."""
+
+    def test_valid_lifetimes(self):
+        """Test that valid lifetime values can be set."""
+        model = CookieLifetime(lifetime_in_days=365)
+        assert model.lifetime_in_days == 365
+
+    def test_days_out_of_range(self):
+        """Test validation when lifetime_in_days exceeds the maximum."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_days=366)
+
+    def test_hours_out_of_range(self):
+        """Test validation when lifetime_in_hours exceeds the maximum."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_hours=73)
+
+    def test_minutes_out_of_range(self):
+        """Test validation when lifetime_in_minutes exceeds the maximum."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_minutes=60)
+
+
+class TestGatewayChoice:
+    """Tests for GatewayChoice oneOf validation."""
+
+    def test_fqdn_only(self):
+        """Test that a gateway choice with only an FQDN is valid."""
+        model = GatewayChoice(fqdn="gw.example.com")
+        assert model.fqdn == "gw.example.com"
+        assert model.ip is None
+
+    def test_ip_only(self):
+        """Test that a gateway choice with only an IP is valid."""
+        model = GatewayChoice(ip={"ipv4": "10.0.0.1"})
+        assert model.ip.ipv4 == "10.0.0.1"
+        assert model.fqdn is None
+
+    def test_both_fqdn_and_ip(self):
+        """Test validation when both fqdn and ip are provided."""
+        with pytest.raises(ValueError) as exc_info:
+            GatewayChoice(fqdn="gw.example.com", ip={"ipv4": "10.0.0.1"})
+        assert "Exactly one of 'fqdn' or 'ip'" in str(exc_info.value)
+
+    def test_neither_fqdn_nor_ip(self):
+        """Test validation when neither fqdn nor ip is provided."""
+        with pytest.raises(ValueError) as exc_info:
+            GatewayChoice()
+        assert "Exactly one of 'fqdn' or 'ip'" in str(exc_info.value)
+
+    def test_invalid_ipv4_pattern(self):
+        """Test validation when ipv4 does not match the allowed pattern."""
+        with pytest.raises(ValidationError):
+            GatewayChoice(ip={"ipv4": "not-an-ip"})
+
+
+class TestGPAppConfig:
+    """Tests for the GlobalProtect app config discriminated union."""
+
+    def test_connect_method_entry(self):
+        """Test that a connect-method entry is parsed into the right model."""
+        model = GPAppConfig(config=[{"name": "connect-method", "value": ["pre-logon"]}])
+        assert isinstance(model.config[0], ConnectMethodAppConfig)
+        assert model.config[0].value == [ConnectMethodValue.PRE_LOGON]
+
+    def test_tunnel_mtu_entry(self):
+        """Test that a tunnel-mtu entry is parsed into the right model."""
+        model = GPAppConfig(config=[{"name": "tunnel-mtu", "value": [1400]}])
+        assert isinstance(model.config[0], TunnelMtuAppConfig)
+        assert model.config[0].value == [1400]
+
+    def test_unknown_entry_name(self):
+        """Test validation when the app config entry name is unknown."""
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "unknown-config", "value": ["x"]}])
+
+    def test_connect_method_invalid_value(self):
+        """Test validation when the connect method value is not allowed."""
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "connect-method", "value": ["always-on"]}])
+
+    def test_connect_method_too_many_values(self):
+        """Test validation when more than one connect method value is provided."""
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "connect-method", "value": ["user-logon", "pre-logon"]}])
+
+    def test_tunnel_mtu_out_of_range(self):
+        """Test validation when the tunnel MTU is out of range."""
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "tunnel-mtu", "value": [999]}])
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "tunnel-mtu", "value": [1421]}])
+
+    def test_tunnel_mtu_empty_value(self):
+        """Test validation when the tunnel MTU value list is empty."""
+        with pytest.raises(ValidationError):
+            GPAppConfig(config=[{"name": "tunnel-mtu", "value": []}])
+
+
+class TestHipModels:
+    """Tests for HIP collection nested models."""
+
+    def test_macos_plist_name_required(self):
+        """Test that the name field is required for macOS plist entries."""
+        with pytest.raises(ValidationError) as exc_info:
+            HipMacOsPlistEntry(key=["k1"])
+        assert "name\n  Field required" in str(exc_info.value)
+
+    def test_windows_registry_key_name_required(self):
+        """Test that the name field is required for Windows registry key entries."""
+        with pytest.raises(ValidationError) as exc_info:
+            HipWindowsRegistryKey(registry_value=["v1"])
+        assert "name\n  Field required" in str(exc_info.value)
+
+    def test_max_wait_time_out_of_range(self):
+        """Test validation when max_wait_time is out of range."""
+        with pytest.raises(ValidationError):
+            HipCollection(max_wait_time=9)
+        with pytest.raises(ValidationError):
+            HipCollection(max_wait_time=61)
+
+    def test_valid_hip_collection(self):
+        """Test that a valid HIP collection can be created."""
+        model = HipCollection(
+            collect_hip_data=True,
+            max_wait_time=20,
+            custom_checks={
+                "windows": {"registry_key": [{"name": "HKLM\\Software", "registry_value": ["v"]}]},
+            },
+            exclusion={"category": [{"name": "antivirus", "vendor": [{"name": "v", "product": ["p"]}]}]},
+        )
+        assert model.collect_hip_data is True
+        assert model.custom_checks.windows.registry_key[0].name == "HKLM\\Software"
+        assert model.exclusion.category[0].vendor[0].product == ["p"]
+
+
+class TestInternalHostDetection:
+    """Tests for internal host detection models."""
+
+    def test_valid_host_detection(self):
+        """Test that a valid internal host detection can be created."""
+        model = InternalHostDetection(hostname="host.example.com", ip_address="10.0.0.1")
+        assert model.hostname == "host.example.com"
+
+    def test_invalid_hostname_pattern(self):
+        """Test validation when hostname has invalid characters."""
+        with pytest.raises(ValidationError):
+            InternalHostDetection(hostname="invalid host!")
+
+
+class TestAgentProfilesCreateModel:
+    """Tests for AgentProfilesCreateModel validation."""
+
+    def test_create_model_valid(self):
+        """Test that a valid create model can be built."""
+        data = AgentProfilesCreateModelFactory.build_valid()
+        model = AgentProfilesCreateModel(**data)
+        assert model.name == data["name"]
+        assert model.folder == "Mobile Users"
+
+    def test_create_model_missing_folder(self):
+        """Test validation when folder is missing."""
+        data = AgentProfilesCreateModelFactory.build_missing_folder()
+        with pytest.raises(ValueError) as exc_info:
+            AgentProfilesCreateModel(**data)
+        assert "Folder is required" in str(exc_info.value)
+
+    def test_create_model_invalid_folder(self):
+        """Test validation when folder is not 'Mobile Users'."""
+        data = AgentProfilesCreateModelFactory.build_invalid_folder()
+        with pytest.raises(ValueError) as exc_info:
+            AgentProfilesCreateModel(**data)
+        assert "Folder must be 'Mobile Users'" in str(exc_info.value)
+
+
+class TestAgentProfilesUpdateModel:
+    """Tests for AgentProfilesUpdateModel validation."""
+
+    def test_update_model_valid(self):
+        """Test that a valid update model can be built."""
+        data = AgentProfilesUpdateModelFactory.build_valid()
+        model = AgentProfilesUpdateModel(**data)
+        assert model.name == data["name"]
+        assert model.folder == "Mobile Users"
+
+    def test_update_model_missing_folder(self):
+        """Test validation when folder is missing."""
+        data = AgentProfilesUpdateModelFactory.build_missing_folder()
+        with pytest.raises(ValueError) as exc_info:
+            AgentProfilesUpdateModel(**data)
+        assert "Folder is required" in str(exc_info.value)
+
+
+class TestAgentProfilesResponseModel:
+    """Tests for AgentProfilesResponseModel validation."""
+
+    def test_response_model_from_factory(self):
+        """Test that a response model can be created from the factory."""
+        model = AgentProfilesResponseModelFactory()
+        assert model.name is not None
+        assert model.folder == "Mobile Users"
+
+    def test_response_model_ignores_extra_fields(self):
+        """Test that unknown fields in API responses are ignored."""
+        model = AgentProfilesResponseModel(
+            name="test-profile",
+            folder="Mobile Users",
+            some_future_field="ignored",
+        )
+        assert model.name == "test-profile"
+        assert not hasattr(model, "some_future_field")


### PR DESCRIPTION
### Checklist for This Pull Request

🚨Please adhere to the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [x] Ensure you are submitting your pull request to **a branch dedicated to a specific topic/feature/bugfix**. Avoid using the master branch for pull requests.
- [x] Target your pull request to the **main development branch** in the `https://github.com/cdot65/pan-scm-sdk` repository (do NOT target the Palo Alto Networks repo!).
- [x] Check that your code additions do not fail any linting checks or unit tests.

### Pull Request Description

Implements the GlobalProtect **agent-profiles** resource from the mobile-agent feb-v1 OpenAPI spec. The SCM UI calls this resource **App Settings / Application Settings**.

#### Endpoints

- `GET /config/mobile-agent/v1/agent-profiles` — list with `name`/`folder`/`limit`/`offset`, auto-paginated
- `POST /config/mobile-agent/v1/agent-profiles?folder=...` — create
- `PUT /config/mobile-agent/v1/agent-profiles?folder=...` — update (addressed by name; the API has **no `/{id}` paths** for this resource and returns 200 OK with no body)
- `DELETE /config/mobile-agent/v1/agent-profiles?name=...&folder=...` — delete by name

#### Models

`AgentProfilesBaseModel/CreateModel/UpdateModel/ResponseModel` plus the full nested schema: `agent_ui` (incl. welcome page), `authentication_override` (cookie lifetime), `certificate`, `client_certificate`, `custom_checks` (plist/registry), `gateways` (external/internal, fqdn-or-ip oneOf enforced), `gp_app_config` (discriminated union of `connect-method` / `tunnel-mtu`), `hip_collection` (per-OS custom checks + exclusions), internal host detection v4/v6, machine account setting, and enums for OS, save-user-credentials, third-party VPN clients, and gateway priority.

#### Wiring

- `client.agent_profile` service registry entry
- mkdocs nav + docs pages (config + models), index rows

#### Tests

- `tests/scm/config/mobile_agent/test_agent_profiles.py` — 27 service tests (CRUD, pagination, folder/name validation, no-body update)
- `tests/scm/models/mobile_agent/test_agent_profiles_models.py` — 48 model tests (enums, nested validation, ranges, discriminated union)
- Factories added to `tests/scm/models/mobile_agent/factories.py`

#### Validation

- `poetry run pytest` — **6238 passed, 111 skipped**
- mobile_agent scope — **181 passed**
- isort + ruff (incl. `--select D`) + flake8 + mypy — **all green** (`Success: no issues found in 521 source files`)
- `poetry run mkdocs build` — **succeeds** with new nav entries

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)