### PR TITLE
fix(deps): bump cryptography to ^49.0.0 (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requests-oauthlib = "^2.0.0"
 setuptools = "^78.1.1"
 pydantic = "^2.12.0"
 pyjwt = "^2.12.0"
-cryptography = "^46.0.0"
+cryptography = "^49.0.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary

Bumps `cryptography` from `^46.0.0` → `^49.0.0` to clear the pip-audit advisory **GHSA-537c-gmf6-5ccf** (affects cryptography < 48.0.1). The fix version (48.0.1+) was **outside** the old `^46.0.0` range, so it required a constraint bump. Resolves to 49.0.0 (current latest).

## Risk

Low. `cryptography` is **not imported anywhere in `scm/` or `tests/`** — it's a transitive dependency of the OAuth2 / JWT / TLS stack (`requests-oauthlib`, `pyjwt`). The full CI suite (quality + tests) exercises the auth path.

## Why a dedicated PR

Surfaced while migrating docs to Docusaurus (#362); kept separate to keep that PR focused and because a crypto-library major bump warrants its own review.

## Verification

- `poetry lock && poetry install` → `cryptography 49.0.0`
- `pip-audit` no longer reports cryptography
- Relying on CI for full quality + test verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)