### PR TITLE
chore(release): bump version to 0.15.1

### DIFF
--- a/docs-site/docs/about/release-notes.md
+++ b/docs-site/docs/about/release-notes.md
@@ -2,6 +2,14 @@
 
 This page contains the release history of the Strata Cloud Manager SDK, with the most recent releases at the top.
 
+## Version 0.15.1
+
+**Released:** June 2026
+
+### Changed
+
+- **Documentation & repository maintenance** (no functional SDK changes): migrated the contributor and policy docs (Contributing, Code of Conduct, Security, Support, SDK Service Styling Guide, Pydantic Models Guide) into the Docusaurus site under `docs-site/docs/about/`; folded the root `CHANGELOG.md` into these release notes; refreshed the project `README` branding with the new `pan-scm-sdk` wordmark; and removed stale repository cruft.
+
 ## Version 0.15.0
 
 **Released:** June 2026
@@ -934,6 +942,11 @@ For more detailed information on each release, visit the [GitHub repository](htt
 The entries below follow the [Keep a Changelog](https://keepachangelog.com/) format and track engineering-level changes (migrated from the former root `CHANGELOG.md`).
 
 ## [Unreleased]
+
+## [0.15.1] - 2026-06-28
+
+### Changed
+- Documentation & repository maintenance only (no functional SDK changes): migrated contributor/policy docs into the Docusaurus site, folded the root `CHANGELOG.md` into the release notes, refreshed the `README` branding, and removed stale repository cruft.
 
 ## [0.15.0] - 2026-06-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-sdk"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python SDK for Palo Alto Networks Strata Cloud Manager."
 authors = ["Calvin Remsburg <calvin@cdot.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Patch release — **no functional SDK changes**. Refreshes the PyPI page (README branding) and records the docs migration / repo cleanup landed in #365.

- Bump `pyproject.toml` → `0.15.1`
- Add `0.15.1` entries to release notes / changelog

Merging then cutting GitHub release `v0.15.1` will trigger `publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)