### PR TITLE
chore(release): 0.15.0 — GlobalProtect mobile agent resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-11
+
+### Added
+
+- **GlobalProtect Infrastructure Settings**: New `scm.infrastructure_settings` service. Endpoint: `/config/mobile-agent/v1/infrastructure-settings`. Folder+name addressed CRUD (no `/{id}` paths) scoped to the Mobile Users folder.
+- **GlobalProtect Global Settings**: New `scm.global_settings` service. Endpoint: `/config/mobile-agent/v1/global-settings`. Singleton resource with `get()` and `update()` only.
+- **GlobalProtect Agent Profiles (Application Settings)**: New `scm.agent_profile` service. Endpoint: `/config/mobile-agent/v1/agent-profiles`. Folder+name addressed CRUD with paginated list; full nested app-settings model (connect method, tunnel MTU, and related structures).
+- **GlobalProtect Tunnel Profiles (Tunnel Settings)**: New `scm.tunnel_profile` service. Endpoint: `/config/mobile-agent/v1/tunnel-profiles`. Folder+name addressed CRUD with paginated list.
+- **GlobalProtect Forwarding Profiles**: New `scm.forwarding_profile` service. Endpoint: `/config/mobile-agent/v1/forwarding-profiles`. UUID-based CRUD with oneOf profile types (PAC file, GlobalProtect proxy, ZTNA agent) plus basic/ZTNA forwarding and block rules.
+- **GlobalProtect Forwarding Profile Destinations**: New `scm.forwarding_profile_destination` service. Endpoint: `/config/mobile-agent/v1/forwarding-profile-destinations`. UUID-based CRUD with FQDN and IP destination entries.
+- **GlobalProtect Forwarding Profile Source Applications**: New `scm.forwarding_profile_source_application` service. Endpoint: `/config/mobile-agent/v1/forwarding-profile-source-applications`. UUID-based CRUD.
+- **GlobalProtect Forwarding Profile User Locations**: New `scm.forwarding_profile_user_location` service. Endpoint: `/config/mobile-agent/v1/forwarding-profile-user-locations`. UUID-based CRUD.
+- **GlobalProtect Forwarding Profile Regional and Custom Proxies**: New `scm.forwarding_profile_regional_and_custom_proxy` service. Endpoint: `/config/mobile-agent/v1/forwarding-profile-regional-and-custom-proxies`. UUID-based CRUD.
+- ~430 new tests across mobile_agent services and models; docs pages for every new service and model set.
+
+### Changed
+
+- **Authentication Settings spec alignment** (non-breaking): `move()` now targets the spec path `/{name}:move` and its model accepts an optional `folder`; `create()` sends `folder` as a query parameter; `list()`/`fetch()` gain a `name` filter and pagination. Existing id-based `get()`/`update()`/`delete()` are unchanged (tracked for live-API verification in [#360](https://github.com/cdot65/pan-scm-sdk/issues/360)).
+
 ## [0.14.0] - 2026-04-21
 
 ### Added

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,28 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.15.0
+
+**Released:** June 2026
+
+### Added
+
+- **GlobalProtect (Mobile Agent) coverage** — nine new services on the unified client, all under `/config/mobile-agent/v1`:
+    - **Infrastructure Settings** (`client.infrastructure_settings`): folder+name addressed CRUD for GlobalProtect infrastructure settings in the Mobile Users folder
+    - **Global Settings** (`client.global_settings`): singleton `get()`/`update()` for tenant-wide GlobalProtect settings
+    - **Agent Profiles / Application Settings** (`client.agent_profile`): CRUD for GlobalProtect app settings profiles, including connect method and tunnel MTU configuration
+    - **Tunnel Profiles / Tunnel Settings** (`client.tunnel_profile`): CRUD for GlobalProtect tunnel settings
+    - **Forwarding Profiles** (`client.forwarding_profile`): UUID-based CRUD with PAC file, GlobalProtect proxy, and ZTNA agent profile types plus forwarding/block rules
+    - **Forwarding Profile Destinations** (`client.forwarding_profile_destination`): FQDN and IP destination entries
+    - **Forwarding Profile Source Applications** (`client.forwarding_profile_source_application`)
+    - **Forwarding Profile User Locations** (`client.forwarding_profile_user_location`)
+    - **Forwarding Profile Regional and Custom Proxies** (`client.forwarding_profile_regional_and_custom_proxy`)
+- ~430 new tests; documentation pages for every new service and model set
+
+### Changed
+
+- **Authentication Settings** aligned with the feb-v1 mobile-agent spec (non-breaking): `move()` uses `/{name}:move`, `create()` sends `folder` as a query parameter, `list()`/`fetch()` support name filtering and pagination. Id-based `get()`/`update()`/`delete()` unchanged ([#360](https://github.com/cdot65/pan-scm-sdk/issues/360) tracks live-API verification).
+
 ## Version 0.14.0
 
 **Released:** April 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.14.0"
+version = "0.15.0"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
## Summary
- Bump version 0.14.0 → 0.15.0 (minor, additive only)
- CHANGELOG + release-notes entries for the nine new GlobalProtect (mobile agent) services merged in #355, #358, #357, #356, #359
- Documents the non-breaking authentication-settings spec alignment (follow-up: #360)

## Release checklist
- [x] All feature PRs merged, main CI green (run 27361390349)
- [x] Full suite passing (6,622 passed / 111 skipped)
- [x] mkdocs builds with new nav
- [ ] Merge this PR
- [ ] Create GitHub release `v0.15.0` (publish.yml builds + publishes on release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)