### PR TITLE
feat(mobile_agent): add tunnel profiles service + auth settings spec alignment

### DIFF
--- a/docs/sdk/config/mobile_agent/index.md
+++ b/docs/sdk/config/mobile_agent/index.md
@@ -14,6 +14,7 @@ This section covers the Mobile Agent configuration objects provided by the Palo 
 | [Agent Versions](agent_versions.md)                    | List and retrieve available GlobalProtect agent versions           |
 | [Global Settings](global_settings.md)                  | Manage the GlobalProtect global settings singleton                 |
 | [Infrastructure Settings](infrastructure_settings.md)  | Manage GlobalProtect infrastructure (DNS, IP pools, portal, WINS)  |
+| [Tunnel Profiles](tunnel_profiles.md)                  | Manage GlobalProtect tunnel settings (split tunneling)             |
 
 ## Related Documentation
 

--- a/docs/sdk/config/mobile_agent/tunnel_profiles.md
+++ b/docs/sdk/config/mobile_agent/tunnel_profiles.md
@@ -1,0 +1,173 @@
+# GlobalProtect Tunnel Profiles Configuration Object
+
+Manages GlobalProtect tunnel settings (tunnel profiles) for mobile users in Palo Alto Networks Strata Cloud Manager. Tunnel profiles control split tunneling behavior, authentication override cookies, and tunnel source restrictions for the GlobalProtect agent.
+
+!!! note
+    The SCM UI refers to this resource as "Tunnel Settings". The underlying API endpoint is `/tunnel-profiles`.
+
+## Class Overview
+
+The `TunnelProfiles` class inherits from `BaseObject` and provides CRUD operations for GlobalProtect tunnel profile objects. Tunnel profiles are addressed **by name** within the `Mobile Users` folder — the API exposes no ID-based endpoints for this resource.
+
+### Methods
+
+| Method     | Description                            | Parameters                                  | Return Type                        |
+|------------|----------------------------------------|---------------------------------------------|------------------------------------|
+| `create()` | Creates a new tunnel profile           | `data: Dict[str, Any]`, `folder: str`       | `TunnelProfileResponseModel`       |
+| `update()` | Updates a tunnel profile by name       | `data: Dict[str, Any]`, `folder: str`       | `TunnelProfileResponseModel`       |
+| `delete()` | Deletes a tunnel profile by name       | `name: str`, `folder: str`                  | `None`                             |
+| `list()`   | Lists tunnel profiles with filtering   | `folder: str`, `name: Optional[str]`        | `List[TunnelProfileResponseModel]` |
+| `fetch()`  | Gets a tunnel profile by name          | `name: str`, `folder: str`                  | `TunnelProfileResponseModel`       |
+
+`folder` defaults to `"Mobile Users"` on all methods, which is the only value accepted by the API.
+
+### Model Attributes
+
+| Attribute                           | Type                         | Required | Default | Description                                                  |
+|-------------------------------------|------------------------------|----------|---------|--------------------------------------------------------------|
+| `name`                              | str                          | Yes      | None    | Name of the tunnel profile (1-31 chars)                      |
+| `authentication_override`           | AuthenticationOverride       | No       | None    | Authentication cookie override configuration                 |
+| `no_direct_access_to_local_network` | bool                         | No       | None    | Disable direct access to the local network                   |
+| `os`                                | List[TunnelOperatingSystem]  | No       | None    | Operating systems the profile applies to                     |
+| `retrieve_framed_ip_address`        | bool                         | No       | None    | Retrieve framed IP address from the authentication server    |
+| `source_address`                    | SourceAddress                | No       | None    | Source IP addresses and regions the profile applies to       |
+| `source_user`                       | List[str]                    | No       | None    | Source users the profile applies to                          |
+| `split_tunneling`                   | SplitTunneling               | No       | None    | Split tunneling routes, applications, and domains            |
+
+### Exceptions
+
+| Exception                    | HTTP Code | Description                          |
+|------------------------------|-----------|--------------------------------------|
+| `InvalidObjectError`         | 400       | Invalid profile data or folder value |
+| `MissingQueryParameterError` | 400       | Missing required parameters          |
+| `NameNotUniqueError`         | 409       | Tunnel profile name already exists   |
+| `ObjectNotPresentError`      | 404       | Tunnel profile not found             |
+| `AuthenticationError`        | 401       | Authentication failed                |
+| `ServerError`                | 500       | Internal server error                |
+
+### Basic Configuration
+
+```python
+from scm.client import Scm
+
+client = Scm(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    tsg_id="your_tsg_id"
+)
+
+tunnel_profiles = client.tunnel_profile
+```
+
+## Methods
+
+### Create Tunnel Profile
+
+```python
+profile_config = {
+    "name": "windows-tunnel",
+    "os": ["Windows", "Mac"],
+    "no_direct_access_to_local_network": True,
+    "split_tunneling": {
+        "access_route": ["10.0.0.0/8"],
+        "exclude_domains": {
+            "list": [{"name": "example.com", "ports": [443]}]
+        },
+    },
+}
+
+new_profile = client.tunnel_profile.create(profile_config)
+print(f"Created tunnel profile: {new_profile.name}")
+```
+
+### List Tunnel Profiles
+
+```python
+all_profiles = client.tunnel_profile.list()
+
+for profile in all_profiles:
+    print(f"Name: {profile.name}, OS: {profile.os}")
+```
+
+**Controlling pagination with max_limit:**
+
+```python
+client.tunnel_profile.max_limit = 1000
+
+all_profiles = client.tunnel_profile.list()
+```
+
+### Fetch Tunnel Profile
+
+```python
+profile = client.tunnel_profile.fetch(name="windows-tunnel", folder="Mobile Users")
+print(f"Split tunneling: {profile.split_tunneling}")
+```
+
+### Update Tunnel Profile
+
+Tunnel profiles are addressed by name in the request body — there is no ID:
+
+```python
+update_config = {
+    "name": "windows-tunnel",
+    "retrieve_framed_ip_address": True,
+}
+
+updated_profile = client.tunnel_profile.update(update_config)
+print(f"Updated tunnel profile: {updated_profile.name}")
+```
+
+### Delete Tunnel Profile
+
+```python
+client.tunnel_profile.delete(name="windows-tunnel")
+```
+
+## Complete Example
+
+```python
+from scm.exceptions import (
+    InvalidObjectError,
+    MissingQueryParameterError,
+    NameNotUniqueError,
+    ObjectNotPresentError
+)
+
+try:
+    profile_config = {
+        "name": "corp-tunnel",
+        "os": ["Windows"],
+        "authentication_override": {
+            "accept_cookie": {
+                "cookie_lifetime": {"lifetime_in_hours": 24},
+                "generate_cookie": True,
+            }
+        },
+        "split_tunneling": {
+            "access_route": ["10.0.0.0/8", "172.16.0.0/12"],
+        },
+    }
+    new_profile = client.tunnel_profile.create(profile_config)
+    result = client.commit(
+        folders=["Mobile Users"],
+        description="Added GlobalProtect tunnel profile",
+        sync=True
+    )
+    status = client.get_job_status(result.job_id)
+
+except InvalidObjectError as e:
+    print(f"Invalid tunnel profile data: {e.message}")
+except NameNotUniqueError as e:
+    print(f"Tunnel profile name already exists: {e.message}")
+except ObjectNotPresentError as e:
+    print(f"Tunnel profile not found: {e.message}")
+except MissingQueryParameterError as e:
+    print(f"Missing parameter: {e.message}")
+```
+
+## Related Topics
+
+- [Tunnel Profiles Models](../../models/mobile_agent/tunnel_profiles_models.md#Overview)
+- [Mobile Agent Overview](index.md)
+- [API Client](../../client.md)

--- a/docs/sdk/models/mobile_agent/index.md
+++ b/docs/sdk/models/mobile_agent/index.md
@@ -22,6 +22,7 @@ Key model patterns:
 - [Agent Version Models](agent_versions_models.md) - Models for GlobalProtect agent version information
 - [Global Settings Models](global_settings_models.md) - Models for the GlobalProtect global settings singleton
 - [Infrastructure Settings Models](infrastructure_settings_models.md) - Models for GlobalProtect infrastructure settings
+- [Tunnel Profiles Models](tunnel_profiles_models.md) - Models for GlobalProtect tunnel settings
 
 ## Usage Examples
 

--- a/docs/sdk/models/mobile_agent/tunnel_profiles_models.md
+++ b/docs/sdk/models/mobile_agent/tunnel_profiles_models.md
@@ -1,0 +1,123 @@
+# GlobalProtect Tunnel Profiles Models
+
+## Overview
+
+The GlobalProtect Tunnel Profiles models provide a structured way to manage tunnel settings for mobile users in Palo Alto Networks' Strata Cloud Manager. These models cover split tunneling configuration, authentication override cookies, and tunnel source restrictions. The models handle validation of inputs and outputs when interacting with the SCM API.
+
+### Models
+
+The module provides the following Pydantic models:
+
+- `TunnelProfileBaseModel`: Base model with fields common to all tunnel profile operations
+- `TunnelProfileCreateModel`: Model for creating new tunnel profiles
+- `TunnelProfileUpdateModel`: Model for updating existing tunnel profiles (addressed by name)
+- `TunnelProfileResponseModel`: Response model for tunnel profile operations
+- `AuthenticationOverride`: Authentication override configuration
+- `AcceptCookie`: Accept cookie configuration for authentication override
+- `CookieLifetime`: Cookie lifetime bounds (days/hours/minutes)
+- `SourceAddress`: Source IP addresses and regions
+- `SplitTunneling`: Split tunneling routes, applications, and domains
+- `SplitTunnelingDomains`: Domain list container for include/exclude domains
+- `SplitTunnelingDomainEntry`: Single domain entry with optional ports
+- `TunnelOperatingSystem`: Enum for available operating systems
+
+All request models use `extra="forbid"` configuration, which rejects any fields not explicitly defined in the model. The response model uses `extra="ignore"` to tolerate additional fields returned by the API.
+
+## Attributes
+
+| Attribute                           | Type                        | Required | Default | Description                                               |
+|-------------------------------------|-----------------------------|----------|---------|-----------------------------------------------------------|
+| `name`                              | `str`                       | Yes      | None    | Name of the tunnel profile. Length: 1-31 chars            |
+| `authentication_override`           | `AuthenticationOverride`    | No       | None    | Authentication cookie override configuration              |
+| `no_direct_access_to_local_network` | `bool`                      | No       | None    | Disable direct access to the local network                |
+| `os`                                | `List[TunnelOperatingSystem]` | No     | None    | Operating systems the profile applies to                  |
+| `retrieve_framed_ip_address`        | `bool`                      | No       | None    | Retrieve framed IP address from the authentication server |
+| `source_address`                    | `SourceAddress`             | No       | None    | Source IP addresses and regions                           |
+| `source_user`                       | `List[str]`                 | No       | None    | Source users the profile applies to                       |
+| `split_tunneling`                   | `SplitTunneling`            | No       | None    | Split tunneling configuration                             |
+
+The response model additionally exposes `folder` (`Optional[str]`) when returned by the API.
+
+### Nested Model Attributes
+
+**CookieLifetime**
+
+| Attribute             | Type  | Constraints | Description                |
+|-----------------------|-------|-------------|----------------------------|
+| `lifetime_in_days`    | `int` | 1-365       | Cookie lifetime in days    |
+| `lifetime_in_hours`   | `int` | 1-72        | Cookie lifetime in hours   |
+| `lifetime_in_minutes` | `int` | 1-59        | Cookie lifetime in minutes |
+
+**SplitTunneling**
+
+| Attribute              | Type                    | Description                          |
+|------------------------|-------------------------|--------------------------------------|
+| `access_route`         | `List[str]`             | Routes included in the tunnel        |
+| `exclude_access_route` | `List[str]`             | Routes excluded from the tunnel      |
+| `exclude_applications` | `List[str]`             | Applications excluded from tunnel    |
+| `exclude_domains`      | `SplitTunnelingDomains` | Domains excluded from the tunnel     |
+| `include_applications` | `List[str]`             | Applications included in the tunnel  |
+| `include_domains`      | `SplitTunnelingDomains` | Domains included in the tunnel       |
+
+**SplitTunnelingDomainEntry**
+
+| Attribute | Type        | Constraints       | Description          |
+|-----------|-------------|-------------------|----------------------|
+| `name`    | `str`       |                   | The domain name      |
+| `ports`   | `List[int]` | each port 1-65535 | Ports for the domain |
+
+## Enumerations
+
+### TunnelOperatingSystem
+
+| Value         | Description              |
+|---------------|--------------------------|
+| `ANDROID`     | Android devices          |
+| `CHROME`      | Chrome OS devices        |
+| `IOT`         | Internet of Things devices |
+| `LINUX`       | Linux systems            |
+| `MAC`         | macOS systems            |
+| `WINDOWS`     | Windows systems          |
+| `WINDOWS_UWP` | Windows UWP applications |
+| `IOS`         | iOS devices              |
+
+!!! note
+    Unlike the authentication settings `OperatingSystem` enum, tunnel profiles do not support `Any`, `Browser`, or `Satellite` values.
+
+## Usage Example
+
+```python
+from scm.client import Scm
+from scm.models.mobile_agent.tunnel_profiles import (
+    TunnelProfileCreateModel,
+    TunnelOperatingSystem,
+)
+
+# Initialize client
+client = Scm(
+   client_id="your_client_id",
+   client_secret="your_client_secret",
+   tsg_id="your_tsg_id"
+)
+
+# Create a tunnel profile using a model
+tunnel_profile = TunnelProfileCreateModel(
+   name="windows-tunnel",
+   os=[TunnelOperatingSystem.WINDOWS],
+   no_direct_access_to_local_network=True,
+   split_tunneling={
+       "access_route": ["10.0.0.0/8"],
+       "exclude_domains": {"list": [{"name": "example.com", "ports": [443]}]},
+   },
+)
+
+# Convert the model to a dictionary for the API call
+profile_dict = tunnel_profile.model_dump(exclude_unset=True)
+result = client.tunnel_profile.create(profile_dict)
+print(f"Created tunnel profile: {result.name}")
+```
+
+## Related Topics
+
+- [Tunnel Profiles Configuration](../../config/mobile_agent/tunnel_profiles.md)
+- [Mobile Agent Overview](index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
           - Agent Versions: sdk/config/mobile_agent/agent_versions.md
           - Global Settings: sdk/config/mobile_agent/global_settings.md
           - Infrastructure Settings: sdk/config/mobile_agent/infrastructure_settings.md
+          - Tunnel Profiles: sdk/config/mobile_agent/tunnel_profiles.md
       - Network:
           - Overview: sdk/config/network/index.md
           - Aggregate Interfaces: sdk/config/network/aggregate_interface.md
@@ -237,6 +238,7 @@ nav:
           - Agent Versions: sdk/models/mobile_agent/agent_versions_models.md
           - Global Settings: sdk/models/mobile_agent/global_settings_models.md
           - Infrastructure Settings: sdk/models/mobile_agent/infrastructure_settings_models.md
+          - Tunnel Profiles: sdk/models/mobile_agent/tunnel_profiles_models.md
       - Network:
           - Overview: sdk/models/network/index.md
           - Aggregate Interfaces: sdk/models/network/aggregate_interface_models.md

--- a/scm/client.py
+++ b/scm/client.py
@@ -740,6 +740,10 @@ class Scm:
                 "scm.config.network.tunnel_interface",
                 "TunnelInterface",
             ),
+            "tunnel_profile": (
+                "scm.config.mobile_agent.tunnel_profiles",
+                "TunnelProfiles",
+            ),
             "vlan_interface": (
                 "scm.config.network.vlan_interface",
                 "VlanInterface",

--- a/scm/config/mobile_agent/__init__.py
+++ b/scm/config/mobile_agent/__init__.py
@@ -5,10 +5,12 @@ from scm.config.mobile_agent.agent_versions import AgentVersions
 from scm.config.mobile_agent.auth_settings import AuthSettings
 from scm.config.mobile_agent.global_settings import GlobalSettings
 from scm.config.mobile_agent.infrastructure_settings import InfrastructureSettings
+from scm.config.mobile_agent.tunnel_profiles import TunnelProfiles
 
 __all__ = [
     "AgentVersions",
     "AuthSettings",
     "GlobalSettings",
     "InfrastructureSettings",
+    "TunnelProfiles",
 ]

--- a/scm/config/mobile_agent/auth_settings.py
+++ b/scm/config/mobile_agent/auth_settings.py
@@ -138,9 +138,13 @@ class AuthSettings(BaseObject):
             by_alias=True,
         )
 
+        # The API expects the folder as a query parameter, not in the request body
+        folder = payload.pop("folder")
+
         # Send the updated object to the remote API as JSON
         response: Dict[str, Any] = self.api_client.post(
             self.ENDPOINT,
+            params={"folder": folder},
             json=payload,
         )
 
@@ -215,24 +219,28 @@ class AuthSettings(BaseObject):
         move_model = AuthSettingsMoveModel(**move_data)
 
         # Convert to dict for API request
-        payload = move_model.model_dump(by_alias=True)
+        payload = move_model.model_dump(by_alias=True, exclude_none=True)
 
-        # Send the move request to the remote API as JSON
-        endpoint = f"{self.ENDPOINT}/move"
+        # The API addresses the object by name in the path and folder as a query parameter
+        folder = move_model.folder or "Mobile Users"
+        endpoint = f"{self.ENDPOINT}/{move_model.name}:move"
         self.api_client.post(
             endpoint,
+            params={"folder": folder},
             json=payload,
         )
 
     def list(
         self,
         folder: str = "Mobile Users",
+        name: Optional[str] = None,
         **filters,
     ) -> List[AuthSettingsResponseModel]:
         """List GlobalProtect Authentication Settings objects with optional filtering.
 
         Args:
             folder: Folder name (defaults to "Mobile Users" as it's the only valid value)
+            name: Optional name to filter results by (server-side filter)
             **filters: Additional filters (not currently used but included for future expansion)
 
         Returns:
@@ -250,34 +258,47 @@ class AuthSettings(BaseObject):
                 details={"error": "Invalid folder value"},
             )
 
-        container_parameters = {"folder": folder}
+        container_parameters: Dict[str, Any] = {"folder": folder}
+        if name is not None:
+            container_parameters["name"] = name
+
+        limit = self._max_limit
+        offset = 0
+        all_objects: List[AuthSettingsResponseModel] = []
 
         try:
-            # Request all authentication settings
-            response = self.api_client.get(
-                self.ENDPOINT,
-                params=container_parameters,
-            )
+            while True:
+                request_params = {**container_parameters, "limit": limit, "offset": offset}
+                response = self.api_client.get(
+                    self.ENDPOINT,
+                    params=request_params,
+                )
 
-            # Handle direct list response
-            if isinstance(response, list):
-                return [AuthSettingsResponseModel(**item) for item in response]
+                # Handle direct list response
+                if isinstance(response, list):
+                    data_items = response
+                elif (
+                    isinstance(response, dict)
+                    and "data" in response
+                    and isinstance(response["data"], list)
+                ):
+                    data_items = response["data"]
+                else:
+                    # Handle unexpected response format
+                    raise InvalidObjectError(
+                        message="Invalid response format: expected list or dictionary with 'data' field",
+                        error_code="E003",
+                        http_status_code=500,
+                        details={"error": "Response has invalid structure"},
+                    )
 
-            # Handle dict response with data array
-            if (
-                isinstance(response, dict)
-                and "data" in response
-                and isinstance(response["data"], list)
-            ):
-                return [AuthSettingsResponseModel(**item) for item in response["data"]]
+                all_objects.extend(AuthSettingsResponseModel(**item) for item in data_items)
 
-            # Handle unexpected response format
-            raise InvalidObjectError(
-                message="Invalid response format: expected list or dictionary with 'data' field",
-                error_code="E003",
-                http_status_code=500,
-                details={"error": "Response has invalid structure"},
-            )
+                if len(data_items) < limit:
+                    break
+                offset += limit
+
+            return all_objects
         except Exception as e:
             self.logger.error(f"Error listing authentication settings: {str(e)}")
             raise
@@ -320,8 +341,8 @@ class AuthSettings(BaseObject):
                 details={"error": "Invalid folder value"},
             )
 
-        # Get all authentication settings and filter by name
-        all_settings = self.list(folder=folder)
+        # Filter server-side by name, then match exactly
+        all_settings = self.list(folder=folder, name=name)
         matching_settings = [setting for setting in all_settings if setting.name == name]
 
         if not matching_settings:

--- a/scm/config/mobile_agent/tunnel_profiles.py
+++ b/scm/config/mobile_agent/tunnel_profiles.py
@@ -1,0 +1,376 @@
+"""Mobile Agent Tunnel Profiles configuration service for Strata Cloud Manager SDK.
+
+Provides service class for managing GlobalProtect tunnel settings (tunnel profiles)
+via the SCM API.
+"""
+
+# scm/config/mobile_agent/tunnel_profiles.py
+
+# Standard library imports
+import logging
+from typing import Any, Dict, List, Optional
+
+# Local SDK imports
+from scm.config import BaseObject
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+from scm.models.mobile_agent import (
+    TunnelProfileCreateModel,
+    TunnelProfileResponseModel,
+    TunnelProfileUpdateModel,
+)
+
+
+class TunnelProfiles(BaseObject):
+    """Manages GlobalProtect Tunnel Profiles in Palo Alto Networks' Strata Cloud Manager.
+
+    Tunnel profiles are addressed by name within the 'Mobile Users' folder. The API
+    exposes no ID-based endpoints for this resource: create and update operations
+    send the folder as a query parameter, and delete operations address the profile
+    by name and folder query parameters.
+
+    Args:
+        api_client: The API client instance
+        max_limit (Optional[int]): Maximum number of objects to return in a single API request.
+            Defaults to 2500. Must be between 1 and 5000.
+
+    """
+
+    ENDPOINT = "/config/mobile-agent/v1/tunnel-profiles"
+    DEFAULT_MAX_LIMIT = 2500
+    ABSOLUTE_MAX_LIMIT = 5000  # Maximum allowed by the API
+
+    def __init__(
+        self,
+        api_client,
+        max_limit: Optional[int] = None,
+    ):
+        """Initialize the TunnelProfiles service with the given API client.
+
+        Args:
+            api_client: The API client instance.
+            max_limit: Maximum number of items per API request. Defaults to API maximum.
+
+        """
+        super().__init__(api_client)
+        self.logger = logging.getLogger(__name__)
+
+        # Validate and set max_limit
+        self._max_limit = self._validate_max_limit(max_limit)
+
+    @property
+    def max_limit(self) -> int:
+        """Get the current maximum limit for API requests.
+
+        Returns:
+            int
+
+        """
+        return self._max_limit
+
+    @max_limit.setter
+    def max_limit(self, value: int) -> None:
+        """Set a new maximum limit for API requests.
+
+        Args:
+            value: The maximum number of items to return in a single API request.
+
+        """
+        self._max_limit = self._validate_max_limit(value)
+
+    def _validate_max_limit(self, limit: Optional[int]) -> int:
+        """Validate the max_limit parameter.
+
+        Args:
+            limit: The limit to validate
+
+        Returns:
+            int: The validated limit
+
+        Raises:
+            InvalidObjectError: If the limit is invalid
+
+        """
+        if limit is None:
+            return self.DEFAULT_MAX_LIMIT
+
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            raise InvalidObjectError(
+                message="max_limit must be an integer",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit type"},
+            )
+
+        if limit_int < 1:
+            raise InvalidObjectError(
+                message="max_limit must be greater than 0",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid max_limit value"},
+            )
+
+        if limit_int > self.ABSOLUTE_MAX_LIMIT:
+            raise InvalidObjectError(
+                message=f"max_limit cannot exceed {self.ABSOLUTE_MAX_LIMIT}",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "max_limit exceeds maximum allowed value"},
+            )
+
+        return limit_int
+
+    @staticmethod
+    def _validate_folder(folder: str) -> None:
+        """Validate that the folder is 'Mobile Users'.
+
+        Args:
+            folder: The folder value to validate
+
+        Raises:
+            InvalidObjectError: If the folder is not 'Mobile Users'
+
+        """
+        if folder != "Mobile Users":
+            raise InvalidObjectError(
+                message="Folder must be 'Mobile Users' for GlobalProtect Tunnel Profiles",
+                error_code="E003",
+                http_status_code=400,
+                details={"error": "Invalid folder value"},
+            )
+
+    def create(
+        self,
+        data: Dict[str, Any],
+        folder: str = "Mobile Users",
+    ) -> TunnelProfileResponseModel:
+        """Create a new GlobalProtect Tunnel Profile object.
+
+        Args:
+            data: Dictionary containing the tunnel profile configuration
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Returns:
+            TunnelProfileResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or folder is invalid.
+
+        """
+        self._validate_folder(folder)
+
+        # Use the dictionary "data" to pass into Pydantic and return a modeled object
+        tunnel_profile = TunnelProfileCreateModel(**data)
+
+        # Convert back to a Python dictionary, removing any unset fields and using aliases
+        payload = tunnel_profile.model_dump(
+            exclude_unset=True,
+            by_alias=True,
+        )
+
+        # Send the updated object to the remote API as JSON
+        response: Dict[str, Any] = self.api_client.post(
+            self.ENDPOINT,
+            params={"folder": folder},
+            json=payload,
+        )
+
+        # Return the API response as a new Pydantic object
+        return TunnelProfileResponseModel(**response)
+
+    def update(
+        self,
+        data: Dict[str, Any],
+        folder: str = "Mobile Users",
+    ) -> TunnelProfileResponseModel:
+        """Update an existing GlobalProtect Tunnel Profile object.
+
+        The API addresses tunnel profiles by the name in the request body and the
+        folder query parameter; there is no ID-based update endpoint.
+
+        Args:
+            data: Dictionary containing the update configuration (must include 'name')
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Returns:
+            TunnelProfileResponseModel
+
+        Raises:
+            InvalidObjectError: If the provided data or folder is invalid.
+
+        """
+        self._validate_folder(folder)
+
+        # Use the dictionary "data" to pass into Pydantic and return a modeled object
+        tunnel_profile = TunnelProfileUpdateModel(**data)
+
+        # Convert back to a Python dictionary, removing any unset fields and using aliases
+        payload = tunnel_profile.model_dump(
+            exclude_unset=True,
+            by_alias=True,
+        )
+
+        # Send the updated object to the remote API as JSON
+        response: Dict[str, Any] = self.api_client.put(
+            self.ENDPOINT,
+            params={"folder": folder},
+            json=payload,
+        )
+
+        # Return the API response as a new Pydantic model
+        return TunnelProfileResponseModel(**response)
+
+    def list(
+        self,
+        folder: str = "Mobile Users",
+        name: Optional[str] = None,
+        **filters,
+    ) -> List[TunnelProfileResponseModel]:
+        """List GlobalProtect Tunnel Profile objects with optional filtering.
+
+        Args:
+            folder: Folder name (defaults to "Mobile Users" as it's the only valid value)
+            name: Optional name to filter results by (server-side filter)
+            **filters: Additional filters (not currently used but included for future expansion)
+
+        Returns:
+            List[TunnelProfileResponseModel]: A list of tunnel profile objects
+
+        Raises:
+            InvalidObjectError: If the provided data or response format is invalid.
+
+        """
+        self._validate_folder(folder)
+
+        params: Dict[str, Any] = {"folder": folder}
+        if name is not None:
+            params["name"] = name
+
+        limit = self._max_limit
+        offset = 0
+        all_objects: List[TunnelProfileResponseModel] = []
+
+        try:
+            while True:
+                request_params = {**params, "limit": limit, "offset": offset}
+                response = self.api_client.get(
+                    self.ENDPOINT,
+                    params=request_params,
+                )
+
+                # Handle direct list response
+                if isinstance(response, list):
+                    data_items = response
+                elif (
+                    isinstance(response, dict)
+                    and "data" in response
+                    and isinstance(response["data"], list)
+                ):
+                    data_items = response["data"]
+                else:
+                    raise InvalidObjectError(
+                        message="Invalid response format: expected list or dictionary with 'data' field",
+                        error_code="E003",
+                        http_status_code=500,
+                        details={"error": "Response has invalid structure"},
+                    )
+
+                all_objects.extend(TunnelProfileResponseModel(**item) for item in data_items)
+
+                if len(data_items) < limit:
+                    break
+                offset += limit
+
+            return all_objects
+        except Exception as e:
+            self.logger.error(f"Error listing tunnel profiles: {str(e)}")
+            raise
+
+    def fetch(
+        self,
+        name: str,
+        folder: str = "Mobile Users",
+    ) -> TunnelProfileResponseModel:
+        """Fetch a single GlobalProtect Tunnel Profile by name.
+
+        Args:
+            name: The name of the tunnel profile to fetch
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Returns:
+            TunnelProfileResponseModel: The fetched tunnel profile object
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided data or response format is invalid.
+
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        self._validate_folder(folder)
+
+        # Filter server-side by name, then match exactly
+        all_profiles = self.list(folder=folder, name=name)
+        matching_profiles = [profile for profile in all_profiles if profile.name == name]
+
+        if not matching_profiles:
+            raise InvalidObjectError(
+                message=f"Tunnel profile '{name}' not found",
+                error_code="E002",
+                http_status_code=404,
+                details={"error": "No matching tunnel profile found"},
+            )
+
+        if len(matching_profiles) > 1:
+            self.logger.warning(
+                f"Multiple tunnel profiles found for '{name}'. Using the first one."
+            )
+
+        return matching_profiles[0]
+
+    def delete(
+        self,
+        name: str,
+        folder: str = "Mobile Users",
+    ) -> None:
+        """Delete a GlobalProtect Tunnel Profile object.
+
+        The API addresses tunnel profiles by name and folder query parameters;
+        there is no ID-based delete endpoint.
+
+        Args:
+            name: The name of the tunnel profile to delete
+            folder: The folder in which the resource is defined (must be "Mobile Users")
+
+        Raises:
+            MissingQueryParameterError: If a required query parameter is missing or empty.
+            InvalidObjectError: If the provided folder is invalid.
+
+        """
+        if not name:
+            raise MissingQueryParameterError(
+                message="Field 'name' cannot be empty",
+                error_code="E003",
+                http_status_code=400,
+                details={
+                    "field": "name",
+                    "error": '"name" is not allowed to be empty',
+                },
+            )
+
+        self._validate_folder(folder)
+
+        self.api_client.delete(
+            self.ENDPOINT,
+            params={"name": name, "folder": folder},
+        )

--- a/scm/models/mobile_agent/__init__.py
+++ b/scm/models/mobile_agent/__init__.py
@@ -39,6 +39,20 @@ from .infrastructure_settings import (
     UserGroup,
     WinsServerEntry,
 )
+from .tunnel_profiles import (
+    AcceptCookie,
+    AuthenticationOverride,
+    CookieLifetime,
+    SourceAddress,
+    SplitTunneling,
+    SplitTunnelingDomainEntry,
+    SplitTunnelingDomains,
+    TunnelOperatingSystem,
+    TunnelProfileBaseModel,
+    TunnelProfileCreateModel,
+    TunnelProfileResponseModel,
+    TunnelProfileUpdateModel,
+)
 
 __all__ = [
     "OperatingSystem",
@@ -73,4 +87,16 @@ __all__ = [
     "UdpQueryRetries",
     "UserGroup",
     "WinsServerEntry",
+    "AcceptCookie",
+    "AuthenticationOverride",
+    "CookieLifetime",
+    "SourceAddress",
+    "SplitTunneling",
+    "SplitTunnelingDomainEntry",
+    "SplitTunnelingDomains",
+    "TunnelOperatingSystem",
+    "TunnelProfileBaseModel",
+    "TunnelProfileCreateModel",
+    "TunnelProfileUpdateModel",
+    "TunnelProfileResponseModel",
 ]

--- a/scm/models/mobile_agent/auth_settings.py
+++ b/scm/models/mobile_agent/auth_settings.py
@@ -204,6 +204,8 @@ class AuthSettingsMoveModel(BaseModel):
         where (MovePosition): The position to move to (before, after, top, bottom).
         destination (Optional[str]): The name of the destination authentication settings
                                      (required for before/after).
+        folder (Optional[str]): The folder in which the resource is defined
+                                (must be 'Mobile Users').
 
     Error:
         ValueError: Raised when destination is not provided for 'before' or 'after' positions.
@@ -228,6 +230,22 @@ class AuthSettingsMoveModel(BaseModel):
         None,
         description="The name of the destination authentication settings (required for before/after)",
     )
+    folder: Optional[str] = Field(
+        None,
+        pattern=r"^[a-zA-Z\d\-_. ]+$",
+        max_length=64,
+        description="The folder in which the resource is defined",
+        examples=["Mobile Users"],
+    )
+
+    @field_validator("folder")
+    def validate_folder(cls, v):  # noqa
+        """Validate that folder is 'Mobile Users' if provided."""
+        if v is not None and v != "Mobile Users":
+            raise ValueError(
+                "Folder must be 'Mobile Users' for GlobalProtect Authentication Settings"
+            )
+        return v
 
     @model_validator(mode="after")
     def validate_destination_required(self) -> "AuthSettingsMoveModel":

--- a/scm/models/mobile_agent/tunnel_profiles.py
+++ b/scm/models/mobile_agent/tunnel_profiles.py
@@ -1,0 +1,340 @@
+"""Tunnel Profiles models for Strata Cloud Manager SDK.
+
+Contains Pydantic models for representing GlobalProtect tunnel settings
+(tunnel profiles) and related data.
+"""
+
+# scm/models/mobile_agent/tunnel_profiles.py
+
+# Standard library imports
+from enum import Enum
+from typing import List, Optional
+
+# External libraries
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class TunnelOperatingSystem(str, Enum):
+    """Available operating systems for GlobalProtect tunnel profiles."""
+
+    ANDROID = "Android"
+    CHROME = "Chrome"
+    IOT = "IoT"
+    LINUX = "Linux"
+    MAC = "Mac"
+    WINDOWS = "Windows"
+    WINDOWS_UWP = "WindowsUWP"
+    IOS = "iOS"
+
+
+class CookieLifetime(BaseModel):
+    """Cookie lifetime configuration for authentication override cookies.
+
+    Attributes:
+        lifetime_in_days (Optional[int]): Cookie lifetime in days (1-365).
+        lifetime_in_hours (Optional[int]): Cookie lifetime in hours (1-72).
+        lifetime_in_minutes (Optional[int]): Cookie lifetime in minutes (1-59).
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    lifetime_in_days: Optional[int] = Field(
+        None,
+        ge=1,
+        le=365,
+        description="Cookie lifetime in days (1-365)",
+    )
+    lifetime_in_hours: Optional[int] = Field(
+        None,
+        ge=1,
+        le=72,
+        description="Cookie lifetime in hours (1-72)",
+    )
+    lifetime_in_minutes: Optional[int] = Field(
+        None,
+        ge=1,
+        le=59,
+        description="Cookie lifetime in minutes (1-59)",
+    )
+
+
+class AcceptCookie(BaseModel):
+    """Accept cookie configuration for authentication override.
+
+    Attributes:
+        cookie_lifetime (Optional[CookieLifetime]): The lifetime of the authentication cookie.
+        cookie_encrypt_decrypt_cert (Optional[str]): The certificate used to encrypt and
+            decrypt the authentication cookie.
+        generate_cookie (Optional[bool]): Whether to generate an authentication cookie.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    cookie_lifetime: Optional[CookieLifetime] = Field(
+        None,
+        description="The lifetime of the authentication cookie",
+    )
+    cookie_encrypt_decrypt_cert: Optional[str] = Field(
+        None,
+        description="The certificate used to encrypt and decrypt the authentication cookie",
+    )
+    generate_cookie: Optional[bool] = Field(
+        None,
+        description="Whether to generate an authentication cookie",
+    )
+
+
+class AuthenticationOverride(BaseModel):
+    """Authentication override configuration for tunnel profiles.
+
+    Attributes:
+        accept_cookie (Optional[AcceptCookie]): Accept cookie configuration.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    accept_cookie: Optional[AcceptCookie] = Field(
+        None,
+        description="Accept cookie configuration",
+    )
+
+
+class SourceAddress(BaseModel):
+    """Source address configuration for tunnel profiles.
+
+    Attributes:
+        ip_address (Optional[List[str]]): List of source IP addresses.
+        region (Optional[List[str]]): List of source regions.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    ip_address: Optional[List[str]] = Field(
+        None,
+        description="List of source IP addresses",
+    )
+    region: Optional[List[str]] = Field(
+        None,
+        description="List of source regions",
+    )
+
+
+class SplitTunnelingDomainEntry(BaseModel):
+    """Domain entry for split tunneling include/exclude domain lists.
+
+    Attributes:
+        name (Optional[str]): The domain name.
+        ports (Optional[List[int]]): The ports for the domain (1-65535).
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    name: Optional[str] = Field(
+        None,
+        description="The domain name",
+    )
+    ports: Optional[List[int]] = Field(
+        None,
+        description="The ports for the domain (1-65535)",
+    )
+
+    @field_validator("ports")
+    def validate_ports(cls, v):  # noqa
+        """Validate that each port is within the valid range (1-65535)."""
+        if v is not None:
+            for port in v:
+                if port < 1 or port > 65535:
+                    raise ValueError("Ports must be between 1 and 65535")
+        return v
+
+
+class SplitTunnelingDomains(BaseModel):
+    """Domain list container for split tunneling include/exclude domains.
+
+    Attributes:
+        list (Optional[List[SplitTunnelingDomainEntry]]): List of domain entries.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    list: Optional[List[SplitTunnelingDomainEntry]] = Field(
+        None,
+        description="List of domain entries",
+    )
+
+
+class SplitTunneling(BaseModel):
+    """Split tunneling configuration for tunnel profiles.
+
+    Attributes:
+        access_route (Optional[List[str]]): Routes included in the tunnel.
+        exclude_access_route (Optional[List[str]]): Routes excluded from the tunnel.
+        exclude_applications (Optional[List[str]]): Applications excluded from the tunnel.
+        exclude_domains (Optional[SplitTunnelingDomains]): Domains excluded from the tunnel.
+        include_applications (Optional[List[str]]): Applications included in the tunnel.
+        include_domains (Optional[SplitTunnelingDomains]): Domains included in the tunnel.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+    )
+
+    access_route: Optional[List[str]] = Field(
+        None,
+        description="Routes included in the tunnel",
+    )
+    exclude_access_route: Optional[List[str]] = Field(
+        None,
+        description="Routes excluded from the tunnel",
+    )
+    exclude_applications: Optional[List[str]] = Field(
+        None,
+        description="Applications excluded from the tunnel",
+    )
+    exclude_domains: Optional[SplitTunnelingDomains] = Field(
+        None,
+        description="Domains excluded from the tunnel",
+    )
+    include_applications: Optional[List[str]] = Field(
+        None,
+        description="Applications included in the tunnel",
+    )
+    include_domains: Optional[SplitTunnelingDomains] = Field(
+        None,
+        description="Domains included in the tunnel",
+    )
+
+
+class TunnelProfileBaseModel(BaseModel):
+    """Base model for GlobalProtect Tunnel Profiles containing fields common to all CRUD operations.
+
+    Attributes:
+        name (str): The name of the tunnel profile.
+        authentication_override (Optional[AuthenticationOverride]): Authentication override
+            configuration.
+        no_direct_access_to_local_network (Optional[bool]): Whether direct access to the
+            local network is disabled.
+        os (Optional[List[TunnelOperatingSystem]]): The operating systems this tunnel
+            profile applies to.
+        retrieve_framed_ip_address (Optional[bool]): Whether to retrieve the framed IP
+            address from the authentication server.
+        source_address (Optional[SourceAddress]): Source address configuration.
+        source_user (Optional[List[str]]): The source users this tunnel profile applies to.
+        split_tunneling (Optional[SplitTunneling]): Split tunneling configuration.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=31,
+        description="The name of the tunnel profile",
+    )
+    authentication_override: Optional[AuthenticationOverride] = Field(
+        None,
+        description="Authentication override configuration",
+    )
+    no_direct_access_to_local_network: Optional[bool] = Field(
+        None,
+        description="Whether direct access to the local network is disabled",
+    )
+    os: Optional[List[TunnelOperatingSystem]] = Field(
+        None,
+        description="The operating systems this tunnel profile applies to",
+    )
+    retrieve_framed_ip_address: Optional[bool] = Field(
+        None,
+        description="Whether to retrieve the framed IP address from the authentication server",
+    )
+    source_address: Optional[SourceAddress] = Field(
+        None,
+        description="Source address configuration",
+    )
+    source_user: Optional[List[str]] = Field(
+        None,
+        description="The source users this tunnel profile applies to",
+    )
+    split_tunneling: Optional[SplitTunneling] = Field(
+        None,
+        description="Split tunneling configuration",
+    )
+
+
+class TunnelProfileCreateModel(TunnelProfileBaseModel):
+    """Represents the creation of a new GlobalProtect Tunnel Profile.
+
+    Tunnel profiles are addressed by name within the 'Mobile Users' folder, which
+    is supplied as a query parameter by the service class rather than in the body.
+    """
+
+
+class TunnelProfileUpdateModel(TunnelProfileBaseModel):
+    """Represents the update of an existing GlobalProtect Tunnel Profile.
+
+    Tunnel profiles have no unique identifier in the API; updates are addressed
+    by the profile name within the 'Mobile Users' folder.
+    """
+
+
+class TunnelProfileResponseModel(TunnelProfileBaseModel):
+    """Represents the response model for GlobalProtect Tunnel Profiles.
+
+    This class defines the structure for tunnel profiles returned by the API.
+
+    Attributes:
+        folder (Optional[str]): The folder in which the resource is defined.
+
+    """
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    )
+
+    folder: Optional[str] = Field(
+        None,
+        description="The folder in which the resource is defined",
+        examples=["Mobile Users"],
+    )

--- a/tests/scm/config/mobile_agent/test_auth_settings.py
+++ b/tests/scm/config/mobile_agent/test_auth_settings.py
@@ -105,11 +105,14 @@ class TestAuthSettings:
         assert isinstance(result, AuthSettingsResponseModel)
         assert result.name == "test-auth-settings"
 
-        # Verify the API client was called correctly
+        # Verify the API client was called correctly: folder is sent as a
+        # query parameter per the spec, not in the request body
         mock_api_client.post.assert_called_once()
         call_args = mock_api_client.post.call_args
         assert call_args[0][0] == auth_settings.ENDPOINT
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
         assert "json" in call_args[1]
+        assert "folder" not in call_args[1]["json"]
 
     def test_get(self, auth_settings, mock_api_client):
         """Test get method for fetching auth settings by ID."""
@@ -173,11 +176,33 @@ class TestAuthSettings:
         # Call the method
         auth_settings.move(test_move_data)
 
-        # Verify the API client was called correctly
+        # Verify the API client was called correctly: the object is addressed
+        # by name in the path ({name}:move) with folder as a query parameter
         mock_api_client.post.assert_called_once()
         call_args = mock_api_client.post.call_args
-        assert call_args[0][0] == f"{auth_settings.ENDPOINT}/move"
+        assert call_args[0][0] == f"{auth_settings.ENDPOINT}/test-auth-settings:move"
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
         assert "json" in call_args[1]
+        # destination is unset for top/bottom moves and must not be sent
+        assert "destination" not in call_args[1]["json"]
+
+    def test_move_with_folder(self, auth_settings, mock_api_client):
+        """Test move method with an explicit folder in the move data."""
+        test_move_data = {
+            "name": "test-auth-settings",
+            "where": "before",
+            "destination": "other-settings",
+            "folder": "Mobile Users",
+        }
+
+        auth_settings.move(test_move_data)
+
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == f"{auth_settings.ENDPOINT}/test-auth-settings:move"
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert call_args[1]["json"]["destination"] == "other-settings"
+        assert call_args[1]["json"]["folder"] == "Mobile Users"
 
     def test_list_with_invalid_folder(self, auth_settings):
         """Test list method with invalid folder."""
@@ -219,7 +244,7 @@ class TestAuthSettings:
         mock_api_client.get.assert_called_once()
         call_args = mock_api_client.get.call_args
         assert call_args[0][0] == auth_settings.ENDPOINT
-        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
 
     def test_list_with_dict_response(self, auth_settings, mock_api_client):
         """Test list method with dictionary response format."""
@@ -256,7 +281,53 @@ class TestAuthSettings:
         mock_api_client.get.assert_called_once()
         call_args = mock_api_client.get.call_args
         assert call_args[0][0] == auth_settings.ENDPOINT
-        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+
+    def test_list_with_name_filter(self, auth_settings, mock_api_client):
+        """Test list method passes the server-side name filter."""
+        mock_api_client.get.return_value = {"data": []}
+
+        auth_settings.list(name="auth-settings-1")
+
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["name"] == "auth-settings-1"
+
+    def test_list_pagination(self, auth_settings, mock_api_client):
+        """Test list method paginates through multiple pages."""
+        auth_settings._max_limit = 2
+        page_one = {
+            "data": [
+                {
+                    "name": "auth-settings-1",
+                    "authentication_profile": "profile-1",
+                    "folder": "Mobile Users",
+                },
+                {
+                    "name": "auth-settings-2",
+                    "authentication_profile": "profile-2",
+                    "folder": "Mobile Users",
+                },
+            ]
+        }
+        page_two = {
+            "data": [
+                {
+                    "name": "auth-settings-3",
+                    "authentication_profile": "profile-3",
+                    "folder": "Mobile Users",
+                },
+            ]
+        }
+        mock_api_client.get.side_effect = [page_one, page_two]
+
+        result = auth_settings.list()
+
+        assert len(result) == 3
+        assert mock_api_client.get.call_count == 2
+        first_call_params = mock_api_client.get.call_args_list[0][1]["params"]
+        second_call_params = mock_api_client.get.call_args_list[1][1]["params"]
+        assert first_call_params["offset"] == 0
+        assert second_call_params["offset"] == 2
 
     def test_list_with_invalid_response(self, auth_settings, mock_api_client):
         """Test list method with invalid response structure."""
@@ -316,11 +387,12 @@ class TestAuthSettings:
         assert isinstance(result, AuthSettingsResponseModel)
         assert result.name == test_name
 
-        # Verify the API client was called correctly
+        # Verify the API client was called correctly with the server-side name filter
         mock_api_client.get.assert_called_once()
         call_args = mock_api_client.get.call_args
         assert call_args[0][0] == auth_settings.ENDPOINT
-        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+        assert call_args[1]["params"]["name"] == test_name
 
     def test_fetch_with_multiple_matching_settings(self, auth_settings, mock_api_client):
         """Test fetch method when multiple matching settings are found."""
@@ -350,11 +422,12 @@ class TestAuthSettings:
         assert result.name == test_name
         assert result.authentication_profile == "profile-1"  # Should return the first match
 
-        # Verify the API client was called correctly
+        # Verify the API client was called correctly with the server-side name filter
         mock_api_client.get.assert_called_once()
         call_args = mock_api_client.get.call_args
         assert call_args[0][0] == auth_settings.ENDPOINT
-        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+        assert call_args[1]["params"]["name"] == test_name
 
     def test_delete(self, auth_settings, mock_api_client):
         """Test delete method for removing auth settings."""

--- a/tests/scm/config/mobile_agent/test_tunnel_profiles.py
+++ b/tests/scm/config/mobile_agent/test_tunnel_profiles.py
@@ -1,0 +1,374 @@
+"""Test module for Mobile Agent Tunnel Profiles configuration service.
+
+This module contains unit tests for the Mobile Agent Tunnel Profiles configuration
+service and its related models.
+"""
+# tests/scm/config/mobile_agent/test_tunnel_profiles.py
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scm.config.mobile_agent import TunnelProfiles
+from scm.exceptions import InvalidObjectError, MissingQueryParameterError
+from scm.models.mobile_agent import TunnelProfileResponseModel
+
+
+class TestTunnelProfiles:
+    """Test cases for TunnelProfiles mobile agent configuration."""
+
+    @pytest.fixture
+    def mock_api_client(self):
+        """Test fixture for mock API client."""
+        mock_client = MagicMock()
+        return mock_client
+
+    @pytest.fixture
+    def tunnel_profiles(self, mock_api_client):
+        """Test fixture for TunnelProfiles instance."""
+        # Patch the isinstance check
+        with patch("scm.config.isinstance", return_value=True):
+            service = TunnelProfiles(mock_api_client)
+            service.logger = MagicMock()
+            return service
+
+    def test_init_with_default_max_limit(self, mock_api_client):
+        """Test initialization with default max limit value."""
+        with patch("scm.config.isinstance", return_value=True):
+            service = TunnelProfiles(mock_api_client)
+            assert service._max_limit == TunnelProfiles.DEFAULT_MAX_LIMIT
+
+    def test_init_with_custom_max_limit(self, mock_api_client):
+        """Test initialization with custom max limit."""
+        with patch("scm.config.isinstance", return_value=True):
+            custom_limit = 1000
+            service = TunnelProfiles(mock_api_client, max_limit=custom_limit)
+            assert service._max_limit == custom_limit
+
+    def test_validate_max_limit_with_invalid_type(self, tunnel_profiles):
+        """Test validate_max_limit with invalid type."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles._validate_max_limit("not_an_int")
+        error = excinfo.value
+        assert "Invalid max_limit type" in str(error.details)
+
+    def test_validate_max_limit_with_negative_value(self, tunnel_profiles):
+        """Test validate_max_limit with negative value."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles._validate_max_limit(-1)
+        error = excinfo.value
+        assert "Invalid max_limit value" in str(error.details)
+
+    def test_validate_max_limit_with_too_large_value(self, tunnel_profiles):
+        """Test validate_max_limit with value exceeding absolute max."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles._validate_max_limit(TunnelProfiles.ABSOLUTE_MAX_LIMIT + 1)
+        error = excinfo.value
+        assert "max_limit exceeds maximum allowed value" in str(error.details)
+
+    def test_validate_max_limit_with_valid_value(self, tunnel_profiles):
+        """Test validate_max_limit with valid value."""
+        result = tunnel_profiles._validate_max_limit(1000)
+        assert result == 1000
+
+    def test_max_limit_property_getter(self, tunnel_profiles):
+        """Test max_limit property getter."""
+        tunnel_profiles._max_limit = 1000
+        assert tunnel_profiles.max_limit == 1000
+
+    def test_max_limit_property_setter(self, tunnel_profiles):
+        """Test max_limit property setter."""
+        tunnel_profiles._validate_max_limit = MagicMock(return_value=1000)
+        tunnel_profiles.max_limit = 1000
+        assert tunnel_profiles._max_limit == 1000
+
+    def test_create(self, tunnel_profiles, mock_api_client):
+        """Test create method for tunnel profiles."""
+        # Prepare test data
+        test_data = {
+            "name": "test-tunnel",
+            "os": ["Windows", "Mac"],
+            "no_direct_access_to_local_network": True,
+        }
+        mock_response = {
+            "name": "test-tunnel",
+            "os": ["Windows", "Mac"],
+            "no_direct_access_to_local_network": True,
+            "folder": "Mobile Users",
+        }
+        mock_api_client.post.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.create(test_data)
+
+        # Verify the result
+        assert isinstance(result, TunnelProfileResponseModel)
+        assert result.name == "test-tunnel"
+
+        # Verify the API client was called correctly
+        mock_api_client.post.assert_called_once()
+        call_args = mock_api_client.post.call_args
+        assert call_args[0][0] == tunnel_profiles.ENDPOINT
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert "json" in call_args[1]
+        assert call_args[1]["json"]["name"] == "test-tunnel"
+
+    def test_create_with_invalid_folder(self, tunnel_profiles):
+        """Test create method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.create({"name": "test-tunnel"}, folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_create_with_nested_configuration(self, tunnel_profiles, mock_api_client):
+        """Test create method with nested split tunneling configuration."""
+        test_data = {
+            "name": "test-tunnel",
+            "split_tunneling": {
+                "access_route": ["10.1.0.0/16"],
+                "exclude_domains": {"list": [{"name": "example.com", "ports": [443]}]},
+            },
+        }
+        mock_response = {**test_data, "folder": "Mobile Users"}
+        mock_api_client.post.return_value = mock_response
+
+        result = tunnel_profiles.create(test_data)
+
+        assert isinstance(result, TunnelProfileResponseModel)
+        assert result.split_tunneling.access_route == ["10.1.0.0/16"]
+        assert result.split_tunneling.exclude_domains.list[0].name == "example.com"
+
+    def test_update(self, tunnel_profiles, mock_api_client):
+        """Test update method for modifying tunnel profiles."""
+        # Prepare test data
+        test_data = {
+            "name": "test-tunnel",
+            "retrieve_framed_ip_address": True,
+        }
+        mock_response = {
+            "name": "test-tunnel",
+            "retrieve_framed_ip_address": True,
+            "folder": "Mobile Users",
+        }
+        mock_api_client.put.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.update(test_data)
+
+        # Verify the result
+        assert isinstance(result, TunnelProfileResponseModel)
+        assert result.name == "test-tunnel"
+
+        # Verify the API client was called correctly: no ID in the URL,
+        # object addressed by name in body + folder query param
+        mock_api_client.put.assert_called_once()
+        call_args = mock_api_client.put.call_args
+        assert call_args[0][0] == tunnel_profiles.ENDPOINT
+        assert call_args[1]["params"] == {"folder": "Mobile Users"}
+        assert "json" in call_args[1]
+        assert call_args[1]["json"]["name"] == "test-tunnel"
+
+    def test_update_with_invalid_folder(self, tunnel_profiles):
+        """Test update method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.update({"name": "test-tunnel"}, folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_list_with_invalid_folder(self, tunnel_profiles):
+        """Test list method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.list(folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_list_with_list_response(self, tunnel_profiles, mock_api_client):
+        """Test list method with list response format."""
+        # Prepare test data
+        mock_response = [
+            {"name": "tunnel-1", "os": ["Windows"], "folder": "Mobile Users"},
+            {"name": "tunnel-2", "os": ["Mac"], "folder": "Mobile Users"},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.list()
+
+        # Verify the result
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(item, TunnelProfileResponseModel) for item in result)
+        assert result[0].name == "tunnel-1"
+        assert result[1].name == "tunnel-2"
+
+        # Verify the API client was called correctly
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == tunnel_profiles.ENDPOINT
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+
+    def test_list_with_dict_response(self, tunnel_profiles, mock_api_client):
+        """Test list method with dictionary response format."""
+        # Prepare test data
+        mock_response = {
+            "data": [
+                {"name": "tunnel-1", "os": ["Windows"], "folder": "Mobile Users"},
+                {"name": "tunnel-2", "os": ["Mac"], "folder": "Mobile Users"},
+            ],
+            "limit": 200,
+            "offset": 0,
+            "total": 2,
+        }
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.list()
+
+        # Verify the result
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(item, TunnelProfileResponseModel) for item in result)
+        assert result[0].name == "tunnel-1"
+        assert result[1].name == "tunnel-2"
+
+        # Verify the API client was called correctly
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == tunnel_profiles.ENDPOINT
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+
+    def test_list_with_name_filter(self, tunnel_profiles, mock_api_client):
+        """Test list method passes the server-side name filter."""
+        mock_api_client.get.return_value = {"data": []}
+
+        tunnel_profiles.list(name="tunnel-1")
+
+        call_args = mock_api_client.get.call_args
+        assert call_args[1]["params"]["name"] == "tunnel-1"
+
+    def test_list_pagination(self, tunnel_profiles, mock_api_client):
+        """Test list method paginates through multiple pages."""
+        tunnel_profiles._max_limit = 2
+        page_one = {
+            "data": [
+                {"name": "tunnel-1", "folder": "Mobile Users"},
+                {"name": "tunnel-2", "folder": "Mobile Users"},
+            ]
+        }
+        page_two = {"data": [{"name": "tunnel-3", "folder": "Mobile Users"}]}
+        mock_api_client.get.side_effect = [page_one, page_two]
+
+        result = tunnel_profiles.list()
+
+        assert len(result) == 3
+        assert mock_api_client.get.call_count == 2
+        first_call_params = mock_api_client.get.call_args_list[0][1]["params"]
+        second_call_params = mock_api_client.get.call_args_list[1][1]["params"]
+        assert first_call_params["offset"] == 0
+        assert second_call_params["offset"] == 2
+
+    def test_list_with_invalid_response(self, tunnel_profiles, mock_api_client):
+        """Test list method with invalid response structure."""
+        # Prepare test data
+        mock_response = {"invalid": "response"}
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.list()
+        error = excinfo.value
+        assert "Response has invalid structure" in str(error.details)
+
+    def test_fetch_with_empty_name(self, tunnel_profiles):
+        """Test fetch method with empty name parameter."""
+        with pytest.raises(MissingQueryParameterError) as excinfo:
+            tunnel_profiles.fetch("")
+        error = excinfo.value
+        assert "name" in str(error.details["field"])
+
+    def test_fetch_with_invalid_folder(self, tunnel_profiles):
+        """Test fetch method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.fetch("test-name", folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)
+
+    def test_fetch_with_no_matching_profiles(self, tunnel_profiles, mock_api_client):
+        """Test fetch method when no matching profiles are found."""
+        # Prepare test data
+        mock_api_client.get.return_value = []
+
+        # Call the method
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.fetch("non-existent")
+        error = excinfo.value
+        assert "No matching tunnel profile found" in str(error.details)
+
+    def test_fetch_with_one_matching_profile(self, tunnel_profiles, mock_api_client):
+        """Test fetch method when one matching profile is found."""
+        # Prepare test data
+        test_name = "test-tunnel"
+        mock_response = [
+            {"name": test_name, "os": ["Windows"], "folder": "Mobile Users"},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.fetch(test_name)
+
+        # Verify the result
+        assert isinstance(result, TunnelProfileResponseModel)
+        assert result.name == test_name
+
+        # Verify the API client was called correctly with the server-side name filter
+        mock_api_client.get.assert_called_once()
+        call_args = mock_api_client.get.call_args
+        assert call_args[0][0] == tunnel_profiles.ENDPOINT
+        assert call_args[1]["params"]["folder"] == "Mobile Users"
+        assert call_args[1]["params"]["name"] == test_name
+
+    def test_fetch_with_multiple_matching_profiles(self, tunnel_profiles, mock_api_client):
+        """Test fetch method when multiple matching profiles are found."""
+        # Prepare test data
+        test_name = "test-tunnel"
+        mock_response = [
+            {"name": test_name, "os": ["Windows"], "folder": "Mobile Users"},
+            {"name": test_name, "os": ["Mac"], "folder": "Mobile Users"},
+        ]
+        mock_api_client.get.return_value = mock_response
+
+        # Call the method
+        result = tunnel_profiles.fetch(test_name)
+
+        # Verify the result: should return the first match
+        assert isinstance(result, TunnelProfileResponseModel)
+        assert result.name == test_name
+        assert result.os[0].value == "Windows"
+
+    def test_delete(self, tunnel_profiles, mock_api_client):
+        """Test delete method for removing tunnel profiles."""
+        # Prepare test data
+        test_name = "test-tunnel"
+
+        # Call the method
+        tunnel_profiles.delete(test_name)
+
+        # Verify the API client was called correctly: name + folder query params, no ID path
+        mock_api_client.delete.assert_called_once_with(
+            tunnel_profiles.ENDPOINT,
+            params={"name": test_name, "folder": "Mobile Users"},
+        )
+
+    def test_delete_with_empty_name(self, tunnel_profiles):
+        """Test delete method with empty name parameter."""
+        with pytest.raises(MissingQueryParameterError) as excinfo:
+            tunnel_profiles.delete("")
+        error = excinfo.value
+        assert "name" in str(error.details["field"])
+
+    def test_delete_with_invalid_folder(self, tunnel_profiles):
+        """Test delete method with invalid folder."""
+        with pytest.raises(InvalidObjectError) as excinfo:
+            tunnel_profiles.delete("test-tunnel", folder="Invalid")
+        error = excinfo.value
+        assert "Invalid folder value" in str(error.details)

--- a/tests/scm/models/mobile_agent/factories.py
+++ b/tests/scm/models/mobile_agent/factories.py
@@ -30,6 +30,13 @@ from scm.models.mobile_agent.infrastructure_settings import (
     PortalHostname,
     PublicDnsServer,
 )
+from scm.models.mobile_agent.tunnel_profiles import (
+    TunnelOperatingSystem,
+    TunnelProfileBaseModel,
+    TunnelProfileCreateModel,
+    TunnelProfileResponseModel,
+    TunnelProfileUpdateModel,
+)
 
 # Create a single faker instance
 fake = FakerGenerator()
@@ -416,3 +423,125 @@ class GlobalSettingsResponseModelFactory(Factory):
         lambda: f"{fake.random_int(min=5, max=6)}.{fake.random_int(min=0, max=9)}.{fake.random_int(min=0, max=9)}"
     )
     manual_gateway = None
+
+
+class TunnelProfileBaseModelFactory(Factory):
+    """Factory for TunnelProfileBaseModel."""
+
+    class Meta:
+        """Meta class for TunnelProfileBaseModelFactory."""
+
+        model = TunnelProfileBaseModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    no_direct_access_to_local_network = Faker("pybool")
+    os = factory.LazyFunction(lambda: [TunnelOperatingSystem.WINDOWS, TunnelOperatingSystem.MAC])
+    retrieve_framed_ip_address = Faker("pybool")
+    source_user = factory.LazyFunction(lambda: [fake.user_name() for _ in range(2)])
+
+
+class TunnelProfileCreateModelFactory(Factory):
+    """Factory for TunnelProfileCreateModel."""
+
+    class Meta:
+        """Meta class for TunnelProfileCreateModelFactory."""
+
+        model = TunnelProfileCreateModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    no_direct_access_to_local_network = Faker("pybool")
+    os = factory.LazyFunction(lambda: [TunnelOperatingSystem.WINDOWS])
+    retrieve_framed_ip_address = Faker("pybool")
+
+    @classmethod
+    def build_valid(cls):
+        """Build valid data for TunnelProfileCreateModel."""
+        return {
+            "name": fake.pystr(min_chars=5, max_chars=30),
+            "no_direct_access_to_local_network": fake.pybool(),
+            "os": [TunnelOperatingSystem.WINDOWS],
+            "retrieve_framed_ip_address": fake.pybool(),
+        }
+
+    @classmethod
+    def build_valid_full(cls):
+        """Build valid data with all nested structures for TunnelProfileCreateModel."""
+        return {
+            "name": fake.pystr(min_chars=5, max_chars=30),
+            "authentication_override": {
+                "accept_cookie": {
+                    "cookie_lifetime": {"lifetime_in_hours": 24},
+                    "cookie_encrypt_decrypt_cert": "test-cert",
+                    "generate_cookie": True,
+                }
+            },
+            "no_direct_access_to_local_network": True,
+            "os": [TunnelOperatingSystem.WINDOWS, TunnelOperatingSystem.IOS],
+            "retrieve_framed_ip_address": False,
+            "source_address": {
+                "ip_address": ["10.0.0.0/24"],
+                "region": ["US"],
+            },
+            "source_user": ["user1", "user2"],
+            "split_tunneling": {
+                "access_route": ["10.1.0.0/16"],
+                "exclude_access_route": ["10.2.0.0/16"],
+                "exclude_applications": ["app1"],
+                "exclude_domains": {"list": [{"name": "example.com", "ports": [443]}]},
+                "include_applications": ["app2"],
+                "include_domains": {"list": [{"name": "internal.example.com", "ports": [80, 443]}]},
+            },
+        }
+
+    @classmethod
+    def build_invalid_name(cls):
+        """Build data with invalid (too long) name for TunnelProfileCreateModel."""
+        data = cls.build_valid()
+        data["name"] = "x" * 32  # exceeds 31 char max
+        return data
+
+    @classmethod
+    def build_invalid_os(cls):
+        """Build data with invalid os value for TunnelProfileCreateModel."""
+        data = cls.build_valid()
+        data["os"] = ["InvalidOS"]
+        return data
+
+
+class TunnelProfileUpdateModelFactory(Factory):
+    """Factory for TunnelProfileUpdateModel."""
+
+    class Meta:
+        """Meta class for TunnelProfileUpdateModelFactory."""
+
+        model = TunnelProfileUpdateModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    no_direct_access_to_local_network = Faker("pybool")
+    os = factory.LazyFunction(lambda: [TunnelOperatingSystem.LINUX])
+    retrieve_framed_ip_address = Faker("pybool")
+
+    @classmethod
+    def build_valid(cls):
+        """Build valid data for TunnelProfileUpdateModel."""
+        return {
+            "name": fake.pystr(min_chars=5, max_chars=30),
+            "no_direct_access_to_local_network": fake.pybool(),
+            "os": [TunnelOperatingSystem.LINUX],
+            "retrieve_framed_ip_address": fake.pybool(),
+        }
+
+
+class TunnelProfileResponseModelFactory(Factory):
+    """Factory for TunnelProfileResponseModel."""
+
+    class Meta:
+        """Meta class for TunnelProfileResponseModelFactory."""
+
+        model = TunnelProfileResponseModel
+
+    name = Faker("pystr", min_chars=5, max_chars=30)
+    no_direct_access_to_local_network = Faker("pybool")
+    os = factory.LazyFunction(lambda: [TunnelOperatingSystem.WINDOWS])
+    retrieve_framed_ip_address = Faker("pybool")
+    folder = "Mobile Users"

--- a/tests/scm/models/mobile_agent/test_auth_settings_models.py
+++ b/tests/scm/models/mobile_agent/test_auth_settings_models.py
@@ -395,6 +395,33 @@ class TestAuthSettingsMoveModel:
             AuthSettingsMoveModel(**data)
         assert "where\n  Input should be" in str(exc_info.value)
 
+    def test_move_model_with_valid_folder(self):
+        """Test that the optional folder field accepts 'Mobile Users'."""
+        model = AuthSettingsMoveModel(
+            name="test-settings",
+            where=MovePosition.TOP,
+            folder="Mobile Users",
+        )
+        assert model.folder == "Mobile Users"
+
+    def test_move_model_without_folder(self):
+        """Test that the folder field defaults to None."""
+        model = AuthSettingsMoveModel(
+            name="test-settings",
+            where=MovePosition.TOP,
+        )
+        assert model.folder is None
+
+    def test_move_model_with_invalid_folder(self):
+        """Test validation when folder is not 'Mobile Users'."""
+        with pytest.raises(ValueError) as exc_info:
+            AuthSettingsMoveModel(
+                name="test-settings",
+                where=MovePosition.TOP,
+                folder="Shared",
+            )
+        assert "Folder must be 'Mobile Users'" in str(exc_info.value)
+
 
 class TestExtraFieldsForbidden:
     """Test that extra fields are rejected by all models."""

--- a/tests/scm/models/mobile_agent/test_tunnel_profiles_models.py
+++ b/tests/scm/models/mobile_agent/test_tunnel_profiles_models.py
@@ -1,0 +1,245 @@
+# tests/scm/models/mobile_agent/test_tunnel_profiles_models.py
+
+"""Tests for mobile agent tunnel profiles models."""
+
+# External libraries
+from pydantic import ValidationError
+import pytest
+
+# Local SDK imports
+from scm.models.mobile_agent.tunnel_profiles import (
+    CookieLifetime,
+    SplitTunnelingDomainEntry,
+    TunnelOperatingSystem,
+    TunnelProfileBaseModel,
+    TunnelProfileCreateModel,
+    TunnelProfileResponseModel,
+    TunnelProfileUpdateModel,
+)
+from tests.scm.models.mobile_agent.factories import (
+    TunnelProfileBaseModelFactory,
+    TunnelProfileCreateModelFactory,
+    TunnelProfileResponseModelFactory,
+    TunnelProfileUpdateModelFactory,
+)
+
+
+class TestTunnelOperatingSystem:
+    """Tests for the TunnelOperatingSystem enum."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert TunnelOperatingSystem.ANDROID == "Android"
+        assert TunnelOperatingSystem.CHROME == "Chrome"
+        assert TunnelOperatingSystem.IOT == "IoT"
+        assert TunnelOperatingSystem.LINUX == "Linux"
+        assert TunnelOperatingSystem.MAC == "Mac"
+        assert TunnelOperatingSystem.WINDOWS == "Windows"
+        assert TunnelOperatingSystem.WINDOWS_UWP == "WindowsUWP"
+        assert TunnelOperatingSystem.IOS == "iOS"
+
+    def test_enum_membership(self):
+        """Test that the enum contains exactly the spec-defined values."""
+        expected = {
+            "Android",
+            "Chrome",
+            "IoT",
+            "Linux",
+            "Mac",
+            "Windows",
+            "WindowsUWP",
+            "iOS",
+        }
+        assert {member.value for member in TunnelOperatingSystem} == expected
+
+
+class TestTunnelProfileBaseModel:
+    """Tests for TunnelProfileBaseModel validation."""
+
+    def test_base_model_minimal(self):
+        """Test that a model with only the required name field can be created."""
+        model = TunnelProfileBaseModel(name="test-tunnel")
+        assert model.name == "test-tunnel"
+        assert model.authentication_override is None
+        assert model.no_direct_access_to_local_network is None
+        assert model.os is None
+        assert model.retrieve_framed_ip_address is None
+        assert model.source_address is None
+        assert model.source_user is None
+        assert model.split_tunneling is None
+
+    def test_base_model_complete(self):
+        """Test that a complete base model can be created."""
+        model = TunnelProfileBaseModelFactory()
+        assert model.name is not None
+        assert isinstance(model.os, list)
+        assert all(isinstance(os_value, TunnelOperatingSystem) for os_value in model.os)
+
+    def test_base_model_missing_name(self):
+        """Test validation when the required name field is missing."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileBaseModel()
+        assert "name\n  Field required" in str(exc_info.value)
+
+    def test_base_model_empty_name(self):
+        """Test validation when name is empty."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileBaseModel(name="")
+        assert "name" in str(exc_info.value)
+
+    def test_base_model_name_too_long(self):
+        """Test validation when name exceeds the 31 character maximum."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileBaseModel(name="x" * 32)
+        assert "name" in str(exc_info.value)
+
+    def test_base_model_name_max_length(self):
+        """Test that a 31 character name is accepted."""
+        model = TunnelProfileBaseModel(name="x" * 31)
+        assert len(model.name) == 31
+
+    def test_base_model_invalid_os(self):
+        """Test validation when os contains an invalid value."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileBaseModel(name="test-tunnel", os=["InvalidOS"])
+        assert "os" in str(exc_info.value)
+
+    def test_base_model_extra_field_forbidden(self):
+        """Test that unknown fields are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileBaseModel(name="test-tunnel", unknown_field="value")
+        assert "unknown_field" in str(exc_info.value)
+
+    def test_model_dump(self):
+        """Test model dumping to dictionary."""
+        model = TunnelProfileBaseModelFactory()
+        model_dict = model.model_dump(exclude_unset=True)
+        assert model_dict["name"] == model.name
+        assert model_dict["os"] == model.os
+
+
+class TestNestedModels:
+    """Tests for the nested tunnel profile models."""
+
+    def test_cookie_lifetime_valid(self):
+        """Test valid cookie lifetime values."""
+        model = CookieLifetime(lifetime_in_hours=24)
+        assert model.lifetime_in_hours == 24
+
+    def test_cookie_lifetime_days_out_of_range(self):
+        """Test that lifetime_in_days above 365 is rejected."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_days=366)
+
+    def test_cookie_lifetime_hours_out_of_range(self):
+        """Test that lifetime_in_hours above 72 is rejected."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_hours=73)
+
+    def test_cookie_lifetime_minutes_out_of_range(self):
+        """Test that lifetime_in_minutes above 59 is rejected."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_minutes=60)
+
+    def test_cookie_lifetime_below_minimum(self):
+        """Test that values below 1 are rejected."""
+        with pytest.raises(ValidationError):
+            CookieLifetime(lifetime_in_days=0)
+
+    def test_domain_entry_valid_ports(self):
+        """Test valid domain entry ports."""
+        model = SplitTunnelingDomainEntry(name="example.com", ports=[80, 443])
+        assert model.ports == [80, 443]
+
+    def test_domain_entry_port_too_large(self):
+        """Test that a port above 65535 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            SplitTunnelingDomainEntry(name="example.com", ports=[65536])
+        assert "Ports must be between 1 and 65535" in str(exc_info.value)
+
+    def test_domain_entry_port_too_small(self):
+        """Test that a port below 1 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            SplitTunnelingDomainEntry(name="example.com", ports=[0])
+        assert "Ports must be between 1 and 65535" in str(exc_info.value)
+
+
+class TestTunnelProfileCreateModel:
+    """Tests for TunnelProfileCreateModel validation."""
+
+    def test_create_model_valid(self):
+        """Test that a valid create model can be built."""
+        data = TunnelProfileCreateModelFactory.build_valid()
+        model = TunnelProfileCreateModel(**data)
+        assert model.name == data["name"]
+
+    def test_create_model_valid_full(self):
+        """Test that a create model with all nested structures can be built."""
+        data = TunnelProfileCreateModelFactory.build_valid_full()
+        model = TunnelProfileCreateModel(**data)
+        assert model.name == data["name"]
+        assert model.authentication_override.accept_cookie.generate_cookie is True
+        assert model.authentication_override.accept_cookie.cookie_lifetime.lifetime_in_hours == 24
+        assert model.source_address.ip_address == ["10.0.0.0/24"]
+        assert model.split_tunneling.access_route == ["10.1.0.0/16"]
+        assert model.split_tunneling.exclude_domains.list[0].name == "example.com"
+        assert model.split_tunneling.include_domains.list[0].ports == [80, 443]
+
+    def test_create_model_invalid_name(self):
+        """Test validation when name is too long."""
+        data = TunnelProfileCreateModelFactory.build_invalid_name()
+        with pytest.raises(ValidationError):
+            TunnelProfileCreateModel(**data)
+
+    def test_create_model_invalid_os(self):
+        """Test validation when os contains an invalid value."""
+        data = TunnelProfileCreateModelFactory.build_invalid_os()
+        with pytest.raises(ValidationError):
+            TunnelProfileCreateModel(**data)
+
+    def test_create_model_dump_excludes_unset(self):
+        """Test that unset fields are excluded from the payload."""
+        model = TunnelProfileCreateModel(name="test-tunnel")
+        payload = model.model_dump(exclude_unset=True)
+        assert payload == {"name": "test-tunnel"}
+
+
+class TestTunnelProfileUpdateModel:
+    """Tests for TunnelProfileUpdateModel validation."""
+
+    def test_update_model_valid(self):
+        """Test that a valid update model can be built."""
+        data = TunnelProfileUpdateModelFactory.build_valid()
+        model = TunnelProfileUpdateModel(**data)
+        assert model.name == data["name"]
+
+    def test_update_model_requires_name(self):
+        """Test that the update model requires a name (name-addressed resource)."""
+        with pytest.raises(ValidationError) as exc_info:
+            TunnelProfileUpdateModel(os=[TunnelOperatingSystem.LINUX])
+        assert "name\n  Field required" in str(exc_info.value)
+
+
+class TestTunnelProfileResponseModel:
+    """Tests for TunnelProfileResponseModel validation."""
+
+    def test_response_model_valid(self):
+        """Test that a valid response model can be built."""
+        model = TunnelProfileResponseModelFactory()
+        assert model.name is not None
+        assert model.folder == "Mobile Users"
+
+    def test_response_model_ignores_extra_fields(self):
+        """Test that unknown fields in API responses are ignored."""
+        model = TunnelProfileResponseModel(
+            name="test-tunnel",
+            folder="Mobile Users",
+            unexpected_api_field="ignored",
+        )
+        assert model.name == "test-tunnel"
+        assert not hasattr(model, "unexpected_api_field")
+
+    def test_response_model_without_folder(self):
+        """Test that the response model works without a folder field."""
+        model = TunnelProfileResponseModel(name="test-tunnel")
+        assert model.folder is None


### PR DESCRIPTION
### Checklist for This Pull Request

- [x] Submitted from a dedicated feature branch (`cdot65/feat-mobileagent-tunnel-profiles`)
- [x] Targets `main` in `cdot65/pan-scm-sdk`
- [x] Linting checks and unit tests pass

### Pull Request Description

Implements GlobalProtect **Tunnel Settings** (`/tunnel-profiles`) per the upstream `mobile-agent-feb-v1` OpenAPI spec, plus a non-breaking drift alignment of the existing auth settings service against the same spec.

#### Endpoints

- `GET/POST/PUT/DELETE /config/mobile-agent/v1/tunnel-profiles` — folder+name addressed (this resource has **no** `/{id}` paths in the spec):
  - `list(folder, name)` — server-side name filter, limit/offset auto-pagination
  - `create(data, folder)` / `update(data, folder)` — folder as query param, object addressed by name in body
  - `delete(name, folder)` — name+folder query params
  - `fetch(name, folder)` — server-side filter + exact match
- Registry attr: `client.tunnel_profile`

#### Models

- `TunnelProfile{Base,Create,Update,Response}Model` + nested `AuthenticationOverride`/`AcceptCookie`/`CookieLifetime`, `SourceAddress`, `SplitTunneling`/`SplitTunnelingDomains`/`SplitTunnelingDomainEntry`, `TunnelOperatingSystem` enum — faithful to the `tunnel-profiles` schema (name 1-31 chars, cookie lifetime bounds, port ranges).

#### auth-settings drift fixes (non-breaking, separate commit)

- `move()` now posts to spec path `/authentication-settings/{name}:move` with `folder` query param (was `/move`); unset fields omitted from body
- `AuthSettingsMoveModel` gains optional `folder` field (per `move-auth-settings` schema)
- `create()` sends `folder` as query param (spec body schema has no folder)
- `list()` gains server-side `name` filter + limit/offset pagination; `fetch()` uses the server-side filter

**Known remaining drift (intentionally NOT changed here, pending maintainer decision):** spec defines no `/{id}` endpoints for authentication-settings, but the SDK exposes id-based `get()`/`update()`/`delete()`. Changing those is a public API break and is tracked separately.

#### Tests

- `tests/scm/config/mobile_agent/test_tunnel_profiles.py` (service: CRUD, pagination, folder validation, error paths)
- `tests/scm/models/mobile_agent/test_tunnel_profiles_models.py` + factories (enums, bounds, nested structures, extra-field rejection)
- Updated auth settings tests for spec-correct move/create/list behavior

#### Validation

- `poetry run pytest` — **6225 passed, 111 skipped**
- `make quality-local` (isort, ruff, ruff-docstrings, flake8) — clean
- `mypy` — `Success: no issues found in 205 source files`
- `poetry run mkdocs build` — builds with new nav entries

#### What does this pull request accomplish?

- Feature addition
- Bug fix (spec drift)
- Documentation update

#### Are there any breaking changes included?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)